### PR TITLE
iOS: Improve user-facing error guidance

### DIFF
--- a/app/src/main/swift/Models/FileImportHandler.swift
+++ b/app/src/main/swift/Models/FileImportHandler.swift
@@ -25,17 +25,21 @@ final class FileImportHandler: @unchecked Sendable {
     var lastImportMessage: String?
     var showImportAlert = false
 
-    private static let biosExtensions: Set<String> = ["bin", "rom"]
-    private static let gameExtensions: Set<String> = ["iso", "chd", "img", "bin", "cue", "mdf", "cso", "zso", "gz", "elf"]
-    private static let pnachExtensions: Set<String> = ["pnach"]
+    private static let biosExtensionList = ["bin", "rom"]
+    private static let gameExtensionList = ["iso", "chd", "img", "bin", "cue", "mdf", "cso", "zso", "gz", "elf"]
+    private static let pnachExtensionList = ["pnach"]
+    private static let biosExtensions = Set(biosExtensionList)
+    private static let gameExtensions = Set(gameExtensionList)
+    private static let pnachExtensions = Set(pnachExtensionList)
     // .bin files > 50MB are treated as game images, not BIOS
     private static let biosSizeThreshold: UInt64 = 50 * 1024 * 1024
 
     // BIOS dumps use loose/non-standard UTTypes on iOS. Keep the picker permissive
     // but include explicit .bin/.rom types so sideloaded Files providers expose them.
-    static let biosContentTypes: [UTType] = broaderContentTypes(for: ["bin", "rom"])
-    static let gameContentTypes: [UTType] = broaderContentTypes(for: ["iso", "chd", "img", "bin", "cue", "mdf", "cso", "zso", "gz", "elf"])
-    static let pnachContentTypes: [UTType] = Array(Set([.item, .data, .content, .text, .plainText] + contentTypes(for: ["pnach", "txt", "patch"])))
+    static let biosContentTypes: [UTType] = broaderContentTypes(for: biosExtensionList)
+    static let gameContentTypes: [UTType] = broaderContentTypes(for: gameExtensionList)
+    static let pnachContentTypes: [UTType] = Array(Set([.item, .data, .content, .text, .plainText] + contentTypes(for: pnachExtensionList + ["txt", "patch"])))
+    static let pnachImportNeedsGameMessage = "PNACH patches need to be imported for a specific game. Boot a game first or long-press a game in your library, then import the patch."
 
     private init() {}
 
@@ -65,8 +69,8 @@ final class FileImportHandler: @unchecked Sendable {
                 if let importedGame {
                     importedGames.append(importedGame)
                 }
-            case .unsupported(let fileName):
-                rejected.append(fileName)
+            case .unsupported(let message):
+                rejected.append(message)
             case .failure(let message):
                 failed.append(message)
             }
@@ -77,52 +81,57 @@ final class FileImportHandler: @unchecked Sendable {
             lines.append(imported.count == 1 ? imported[0] : "Imported \(imported.count) files.")
         }
         if !rejected.isEmpty {
-            lines.append("Unsupported: \(rejected.joined(separator: ", "))")
+            lines.append(rejected.joined(separator: "\n"))
         }
         if !failed.isEmpty {
             lines.append(failed.joined(separator: "\n"))
         }
 
-        lastImportMessage = lines.isEmpty ? "No files imported." : lines.joined(separator: "\n")
-        showImportAlert = true
+        presentImportResult(lines.isEmpty ? "No files imported." : lines.joined(separator: "\n"))
         return importedGames
     }
 
     @discardableResult
