### PR TITLE
iOS: extract CoverThumbnailView, unify presets, and clean up readability

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -138,6 +138,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
 		${CMAKE_SOURCE_DIR}/../swift/Views/RootView.swift
 		${CMAKE_SOURCE_DIR}/../swift/Views/BootSplashView.swift
 		${CMAKE_SOURCE_DIR}/../swift/Views/GameListView.swift
+		${CMAKE_SOURCE_DIR}/../swift/Views/CoverThumbnailView.swift
 		${CMAKE_SOURCE_DIR}/../swift/Views/BIOSListView.swift
 		${CMAKE_SOURCE_DIR}/../swift/Views/HelpView.swift
 		${CMAKE_SOURCE_DIR}/../swift/Views/GameScreenView.swift

--- a/app/src/main/cpp/ios_main.mm
+++ b/app/src/main/cpp/ios_main.mm
@@ -2219,7 +2219,6 @@ namespace Host
     }
 
     // Only needed stubs for linking
-    // GetHTTPUserAgent removed (duplicate)
     bool CopyTextToClipboard(const std::string_view text) { return false; }
     void OnOSDMessage(const std::string&, float, u32) {}
     void ReportError(const char*, const char*) {}
@@ -2755,8 +2754,6 @@ namespace FileSystem {
 }
 
 
