### PR TITLE
Fix games not starting and Experimental Minimum Blending Accuracy

### DIFF
--- a/app/src/main/cpp/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
+++ b/app/src/main/cpp/pcsx2/GS/Renderers/HW/GSRendererHW.cpp
@@ -5687,7 +5687,10 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, const boo
 				sw_blending |= blend_mix;
 				[[fallthrough]];
 			case AccBlendLevel::Minimum:
-				break;
+				sw_blending |= blend_non_recursive || alpha_eq_less_one || alpha_c0_high_max_one;
+				blend_mix &= !sw_blending;
+				sw_blending |= blend_mix;
+                break;
 		}
 	}
 	else
@@ -5728,7 +5731,10 @@ void GSRendererHW::EmulateBlending(int rt_alpha_min, int rt_alpha_max, const boo
 				sw_blending |= blend_mix;
 				[[fallthrough]];
 			case AccBlendLevel::Minimum:
-				break;
+                sw_blending |= blend_non_recursive || alpha_eq_less_one || alpha_c0_high_max_one;
+				blend_mix &= !sw_blending;
+				sw_blending |= blend_mix;
+                break;
 		}
 	}
 

--- a/app/src/main/java/kr/co/iefriends/pcsx2/activities/MainActivity.java
+++ b/app/src/main/java/kr/co/iefriends/pcsx2/activities/MainActivity.java
@@ -5487,17 +5487,7 @@ public class MainActivity extends AppCompatActivity {
     // Cheap but effective: if emulator isn't running yet, boot BIOS first, then load the game like the File button flow.
     private void launchGameWithPreflight(@NonNull Uri uri) {
         applyPerGameSettingsForUri(uri);
-        if (isThread()) {
-            handleSelectedGameUri(uri);
-            return;
-        }
-        // Start BIOS first
-        try { Toast.makeText(this, R.string.home_preflight_boot_bios, Toast.LENGTH_SHORT).show(); } catch (Throwable ignored) {}
-        pendingGameUri = uri;
-        pendingLaunchRetries = 0;
-        bootBios();
-        getWindow().getDecorView().postDelayed(pendingLaunchRunnable, 900);
-        schedulePreflightFallback();
+        handleSelectedGameUri(uri);
     }
 
     private final Runnable pendingLaunchRunnable = new Runnable() {


### PR DESCRIPTION
Fix games going to BIOS and not starting
Now games should start without needing to boot into BIOS first
And experimental addition of Minimum Blending Accuracy