-    func importPNACHURLs(_ urls: [URL], asCheat: Bool = true) -> String {
+    func importPNACHURLs(_ urls: [URL], asCheat: Bool = true, presentsAlert: Bool = true) -> String {
         let destinationPath = ARMSX2Bridge.pnachPathForCurrentGame(asCheat: asCheat)
         let results = urls.map { importPNACHFile($0, destinationPath: destinationPath, asCheat: asCheat) }
-        return finishPNACHImport(results)
+        return finishPNACHImport(results, presentsAlert: presentsAlert)
     }
 
     @discardableResult
-    func importPNACHURLs(_ urls: [URL], forISO isoName: String, asCheat: Bool = true) -> String {
+    func importPNACHURLs(_ urls: [URL], forISO isoName: String, asCheat: Bool = true, presentsAlert: Bool = true) -> String {
         let destinationPath = ARMSX2Bridge.pnachPath(forISO: isoName, asCheat: asCheat)
         let results = urls.map { importPNACHFile($0, destinationPath: destinationPath, asCheat: asCheat) }
-        return finishPNACHImport(results)
+        return finishPNACHImport(results, presentsAlert: presentsAlert)
     }
 
-    private func finishPNACHImport(_ results: [ImportResult]) -> String {
+    func presentImportResult(_ message: String) {
+        lastImportMessage = message
+        showImportAlert = true
+    }
+
+    private func finishPNACHImport(_ results: [ImportResult], presentsAlert: Bool) -> String {
         let messages = results.map { result -> String in
             switch result {
             case .success(let message, _):
                 return message
-            case .unsupported(let fileName):
-                return "Unsupported: \(fileName)"
+            case .unsupported(let message):
+                return message
             case .failure(let message):
                 return message
             }
         }
 
         let message = messages.isEmpty ? "No PNACH files imported." : messages.joined(separator: "\n")
-        lastImportMessage = message
-        showImportAlert = true
+        if presentsAlert {
+            presentImportResult(message)
+        }
         return message
     }
 
     private enum ImportResult {
         case success(String, importedGame: ImportedGame? = nil)
-        case unsupported(String)
+        case unsupported(message: String)
         case failure(String)
     }
 
@@ -148,21 +157,21 @@ final class FileImportHandler: @unchecked Sendable {
         if preferredDestination == .game {
             guard Self.gameExtensions.contains(ext) else {
                 NSLog("[ARMSX2 iOS Import] unsupported game file: %@", fileName)
-                return .unsupported(fileName)
+                return .unsupported(message: Self.unsupportedGameImportMessage(for: fileName))
             }
             destDir = (docsPath as NSString).appendingPathComponent("iso")
             category = "Game"
         } else if preferredDestination == .bios {
             guard Self.biosExtensions.contains(ext) else {
                 NSLog("[ARMSX2 iOS Import] unsupported BIOS file: %@", fileName)
-                return .unsupported(fileName)
+                return .unsupported(message: Self.unsupportedBIOSImportMessage(for: fileName))
             }
 
             let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
             let size = attrs?[.size] as? UInt64 ?? 0
             if size > 0 && size > Self.biosSizeThreshold {
                 NSLog("[ARMSX2 iOS Import] rejecting oversized BIOS candidate: %@ size=%llu", fileName, size)
-                return .failure("\(fileName): too large for a PS2 BIOS dump.")
+                return .failure(Self.oversizedBIOSImportMessage(for: fileName))
             }
 
             destDir = (docsPath as NSString).appendingPathComponent("bios")
@@ -183,7 +192,7 @@ final class FileImportHandler: @unchecked Sendable {
             }
         } else {
             NSLog("[ARMSX2 iOS Import] unsupported file: %@", fileName)
-            return .unsupported(fileName)
+            return .unsupported(message: Self.unsupportedAutomaticImportMessage(for: fileName))
         }
 
         // Create directory if needed
@@ -217,14 +226,14 @@ final class FileImportHandler: @unchecked Sendable {
         }
 
         guard let destinationPath, !destinationPath.isEmpty else {
-            return .failure("Boot the target game before importing \(fileName), so ARMSX2 can rename it to Serial_CRC.pnach.")
+            return .failure(Self.pnachImportNeedsGameMessage)
         }
 
         let destinationURL = URL(fileURLWithPath: destinationPath)
         do {
             let data = try Data(contentsOf: url)
             guard let text = String(data: data, encoding: .utf8) ?? String(data: data, encoding: .ascii) else {
-                return .failure("\(fileName): PNACH must be UTF-8 or ASCII text.")
+                return .failure(Self.unreadablePNACHImportMessage(for: fileName))
             }
 
             let normalized = Self.normalizedPNACHText(text)
@@ -243,8 +252,24 @@ final class FileImportHandler: @unchecked Sendable {
             return .success("PNACH imported as \(destinationURL.lastPathComponent)")
         } catch {
             NSLog("[ARMSX2 iOS Import] PNACH failed: %@ -> %@ error=%@", fileName, destinationURL.path, error.localizedDescription)
-            return .failure("\(fileName): \(error.localizedDescription)")
+            return .failure(Self.failedPNACHImportMessage(for: fileName, errorDescription: error.localizedDescription))
         }
+    }
+
+    static func isUserCancelledPickerError(_ error: Error) -> Bool {
+        (error as NSError).code == NSUserCancelledError
+    }
+
+    static func failedGamePickerMessage(errorDescription: String) -> String {
+        "Game import failed. Try importing a supported PS2 game image.\n\(errorDescription)"
+    }
+
+    static func failedBIOSPickerMessage(errorDescription: String) -> String {
+        "BIOS import failed. Try importing a PS2 BIOS dump.\n\(errorDescription)"
+    }
+
+    static func failedPNACHPickerMessage(errorDescription: String) -> String {
+        "PNACH import failed. Try importing a text patch for the selected game.\n\(errorDescription)"
     }
 
     private static func contentTypes(for extensions: [String]) -> [UTType] {
@@ -255,6 +280,41 @@ final class FileImportHandler: @unchecked Sendable {
 
     private static func broaderContentTypes(for extensions: [String]) -> [UTType] {
         Array(Set([.item, .data, .content] + contentTypes(for: extensions)))
+    }
+
+    private static func unsupportedGameImportMessage(for fileName: String) -> String {
+        "This does not look like a supported game image: \(fileName). Try importing a PS2 game file such as \(formatList(gameExtensionList))."
+    }
+
+    private static func unsupportedBIOSImportMessage(for fileName: String) -> String {
+        "This does not look like a PS2 BIOS file: \(fileName). Try importing a BIOS dump such as \(formatList(biosExtensionList))."
+    }
+
+    private static func oversizedBIOSImportMessage(for fileName: String) -> String {
+        "This file is too large to be a normal PS2 BIOS dump: \(fileName). Try importing a BIOS dump between 1 MB and 50 MB, usually \(formatList(biosExtensionList))."
+    }
+
+    private static func unsupportedAutomaticImportMessage(for fileName: String) -> String {
+        "ARMSX2 could not import \(fileName). Try importing it from the matching Games, BIOS, or PNACH patch option."
+    }
+
+    private static func unreadablePNACHImportMessage(for fileName: String) -> String {
+        "\(fileName) is not a readable PNACH patch. PNACH patches need to be UTF-8 or ASCII text."
+    }
+
+    private static func failedPNACHImportMessage(for fileName: String, errorDescription: String) -> String {
+        "PNACH import failed for \(fileName). Check that this is a text patch for the selected game.\n\(errorDescription)"
+    }
+
+    private static func formatList(_ extensions: [String]) -> String {
+        let formats = extensions.map { ".\($0)" }
+        guard let last = formats.last else {
+            return ""
+        }
+        if formats.count == 1 {
+            return last
+        }
+        return "\(formats.dropLast().joined(separator: ", ")), or \(last)"
     }
 
     private func copyImportedFile(from sourceURL: URL, to destinationURL: URL) throws {
@@ -488,8 +548,7 @@ enum ARMSX2DeepLinkHandler {
     }
 
     private static func showMessage(_ message: String) {
-        FileImportHandler.shared.lastImportMessage = message
-        FileImportHandler.shared.showImportAlert = true
+        FileImportHandler.shared.presentImportResult(message)
     }
 }
 

--- a/app/src/main/swift/Views/BIOSListView.swift
+++ b/app/src/main/swift/Views/BIOSListView.swift
@@ -56,11 +56,6 @@ struct BIOSListView: View {
                     }
                 }
             }
-            .alert(settings.localized("Import Result"), isPresented: $fileImporter.showImportAlert) {
-                Button(settings.localized("OK")) {}
-            } message: {
-                Text(fileImporter.lastImportMessage ?? "")
-            }
             .sheet(isPresented: $showBIOSImporter) {
                 ImportDocumentPicker(
                     allowedContentTypes: FileImportHandler.biosContentTypes,
@@ -162,18 +157,17 @@ struct BIOSListView: View {
                 defaultBIOS = firstBIOS
             }
             if bioses.isEmpty, !urls.isEmpty {
-                fileImporter.lastImportMessage = [
+                let message = [
                     fileImporter.lastImportMessage,
                     "No usable PS2 BIOS was found after import. Use a 1-50 MB .bin or .rom BIOS dump."
                 ]
                 .compactMap { $0 }
                 .joined(separator: "\n")
-                fileImporter.showImportAlert = true
+                fileImporter.presentImportResult(message)
             }
         case .failure(let error):
-            if (error as NSError).code != NSUserCancelledError {
-                fileImporter.lastImportMessage = "BIOS import failed: \(error.localizedDescription)"
-                fileImporter.showImportAlert = true
+            if !FileImportHandler.isUserCancelledPickerError(error) {
+                fileImporter.presentImportResult(FileImportHandler.failedBIOSPickerMessage(errorDescription: error.localizedDescription))
             }
         }
     }

--- a/app/src/main/swift/Views/GameListView.swift
+++ b/app/src/main/swift/Views/GameListView.swift
@@ -150,11 +150,6 @@ struct GameListView: View {
                     }
                 }
             }
-            .alert(settings.localized("Import Result"), isPresented: $fileImporter.showImportAlert) {
-                Button(settings.localized("OK")) {}
-            } message: {
-                Text(fileImporter.lastImportMessage ?? "")
-            }
             .alert(settings.localized("Cover Result"), isPresented: $coverStore.showCoverAlert) {
                 Button(settings.localized("OK")) {}
             } message: {
@@ -259,9 +254,8 @@ struct GameListView: View {
                         loadGames()
                         autoDownloadCovers(for: importedGames)
                     case .failure(let error):
-                        if (error as NSError).code != NSUserCancelledError {
-                            fileImporter.lastImportMessage = "Import failed: \(error.localizedDescription)"
-                            fileImporter.showImportAlert = true
+                        if !FileImportHandler.isUserCancelledPickerError(error) {
+                            fileImporter.presentImportResult(FileImportHandler.failedGamePickerMessage(errorDescription: error.localizedDescription))
                         }
                     }
                 }
@@ -293,14 +287,12 @@ struct GameListView: View {
                         if let pendingPNACHGameName {
                             fileImporter.importPNACHURLs(urls, forISO: pendingPNACHGameName, asCheat: true)
                         } else {
-                            fileImporter.lastImportMessage = "Pick a game first, then import its PNACH patch."
-                            fileImporter.showImportAlert = true
+                            fileImporter.presentImportResult(FileImportHandler.pnachImportNeedsGameMessage)
                         }
                         pendingPNACHGameName = nil
                     case .failure(let error):
-                        if (error as NSError).code != NSUserCancelledError {
-                            fileImporter.lastImportMessage = "PNACH import failed: \(error.localizedDescription)"
-                            fileImporter.showImportAlert = true
+                        if !FileImportHandler.isUserCancelledPickerError(error) {
+                            fileImporter.presentImportResult(FileImportHandler.failedPNACHPickerMessage(errorDescription: error.localizedDescription))
                         }
                         pendingPNACHGameName = nil
                     }

--- a/app/src/main/swift/Views/GameScreenView.swift
+++ b/app/src/main/swift/Views/GameScreenView.swift
@@ -46,8 +46,12 @@ struct GameScreenView: View {
     @State private var compatibilityIdentity = ""
     @State private var compatibilityAutoPresets = true
     @State private var saveStateStatus: String? = nil
+    @State private var saveStateStatusGeneration = 0
     @State private var runtimeOverlayPauseActive = false
     @State private var previousHideHomeIndicator = false
+
+    private static let briefStatusDisplayDuration: TimeInterval = 2.2
+    private static let importantStatusDisplayDuration: TimeInterval = 6.0
 
     var body: some View {
         GeometryReader { geo in
@@ -90,8 +94,11 @@ struct GameScreenView: View {
             ARMSX2Bridge.setFullScreen(newValue)
         }
         .sheet(isPresented: $showSaveStates) {
-            SaveStatesPanel { message in
-                presentSaveStateStatus(message)
+            SaveStatesPanel { message, isImportant in
+                presentSaveStateStatus(
+                    message,
+                    displayDuration: isImportant ? Self.importantStatusDisplayDuration : Self.briefStatusDisplayDuration
+                )
             }
         }
         .sheet(isPresented: $showSpeedControl) {
@@ -113,11 +120,11 @@ struct GameScreenView: View {
                 showPNACHImporter = false
                 switch result {
                 case .success(let urls):
-                    let message = fileImporter.importPNACHURLs(urls, asCheat: true)
-                    presentSaveStateStatus(message)
+                    let message = fileImporter.importPNACHURLs(urls, asCheat: true, presentsAlert: false)
+                    presentPNACHImportResult(message)
                 case .failure(let error):
-                    if (error as NSError).code != NSUserCancelledError {
-                        presentSaveStateStatus("PNACH import failed: \(error.localizedDescription)")
+                    if !FileImportHandler.isUserCancelledPickerError(error) {
+                        fileImporter.presentImportResult(FileImportHandler.failedPNACHPickerMessage(errorDescription: error.localizedDescription))
                     }
                 }
             }
@@ -416,7 +423,7 @@ struct GameScreenView: View {
         guard let entry = makeRuntimePerGameSettingsEntry() else {
             runtimePerGameSettingsEntry = nil
             showPerGameSettings = true
-            presentSaveStateStatus(settings.localized("Per-game settings need a running game."))
+            presentImportantSaveStateStatus(settings.localized("Per-game settings need a running game."))
             return
         }
 
@@ -730,7 +737,7 @@ struct GameScreenView: View {
 
     private func clearCurrentGameCache() {
         guard let gameName = currentRuntimeGameName() else {
-            presentSaveStateStatus(settings.localized("Cache clear needs a running game."))
+            presentImportantSaveStateStatus(settings.localized("Cache clear needs a running game."))
             return
         }
 
@@ -752,16 +759,41 @@ struct GameScreenView: View {
         }
     }
 
-    private func presentSaveStateStatus(_ message: String) {
+    private func presentSaveStateStatus(
+        _ message: String,
+        displayDuration: TimeInterval = Self.briefStatusDisplayDuration
+    ) {
+        saveStateStatusGeneration += 1
+        let currentGeneration = saveStateStatusGeneration
         withAnimation(.easeOut(duration: 0.18)) {
             saveStateStatus = message
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.2) {
-            guard saveStateStatus == message else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + displayDuration) {
+            guard saveStateStatusGeneration == currentGeneration else { return }
             withAnimation(.easeIn(duration: 0.18)) {
                 saveStateStatus = nil
             }
         }
+    }
+
+    private func presentImportantSaveStateStatus(_ message: String) {
+        presentSaveStateStatus(message, displayDuration: Self.importantStatusDisplayDuration)
+    }
+
+    private func presentPNACHImportResult(_ message: String) {
+        if Self.isPNACHImportSuccessMessage(message) {
+            presentSaveStateStatus(message)
+        } else {
+            fileImporter.presentImportResult(message)
+        }
+    }
+
+    private static func isPNACHImportSuccessMessage(_ message: String) -> Bool {
+        let lines = message
+            .split(separator: "\n")
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return !lines.isEmpty && lines.allSatisfy { $0.hasPrefix("PNACH imported") }
     }
 
     private var availableDiscSwapNames: [String] {
@@ -772,7 +804,11 @@ struct GameScreenView: View {
         presentSaveStateStatus("Changing disc...")
         ARMSX2Bridge.changeDisc(toISO: discName) { success in
             Task { @MainActor in
-                presentSaveStateStatus(success ? "\(discName) inserted. Use the game's disc-swap prompt if needed." : "Failed to change disc")
+                if success {
+                    presentSaveStateStatus("\(discName) inserted. Use the game's disc-swap prompt if needed.")
+                } else {
+                    presentImportantSaveStateStatus("Could not change discs. Open the game's disc-swap prompt first, or restart with the target disc.")
+                }
             }
         }
     }
@@ -786,7 +822,11 @@ struct GameScreenView: View {
         presentSaveStateStatus("Ejecting disc...")
         ARMSX2Bridge.ejectDisc { success in
             Task { @MainActor in
-                presentSaveStateStatus(success ? "Disc ejected" : "Failed to eject disc")
+                if success {
+                    presentSaveStateStatus("Disc ejected")
+                } else {
+                    presentImportantSaveStateStatus("Could not eject the disc. Try again after the game has finished loading.")
+                }
             }
         }
     }
@@ -799,7 +839,7 @@ private struct SaveStatesPanel: View {
     @State private var busySlot: Int? = nil
     @State private var pendingOverwrite: ARMSX2SaveStateSlotInfo? = nil
 
-    let statusHandler: (String) -> Void
+    let statusHandler: (String, Bool) -> Void
 
     var body: some View {
         NavigationStack {
@@ -890,7 +930,10 @@ private struct SaveStatesPanel: View {
             Task { @MainActor in
                 busySlot = nil
                 refresh()
-                statusHandler(success ? "\(settings.localized("State saved to slot")) \(slotNumber)" : "\(settings.localized("Failed to save slot")) \(slotNumber)")
+                let message = success
+                    ? "\(settings.localized("State saved to slot")) \(slotNumber)"
+                    : "\(settings.localized("Could not save slot")) \(slotNumber). \(settings.localized("Try again after gameplay has fully loaded."))"
+                statusHandler(message, !success)
             }
         }
     }
@@ -902,7 +945,10 @@ private struct SaveStatesPanel: View {
             Task { @MainActor in
                 busySlot = nil
                 refresh()
-                statusHandler(success ? "\(settings.localized("State loaded from slot")) \(slotNumber)" : "\(settings.localized("Failed to load slot")) \(slotNumber)")
+                let message = success
+                    ? "\(settings.localized("State loaded from slot")) \(slotNumber)"
+                    : "\(settings.localized("Could not load slot")) \(slotNumber). \(settings.localized("Make sure it has a saved state first."))"
+                statusHandler(message, !success)
                 if success {
                     dismiss()
                 }

--- a/app/src/main/swift/Views/Settings/MemoryCardSettingsView.swift
+++ b/app/src/main/swift/Views/Settings/MemoryCardSettingsView.swift
@@ -15,6 +15,7 @@ struct MemoryCardSettingsView: View {
     @State private var showResult = false
 
     private let cardSizes = [8, 16, 32, 64]
+    private let pathLikeCharacters: [Character] = ["/", "\\", ":", "*", "?", "\"", "<", ">", "|"]
 
     var body: some View {
         Form {
@@ -105,9 +106,32 @@ struct MemoryCardSettingsView: View {
     }
 
     private func createCard() {
+        if let validationMessage = validateNewMemoryCardName(newCardName) {
+            resultMessage = validationMessage
+            showResult = true
+            return
+        }
+
         let success = ARMSX2Bridge.createMemoryCard(named: newCardName, sizeMB: newCardSizeMB, folder: createFolderCard)
         refresh()
         resultMessage = success ? "Memory card created." : "Could not create memory card. Check the name, size, or whether it already exists."
         showResult = true
+    }
+
+    private func validateNewMemoryCardName(_ name: String) -> String? {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedName.isEmpty {
+            return "Enter a name for the memory card first."
+        }
+
+        if trimmedName.contains(where: { pathLikeCharacters.contains($0) }) {
+            return "Memory card names cannot contain folder or path characters like / or \\."
+        }
+
+        if availableCards.contains(where: { $0.caseInsensitiveCompare(trimmedName) == .orderedSame }) {
+            return "A memory card with this name already exists."
+        }
+
+        return nil
     }
 }


### PR DESCRIPTION
This PR improves a few iOS error and guidance messages so users get clearer next steps when something goes wrong.

The main reason for this change is that some failures were technically reported, but the messages were either too short, too vague, or disappeared too quickly to be useful. Import/setup errors now stay visible until dismissed, and important in-game failure toasts no longer get hidden too quickly.

Changes:
- Adds clearer guidance for unsupported game, BIOS, and PNACH imports.
- Fixes import/setup alerts so they no longer flash and disappear before the user can read them.
- Adds simple memory card name validation before calling the bridge.
- Improves disc change/eject and save/load failure messages with suggested next steps.
- Makes important failure toasts stay readable longer, while keeping success/progress toasts brief.

This does not change emulator core behavior, import/copy paths, save/load logic, memory-card internals, or native bridge behavior. Successful paths should behave the same as before.

Validation:
- IPA build passed.
- App launched successfully.
- Unsupported game import tested.
- Error visibility checked.