-// ... IOCtlSrc Stub Removed ...
-
 // ... CocoaTools Stub ...
 namespace CocoaTools {
     void InhibitAppNap(const std::string&) {}
@@ -2816,7 +2813,6 @@ bool PCAPAdapter::ValidateEtherFrame(NetPacket*) { return false; }
 
 
 // ... FileSystem Stub ...
-// Duplicate FileSystem block removed
 
 // -- End Host Stubs --
 
@@ -3694,8 +3690,6 @@ static void SetupIOSDirectories(const std::string& dataRoot)
 #include <cstdio>
 
 int main(int argc, char * argv[]) {
-    // InstallSignalHandler(); // Removed
-    
     @autoreleasepool {
         // SDL_MAIN_HANDLED is set, so we use standard main()
         return UIApplicationMain(argc, argv, nil, NSStringFromClass([PCSX2AppDelegate class]));

--- a/app/src/main/cpp/pcsx2/GS/Renderers/Metal/cas.metal
+++ b/app/src/main/cpp/pcsx2/GS/Renderers/Metal/cas.metal
@@ -5,7 +5,7 @@
 #define A_MSL 1
 #define A_HALF 1
 
-#include "../../../../bin/resources/shaders/common/ffx_a.h"
+#include "shaders/common/ffx_a.h"
 
 struct CASTextureF
 {
@@ -35,7 +35,7 @@ A_STATIC AH3 CasLoadH(CASTextureH tex, ASW2 coord)
 
 A_STATIC void CasInputH(inoutAH2 r, inoutAH2 g, inoutAH2 b){}
 
-#include "../../../../bin/resources/shaders/common/ffx_cas.h"
+#include "shaders/common/ffx_cas.h"
 
 #include "GSMTLShaderCommon.h"
 

--- a/app/src/main/cpp/pcsx2/GS/Renderers/Metal/fxaa.metal
+++ b/app/src/main/cpp/pcsx2/GS/Renderers/Metal/fxaa.metal
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "GSMTLShaderCommon.h"
-#include "../../../../bin/resources/shaders/common/fxaa.fx"
+#include "shaders/common/fxaa.fx"
 
 fragment float4 ps_fxaa(ConvertShaderData data [[stage_in]], texture2d<float> tex [[texture(GSMTLTextureIndexNonHW)]])
 {

--- a/app/src/main/swift/Models/EmulatorBridge.swift
+++ b/app/src/main/swift/Models/EmulatorBridge.swift
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 import SwiftUI
-import Combine
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -11,6 +10,9 @@ import UIKit
 enum StikDebugLauncher {
     private static let lastAutoOpenKey = "ARMSX2iOSLastStikDebugAutoOpenTime"
     private static let autoOpenCooldown: TimeInterval = 120
+    private static func log(_ message: String) {
+        print("[ARMSX2 iOS] StikDebug \(message)")
+    }
 
     static func open(reason: String = "manual", completion: ((Bool) -> Void)? = nil) {
 #if canImport(UIKit)
@@ -23,14 +25,14 @@ enum StikDebugLauncher {
         ].compactMap(URL.init(string:))
 
         guard !candidates.isEmpty else {
-            print("[ARMSX2 iOS] StikDebug open failed: no valid launch URLs")
+            log("open failed: no valid launch URLs")
             completion?(false)
             return
         }
 
         openFirstAvailableURL(candidates, reason: reason, completion: completion)
 #else
-        print("[ARMSX2 iOS] StikDebug open skipped: UIKit unavailable reason=\(reason)")
+        log("open skipped: UIKit unavailable reason=\(reason)")
         completion?(false)
 #endif
     }
@@ -38,13 +40,13 @@ enum StikDebugLauncher {
 #if canImport(UIKit)
     private static func openFirstAvailableURL(_ urls: [URL], reason: String, completion: ((Bool) -> Void)?) {
         guard let url = urls.first else {
-            print("[ARMSX2 iOS] StikDebug open failed reason=\(reason): no URL scheme accepted")
+            log("open failed reason=\(reason): no URL scheme accepted")
             completion?(false)
             return
         }
 
         UIApplication.shared.open(url, options: [:]) { success in
-            print("[ARMSX2 iOS] StikDebug open \(success ? "succeeded" : "failed") reason=\(reason) url=\(url.absoluteString)")
+            log("open \(success ? "succeeded" : "failed") reason=\(reason) url=\(url.absoluteString)")
             if success {
                 completion?(true)
             } else {
@@ -61,7 +63,7 @@ enum StikDebugLauncher {
         let now = Date().timeIntervalSince1970
         let last = UserDefaults.standard.double(forKey: lastAutoOpenKey)
         guard now - last >= autoOpenCooldown else {
-            print("[ARMSX2 iOS] StikDebug auto-open throttled reason=\(reason)")
+            log("auto-open throttled reason=\(reason)")
             return
         }
 

--- a/app/src/main/swift/Views/CoverThumbnailView.swift
+++ b/app/src/main/swift/Views/CoverThumbnailView.swift
@@ -1,0 +1,129 @@
+// CoverThumbnailView.swift - Cover thumbnail rendering and cache
+// SPDX-License-Identifier: GPL-3.0+
+
+import SwiftUI
+import UIKit
+import ImageIO
+
+struct CoverThumbnailView: View {
+    let gameName: String
+    let coverURL: URL?
+    let coverSignature: String?
+    let width: CGFloat
+    let height: CGFloat
+
+    @State private var image: UIImage?
+
+    private var cacheID: String {
+        "\(coverSignature ?? "placeholder")|\(Int(width))x\(Int(height))"
+    }
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color(.secondarySystemGroupedBackground))
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .strokeBorder(.white.opacity(0.12), lineWidth: 1)
+
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: width, height: height)
+                    .clipped()
+            } else {
+                VStack(spacing: 6) {
+                    Image(systemName: gameName.lowercased().hasSuffix(".chd") ? "archivebox" : "opticaldisc")
+                        .font(.system(size: 24, weight: .medium))
+                    Text(gameName.lowercased().hasSuffix(".chd") ? "CHD" : "PS2")
+                        .font(.caption2)
+                        .fontWeight(.bold)
+                }
+                .foregroundStyle(.secondary)
+            }
+        }
+        .frame(width: width, height: height)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .task(id: cacheID) {
+            await loadThumbnail()
+        }
+    }
+
+    @MainActor
+    private func loadThumbnail() async {
+        guard let coverURL else {
+            image = nil
+            return
+        }
+
+        let scale = UIScreen.main.scale
+        if let cached = CoverThumbnailCache.shared.cachedImage(for: coverURL, signature: coverSignature, width: width, height: height, scale: scale) {
+            image = cached
+            return
+        }
+
+        image = await CoverThumbnailCache.shared.thumbnail(for: coverURL, signature: coverSignature, width: width, height: height, scale: scale)
+    }
+}
+
+final class CoverThumbnailCache: @unchecked Sendable {
+    static let shared = CoverThumbnailCache()
+
+    private let cache = NSCache<NSString, UIImage>()
+
+    private init() {
+        cache.countLimit = 768
+        cache.totalCostLimit = 96 * 1024 * 1024
+    }
+
+    func cachedImage(for url: URL, signature: String?, width: CGFloat, height: CGFloat, scale: CGFloat) -> UIImage? {
+        cache.object(forKey: cacheKey(for: url, signature: signature, width: width, height: height, scale: scale))
+    }
+
+    func thumbnail(for url: URL, signature: String?, width: CGFloat, height: CGFloat, scale: CGFloat) async -> UIImage? {
+        let key = cacheKey(for: url, signature: signature, width: width, height: height, scale: scale)
+        if let cached = cache.object(forKey: key) {
+            return cached
+        }
+
+        let path = url.path
+        let maxPixelSize = max(1, Int(max(width, height) * scale))
+        let image = await Task.detached(priority: .utility) {
+            let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
+            let thumbnailOptions = [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceCreateThumbnailWithTransform: true,
+                kCGImageSourceShouldCacheImmediately: true,
+                kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+            ] as CFDictionary
+
+            guard let source = CGImageSourceCreateWithURL(url as CFURL, sourceOptions),
+                  let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions) else {
+                return UIImage(contentsOfFile: path)
+            }
+
+            return UIImage(cgImage: cgImage, scale: scale, orientation: .up)
+        }.value
+
+        if let image {
+            let cost = max(1, Int(image.size.width * image.scale * image.size.height * image.scale * 4))
+            cache.setObject(image, forKey: key, cost: cost)
+        }
+
+        return image
+    }
+
+    static func signature(for url: URL?) -> String? {
+        guard let url else { return nil }
+        let values = try? url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
+        let modified = values?.contentModificationDate?.timeIntervalSince1970 ?? 0
+        let size = values?.fileSize ?? 0
+        return "\(url.path)|\(modified)|\(size)"
+    }
+
+    private func cacheKey(for url: URL, signature: String?, width: CGFloat, height: CGFloat, scale: CGFloat) -> NSString {
+        let pixelWidth = Int(width * scale)
+        let pixelHeight = Int(height * scale)
+        return "\(signature ?? url.path)|\(pixelWidth)x\(pixelHeight)" as NSString
+    }
+}

--- a/app/src/main/swift/Views/GameListView.swift
+++ b/app/src/main/swift/Views/GameListView.swift
@@ -4,7 +4,6 @@
 import SwiftUI
 import UniformTypeIdentifiers
 import UIKit
-import ImageIO
 
 struct ISOEntry: Identifiable {
     var id: String { name }
@@ -1001,25 +1000,6 @@ private struct GameInfoPanel: View {
     }
 }
 
-private struct LibraryCompatibilityPreset: Identifiable {
-    let id: String
-    let title: String
-    let systemImage: String
-}
-
-private let libraryCompatibilityPresets: [LibraryCompatibilityPreset] = [
-    LibraryCompatibilityPreset(id: "off", title: "Off / Default", systemImage: "power"),
-    LibraryCompatibilityPreset(id: "cop1", title: "COP1 Everything Only", systemImage: "function"),
-    LibraryCompatibilityPreset(id: "loadstore", title: "COP1 + EE Load/Store", systemImage: "arrow.left.arrow.right"),
-    LibraryCompatibilityPreset(id: "mmi", title: "COP1 + EE MMI", systemImage: "rectangle.3.group"),
-    LibraryCompatibilityPreset(id: "cop2vu", title: "COP1 + EE COP2/VU Macro", systemImage: "cube.transparent"),
-    LibraryCompatibilityPreset(id: "multdiv", title: "COP1 + EE Mult/Div", systemImage: "multiply"),
-    LibraryCompatibilityPreset(id: "shifts", title: "COP1 + EE Shifts", systemImage: "arrow.left.and.right"),
-    LibraryCompatibilityPreset(id: "moves", title: "COP1 + EE Moves/HI-LO", systemImage: "arrow.triangle.swap"),
-    LibraryCompatibilityPreset(id: "integeralu", title: "COP1 + EE Integer ALU", systemImage: "plus.forwardslash.minus"),
-    LibraryCompatibilityPreset(id: "branches", title: "COP1 + EE Branches/Jumps", systemImage: "arrow.triangle.branch"),
-]
-
 private struct GameCompatibilityPanel: View {
     @Environment(\.dismiss) private var dismiss
     @State private var settings = SettingsStore.shared
@@ -1054,7 +1034,7 @@ private struct GameCompatibilityPanel: View {
                 }
 
                 Section(settings.localized("Presets")) {
-                    ForEach(libraryCompatibilityPresets) { preset in
+                    ForEach(compatibilityPresets) { preset in
                         Button {
                             apply(preset)
                         } label: {
@@ -1120,7 +1100,7 @@ private struct GameCompatibilityPanel: View {
         }
     }
 
-    private func apply(_ preset: LibraryCompatibilityPreset) {
+    private func apply(_ preset: CompatibilityPreset) {
         ARMSX2Bridge.setCompatibilityPreset(preset.id, forISO: game.name)
         selectedPreset = ARMSX2Bridge.compatibilityPreset(forISO: game.name)
         identity = ARMSX2Bridge.compatibilityIdentity(forISO: game.name)
@@ -1128,11 +1108,11 @@ private struct GameCompatibilityPanel: View {
     }
 
     private func presetTitle(_ id: String) -> String {
-        libraryCompatibilityPresets.first(where: { $0.id == id })?.title ?? "Custom Advanced Flags"
+        compatibilityPresets.first(where: { $0.id == id })?.title ?? "Custom Advanced Flags"
     }
 
-    private var advancedPresets: [LibraryCompatibilityPreset] {
-        libraryCompatibilityPresets.filter { $0.id != "off" }
+    private var advancedPresets: [CompatibilityPreset] {
+        compatibilityPresets.filter { $0.id != "off" }
     }
 }
 
@@ -1332,129 +1312,6 @@ struct PerGameSettingsPanel: View {
             return number.floatValue
         }
         return defaultValue
-    }
-}
-
-private struct CoverThumbnailView: View {
-    let gameName: String
-    let coverURL: URL?
-    let coverSignature: String?
-    let width: CGFloat
-    let height: CGFloat
-
-    @State private var image: UIImage?
-
-    private var cacheID: String {
-        "\(coverSignature ?? "placeholder")|\(Int(width))x\(Int(height))"
-    }
-
-    var body: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(Color(.secondarySystemGroupedBackground))
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .strokeBorder(.white.opacity(0.12), lineWidth: 1)
-
-            if let image {
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFill()
-                    .frame(width: width, height: height)
-                    .clipped()
-            } else {
-                VStack(spacing: 6) {
-                    Image(systemName: gameName.lowercased().hasSuffix(".chd") ? "archivebox" : "opticaldisc")
-                        .font(.system(size: 24, weight: .medium))
-                    Text(gameName.lowercased().hasSuffix(".chd") ? "CHD" : "PS2")
-                        .font(.caption2)
-                        .fontWeight(.bold)
-                }
-                .foregroundStyle(.secondary)
-            }
-        }
-        .frame(width: width, height: height)
-        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-        .task(id: cacheID) {
-            await loadThumbnail()
-        }
-    }
-
-    @MainActor
-    private func loadThumbnail() async {
-        guard let coverURL else {
-            image = nil
-            return
-        }
-
-        let scale = UIScreen.main.scale
-        if let cached = CoverThumbnailCache.shared.cachedImage(for: coverURL, signature: coverSignature, width: width, height: height, scale: scale) {
-            image = cached
-            return
-        }
-
-        image = await CoverThumbnailCache.shared.thumbnail(for: coverURL, signature: coverSignature, width: width, height: height, scale: scale)
-    }
-}
-
-private final class CoverThumbnailCache: @unchecked Sendable {
-    static let shared = CoverThumbnailCache()
-
-    private let cache = NSCache<NSString, UIImage>()
-
-    private init() {
-        cache.countLimit = 768
-        cache.totalCostLimit = 96 * 1024 * 1024
-    }
-
-    func cachedImage(for url: URL, signature: String?, width: CGFloat, height: CGFloat, scale: CGFloat) -> UIImage? {
-        cache.object(forKey: cacheKey(for: url, signature: signature, width: width, height: height, scale: scale))
-    }
-
-    func thumbnail(for url: URL, signature: String?, width: CGFloat, height: CGFloat, scale: CGFloat) async -> UIImage? {
-        let key = cacheKey(for: url, signature: signature, width: width, height: height, scale: scale)
-        if let cached = cache.object(forKey: key) {
-            return cached
-        }
-
-        let path = url.path
-        let maxPixelSize = max(1, Int(max(width, height) * scale))
-        let image = await Task.detached(priority: .utility) {
-            let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
-            let thumbnailOptions = [
-                kCGImageSourceCreateThumbnailFromImageAlways: true,
-                kCGImageSourceCreateThumbnailWithTransform: true,
-                kCGImageSourceShouldCacheImmediately: true,
-                kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
-            ] as CFDictionary
-
-            guard let source = CGImageSourceCreateWithURL(url as CFURL, sourceOptions),
-                  let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions) else {
-                return UIImage(contentsOfFile: path)
-            }
-
-            return UIImage(cgImage: cgImage, scale: scale, orientation: .up)
-        }.value
-
-        if let image {
-            let cost = max(1, Int(image.size.width * image.scale * image.size.height * image.scale * 4))
-            cache.setObject(image, forKey: key, cost: cost)
-        }
-
-        return image
-    }
-
-    static func signature(for url: URL?) -> String? {
-        guard let url else { return nil }
-        let values = try? url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
-        let modified = values?.contentModificationDate?.timeIntervalSince1970 ?? 0
-        let size = values?.fileSize ?? 0
-        return "\(url.path)|\(modified)|\(size)"
-    }
-
-    private func cacheKey(for url: URL, signature: String?, width: CGFloat, height: CGFloat, scale: CGFloat) -> NSString {
-        let pixelWidth = Int(width * scale)
-        let pixelHeight = Int(height * scale)
-        return "\(signature ?? url.path)|\(pixelWidth)x\(pixelHeight)" as NSString
     }
 }
 

--- a/app/src/main/swift/Views/GameScreenView.swift
+++ b/app/src/main/swift/Views/GameScreenView.swift
@@ -6,13 +6,13 @@ import UIKit
 
 private let runtimeMenuStateChangedNotification = Notification.Name("ARMSX2iOSRuntimeMenuStateChanged")
 
-private struct CompatibilityPreset: Identifiable {
+struct CompatibilityPreset: Identifiable {
     let id: String
     let title: String
     let systemImage: String
 }
 
-private let compatibilityPresets: [CompatibilityPreset] = [
+let compatibilityPresets: [CompatibilityPreset] = [
     CompatibilityPreset(id: "off", title: "Off / Default", systemImage: "power"),
     CompatibilityPreset(id: "cop1", title: "COP1 Everything Only", systemImage: "function"),
     CompatibilityPreset(id: "loadstore", title: "COP1 + EE Load/Store", systemImage: "arrow.left.arrow.right"),

--- a/app/src/main/swift/Views/Settings/StorageSettingsView.swift
+++ b/app/src/main/swift/Views/Settings/StorageSettingsView.swift
@@ -100,16 +100,7 @@ private enum StorageClearAction: Identifiable, Sendable {
 private enum StorageCleaner {
     static func report(paths: StoragePaths) async -> StorageReport {
         await Task.detached(priority: .utility) {
-            StorageReport(
-                appCacheBytes: directorySize(paths.emulatorCacheURL) + directorySize(paths.systemCachesURL) + directorySize(paths.temporaryURL),
-                textureDumpBytes: textureDumpDirectories(in: paths.textureRootURL).reduce(Int64(0)) { partial, url in
-                    partial + directorySize(url)
-                },
-                diagnosticLogBytes: directorySize(paths.logsURL) + paths.rootLogURLs.reduce(Int64(0)) { partial, url in
-                    partial + directorySize(url)
-                },
-                stateSafetyBackupBytes: directorySize(paths.stateSafetyBackupsURL)
-            )
+            awaitableReport(paths: paths)
         }.value
     }
 


### PR DESCRIPTION
### Summary

The aim of this PR is to clean up the iOS target by removing duplicate code, improving readability and extracting a few UI components. There are no behavioural changes.

### What's Changed

* **Component Extractions:** Pulled `CoverThumbnailView` and its cache out of `GameListView` into a dedicated, reusable component.
* **Model Unification:** Consolidated the `CompatibilityPreset` metadata so both `GameScreenView` and `GameListView` share a single model instead of duplicating tables.
* **General Cleanups:** Removed an unused `Combine` import in `EmulatorBridge.swift` (silencing a compiler warning), deleted stale refactoring comments in `ios_main.mm`, and deduplicated the `StorageCleaner` report logic.
* **Logging Consolidation:** Routed scattered `StikDebug` prints through a new `StikDebugLauncher.log(_:)` helper to create a single choke point for debug outputs.
* **Metal Shader Paths:** Fixed `cas.metal` and `fxaa.metal` to use search-path-relative includes (`shaders/common/...`) instead of fragile PC-relative paths, making out-of-tree and iOS builds much more reliable.

### Verification

I built an unsigned iOS IPA and sideloaded it for manual device validation. Everything is running smoothly with no regressions:

* App launches cleanly and all Storage Settings/Compatibility Labs function normally.
* Game list thumbnails render perfectly across list, grid, and landscape cover-flow views.
* The build completes cleanly with the Metal shader fix applied and zero Swift compiler warnings.

I developed this on a Windows machine using macOS GitHub Actions runners. To keep the upstream repository clean, I intentionally excluded my custom .github/workflows/ios-ipa.yml and local tooling from this branch. However, if you think that having a CI configuration for unsigned IPA generation would be useful for the project, please let me know and I can submit that as a separate PR!