### PR TITLE
Android: Add RetroAchievements host override receiver

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,6 +46,7 @@
         android:largeHeap="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="false"
         android:resizeableActivity="true"
@@ -99,6 +100,15 @@
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
             android:exported="false"
             android:parentActivityName=".activities.SettingsActivity" />
+
+        <receiver
+            android:name=".utils.RetroAchievementsHostOverrideReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="${applicationId}.action.SET_RETROACHIEVEMENTS_HOST_OVERRIDE" />
+                <action android:name="${applicationId}.action.CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE" />
+            </intent-filter>
+        </receiver>
 
         <activity
             android:name="com.discord.socialsdk.AuthenticationActivity"

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -47,6 +47,74 @@ namespace
 	static jmethodID s_ra_notify_state_changed = nullptr;
 	static jmethodID s_ra_notify_hardcore_changed = nullptr;
         static std::mutex s_ra_bridge_mutex;
+        static std::mutex s_ra_override_mutex;
+        static std::string s_ra_host_override;
+        static bool s_ra_has_saved_hardcore_mode = false;
+
+	static void ApplyRetroAchievementsHostOverrideLocked()
+	{
+		if (s_ra_host_override.empty())
+		{
+			Achievements::ClearHostOverride();
+			return;
+		}
+
+		Achievements::SetHostOverride(s_ra_host_override);
+	}
+
+	static void RestartAchievementsClientIfNeeded()
+	{
+		if (!EmuConfig.Achievements.Enabled || !Achievements::IsActive())
+			return;
+
+		Achievements::Shutdown(false);
+		Achievements::Initialize();
+	}
+
+	static void SetRetroAchievementsHostOverride(const std::string& host)
+	{
+		std::lock_guard<std::mutex> lock(s_ra_override_mutex);
+		if (!s_ra_has_saved_hardcore_mode)
+		{
+			s_ra_has_saved_hardcore_mode = true;
+		}
+
+		s_ra_host_override = host;
+		ApplyRetroAchievementsHostOverrideLocked();
+
+		if (EmuConfig.Achievements.HardcoreMode)
+		{
+			Pcsx2Config::AchievementsOptions old_config = EmuConfig.Achievements;
+			EmuConfig.Achievements.HardcoreMode = false;
+			Host::SetBaseBoolSettingValue("Achievements", "ChallengeMode", false);
+			Host::CommitBaseSettingChanges();
+			Achievements::UpdateSettings(old_config);
+		}
+
+		RestartAchievementsClientIfNeeded();
+	}
+
+	static void ClearRetroAchievementsHostOverride(bool restore_hardcore, bool hardcore_enabled)
+	{
+		std::lock_guard<std::mutex> lock(s_ra_override_mutex);
+		s_ra_host_override.clear();
+		ApplyRetroAchievementsHostOverrideLocked();
+
+		const bool should_restore = restore_hardcore && s_ra_has_saved_hardcore_mode;
+		const bool restored_hardcore = should_restore ? hardcore_enabled : EmuConfig.Achievements.HardcoreMode;
+		s_ra_has_saved_hardcore_mode = false;
+
+		if (EmuConfig.Achievements.HardcoreMode != restored_hardcore)
+		{
+			Pcsx2Config::AchievementsOptions old_config = EmuConfig.Achievements;
+			EmuConfig.Achievements.HardcoreMode = restored_hardcore;
+			Host::SetBaseBoolSettingValue("Achievements", "ChallengeMode", restored_hardcore);
+			Host::CommitBaseSettingChanges();
+			Achievements::UpdateSettings(old_config);
+		}
+
+		RestartAchievementsClientIfNeeded();
+	}
 
 	static void EnsureAchievementsClientInitialized()
 	{
@@ -1503,6 +1571,23 @@ Java_kr_co_iefriends_pcsx2_utils_RetroAchievementsBridge_nativeSetHardcore(JNIEn
     Host::CommitBaseSettingChanges();
     Achievements::UpdateSettings(old_config);
     NotifyRetroAchievementsState();
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_kr_co_iefriends_pcsx2_NativeApp_setAchievementsHostOverride(JNIEnv* env, jclass, jstring j_host)
+{
+	SetRetroAchievementsHostOverride(GetJavaString(env, j_host));
+	NotifyRetroAchievementsState();
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_kr_co_iefriends_pcsx2_NativeApp_clearAchievementsHostOverride(JNIEnv*, jclass, jboolean restore_hardcore,
+	jboolean hardcore_enabled)
+{
+	ClearRetroAchievementsHostOverride(restore_hardcore == JNI_TRUE, hardcore_enabled == JNI_TRUE);
+	NotifyRetroAchievementsState();
 }
 
 extern "C"

--- a/app/src/main/cpp/pcsx2/Achievements.cpp
+++ b/app/src/main/cpp/pcsx2/Achievements.cpp
@@ -186,6 +186,7 @@ namespace Achievements
 	static void CloseLeaderboard();
 
 	static bool s_hardcore_mode = false;
+	static std::string s_host_override;
 
 #ifdef ENABLE_RAINTEGRATION
 	static bool s_using_raintegration = false;
@@ -442,6 +443,8 @@ bool Achievements::Initialize()
 	if (!CreateClient(&s_client, &s_http_downloader))
 		return false;
 
+	rc_client_set_host(s_client, s_host_override.empty() ? nullptr : s_host_override.c_str());
+
 	// Hardcore starts off. We enable it on first boot.
 	s_hardcore_mode = false;
 
@@ -509,6 +512,26 @@ bool Achievements::CreateClient(rc_client_t** client, std::unique_ptr<HTTPDownlo
 
 	*client = new_client;
 	return true;
+}
+
+void Achievements::SetHostOverride(std::string host)
+{
+	if (IsUsingRAIntegration())
+		return;
+
+	auto lock = GetLock();
+	s_host_override = std::move(host);
+	rc_client_set_host(s_client, s_host_override.empty() ? nullptr : s_host_override.c_str());
+}
+
+void Achievements::ClearHostOverride()
+{
+	if (IsUsingRAIntegration())
+		return;
+
+	auto lock = GetLock();
+	s_host_override.clear();
+	rc_client_set_host(s_client, nullptr);
 }
 
 void Achievements::DestroyClient(rc_client_t** client, std::unique_ptr<HTTPDownloader>* http)

--- a/app/src/main/cpp/pcsx2/Achievements.h
+++ b/app/src/main/cpp/pcsx2/Achievements.h
@@ -61,6 +61,10 @@ namespace Achievements
 	/// If the login is successful, the token returned by the server will be saved.
 	bool Login(const char* username, const char* password, Error* error);
 
+	/// Overrides the RetroAchievements API host for loopback proxy integrations.
+	void SetHostOverride(std::string host);
+	void ClearHostOverride();
+
 	/// Logs out of RetroAchievements, clearing any credentials.
 	void Logout();
 

--- a/app/src/main/java/kr/co/iefriends/pcsx2/NativeApp.java
+++ b/app/src/main/java/kr/co/iefriends/pcsx2/NativeApp.java
@@ -11,6 +11,7 @@ import java.lang.ref.WeakReference;
 
 import kr.co.iefriends.pcsx2.activities.MainActivity;
 import kr.co.iefriends.pcsx2.utils.DataDirectoryManager;
+import kr.co.iefriends.pcsx2.utils.RetroAchievementsHostOverrideReceiver;
 
 public class NativeApp {
 	static {
@@ -56,6 +57,14 @@ public class NativeApp {
 			externalFilesDir = context.getDataDir();
 		}
 		initialize(externalFilesDir.getAbsolutePath(), android.os.Build.VERSION.SDK_INT);
+
+		String achievementsHostOverride = RetroAchievementsHostOverrideReceiver.getHostOverride(context);
+		if (!TextUtils.isEmpty(achievementsHostOverride)) {
+			setAchievementsHostOverride(achievementsHostOverride);
+		} else if (RetroAchievementsHostOverrideReceiver.hasPendingHardcoreRestore(context)) {
+			clearAchievementsHostOverride(true, RetroAchievementsHostOverrideReceiver.getPendingHardcoreRestoreValue(context));
+			RetroAchievementsHostOverrideReceiver.clearPendingHardcoreRestore(context);
+		}
 	}
 
 	public static void setDataRootOverride(String path) {
@@ -112,6 +121,8 @@ public class NativeApp {
 
 	public static native void setSetting(String section, String key, String type, String value);
 	public static native String getSetting(String section, String key, String type);
+	public static native void setAchievementsHostOverride(String host);
+	public static native void clearAchievementsHostOverride(boolean restoreHardcore, boolean hardcoreEnabled);
 
 	public static native void onNativeSurfaceCreated();
 	public static native void onNativeSurfaceChanged(Surface surface, int w, int h);

--- a/app/src/main/java/kr/co/iefriends/pcsx2/utils/RetroAchievementsBridge.java
+++ b/app/src/main/java/kr/co/iefriends/pcsx2/utils/RetroAchievementsBridge.java
@@ -20,6 +20,7 @@ By MoonPower (Momo-AUX1) GPLv3 License
 
 package kr.co.iefriends.pcsx2.utils;
 
+import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
@@ -29,6 +30,8 @@ import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+
+import kr.co.iefriends.pcsx2.NativeApp;
 
 public final class RetroAchievementsBridge {
 
@@ -212,6 +215,15 @@ public final class RetroAchievementsBridge {
         sMainHandler.post(runnable);
     }
 
+    private static void cacheHardcorePreference(boolean enabled) {
+        Context context = NativeApp.getContext();
+        if (context == null) {
+            return;
+        }
+
+        RetroAchievementsHostOverrideReceiver.cacheHardcorePreference(context, enabled);
+    }
+
     @SuppressWarnings("unused") // Called from native
     static void notifyLoginRequested(int reason) {
         postToMain(() -> {
@@ -263,6 +275,8 @@ public final class RetroAchievementsBridge {
         synchronized (RetroAchievementsBridge.class) {
             sLastState = state;
         }
+
+        cacheHardcorePreference(state.hardcorePreference);
 
         postToMain(() -> {
             Listener listener = sListener;

--- a/app/src/main/java/kr/co/iefriends/pcsx2/utils/RetroAchievementsHostOverrideReceiver.java
+++ b/app/src/main/java/kr/co/iefriends/pcsx2/utils/RetroAchievementsHostOverrideReceiver.java
@@ -1,0 +1,187 @@
+package kr.co.iefriends.pcsx2.utils;
+
+import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import android.text.TextUtils;
+
+import java.util.Locale;
+
+import kr.co.iefriends.pcsx2.NativeApp;
+
+public class RetroAchievementsHostOverrideReceiver extends BroadcastReceiver {
+    private static final String ACTION_SET_HOST_OVERRIDE_SUFFIX = ".action.SET_RETROACHIEVEMENTS_HOST_OVERRIDE";
+    private static final String ACTION_CLEAR_HOST_OVERRIDE_SUFFIX = ".action.CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE";
+    private static final String PREFS_NAME = "retroachievements_host_override";
+    private static final String KEY_HOST = "host";
+    private static final String KEY_HARDCORE_RESTORE_PRESENT = "hardcore_restore_present";
+    private static final String KEY_HARDCORE_RESTORE_VALUE = "hardcore_restore_value";
+    private static final String KEY_PENDING_HARDCORE_RESTORE_PRESENT = "pending_hardcore_restore_present";
+    private static final String KEY_PENDING_HARDCORE_RESTORE_VALUE = "pending_hardcore_restore_value";
+    private static final String KEY_LAST_KNOWN_HARDCORE = "last_known_hardcore";
+
+    public static final String EXTRA_HOST = "host";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (intent == null || intent.getAction() == null) {
+            return;
+        }
+
+        String packageName = context.getPackageName();
+        String setAction = packageName + ACTION_SET_HOST_OVERRIDE_SUFFIX;
+        String clearAction = packageName + ACTION_CLEAR_HOST_OVERRIDE_SUFFIX;
+
+        if (clearAction.equals(intent.getAction())) {
+            clearHostOverride(context);
+            setResultCode(Activity.RESULT_OK);
+            return;
+        }
+
+        if (!setAction.equals(intent.getAction())) {
+            return;
+        }
+
+        String rawHost = intent.getStringExtra(EXTRA_HOST);
+        if (TextUtils.isEmpty(rawHost) || TextUtils.isEmpty(rawHost.trim())) {
+            clearHostOverride(context);
+            setResultCode(Activity.RESULT_OK);
+            return;
+        }
+
+        String host = normalizeHost(rawHost);
+        if (host == null) {
+            setResultCode(Activity.RESULT_CANCELED);
+            return;
+        }
+
+        SharedPreferences prefs = sharedPreferences(context);
+        boolean hasExistingOverride = !TextUtils.isEmpty(prefs.getString(KEY_HOST, null));
+
+        if (!hasExistingOverride) {
+            prefs.edit()
+                    .putBoolean(KEY_HARDCORE_RESTORE_PRESENT, true)
+                    .putBoolean(KEY_HARDCORE_RESTORE_VALUE, prefs.getBoolean(KEY_LAST_KNOWN_HARDCORE, false))
+                    .apply();
+        }
+
+        prefs.edit()
+                .putString(KEY_HOST, host)
+                .remove(KEY_PENDING_HARDCORE_RESTORE_PRESENT)
+                .remove(KEY_PENDING_HARDCORE_RESTORE_VALUE)
+                .apply();
+
+        if (NativeApp.getContext() != null) {
+            NativeApp.setAchievementsHostOverride(host);
+        }
+
+        setResultCode(Activity.RESULT_OK);
+    }
+
+    public static String getHostOverride(Context context) {
+        return sharedPreferences(context).getString(KEY_HOST, null);
+    }
+
+    public static void cacheHardcorePreference(Context context, boolean enabled) {
+        sharedPreferences(context)
+                .edit()
+                .putBoolean(KEY_LAST_KNOWN_HARDCORE, enabled)
+                .apply();
+    }
+
+    public static boolean hasPendingHardcoreRestore(Context context) {
+        return sharedPreferences(context).getBoolean(KEY_PENDING_HARDCORE_RESTORE_PRESENT, false);
+    }
+
+    public static boolean getPendingHardcoreRestoreValue(Context context) {
+        return sharedPreferences(context).getBoolean(KEY_PENDING_HARDCORE_RESTORE_VALUE, false);
+    }
+
+    public static void clearPendingHardcoreRestore(Context context) {
+        sharedPreferences(context)
+                .edit()
+                .remove(KEY_PENDING_HARDCORE_RESTORE_PRESENT)
+                .remove(KEY_PENDING_HARDCORE_RESTORE_VALUE)
+                .apply();
+    }
+
+    private static void clearHostOverride(Context context) {
+        SharedPreferences prefs = sharedPreferences(context);
+        boolean restoreHardcore = prefs.getBoolean(KEY_HARDCORE_RESTORE_VALUE, false);
+        boolean hasRestoreValue = prefs.getBoolean(KEY_HARDCORE_RESTORE_PRESENT, false);
+
+        SharedPreferences.Editor editor = prefs.edit()
+                .remove(KEY_HOST)
+                .remove(KEY_HARDCORE_RESTORE_PRESENT)
+                .remove(KEY_HARDCORE_RESTORE_VALUE);
+
+        if (NativeApp.getContext() == null && hasRestoreValue) {
+            editor.putBoolean(KEY_PENDING_HARDCORE_RESTORE_PRESENT, true)
+                    .putBoolean(KEY_PENDING_HARDCORE_RESTORE_VALUE, restoreHardcore);
+        } else {
+            editor.remove(KEY_PENDING_HARDCORE_RESTORE_PRESENT)
+                    .remove(KEY_PENDING_HARDCORE_RESTORE_VALUE);
+        }
+
+        editor.apply();
+
+        if (NativeApp.getContext() != null) {
+            NativeApp.clearAchievementsHostOverride(hasRestoreValue, restoreHardcore);
+        }
+    }
+
+    private static SharedPreferences sharedPreferences(Context context) {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+    }
+
+    private static String normalizeHost(String value) {
+        String trimmedValue = value == null ? "" : value.trim();
+        if (trimmedValue.isEmpty()) {
+            return null;
+        }
+
+        String candidate = trimmedValue.contains("://") ? trimmedValue : "http://" + trimmedValue;
+        Uri uri = Uri.parse(candidate);
+        if (uri == null) {
+            return null;
+        }
+
+        String scheme = uri.getScheme();
+        String host = uri.getHost();
+        if (scheme == null || host == null) {
+            return null;
+        }
+
+        String normalizedScheme = scheme.toLowerCase(Locale.US);
+        String normalizedHost = host.toLowerCase(Locale.US);
+        if (!"http".equals(normalizedScheme)) {
+            return null;
+        }
+
+        if (!"127.0.0.1".equals(normalizedHost) && !"localhost".equals(normalizedHost)) {
+            return null;
+        }
+
+        int port = uri.getPort();
+        if (port < 1 || port > 65535) {
+            return null;
+        }
+
+        String authority = uri.getEncodedAuthority();
+        if ((authority != null && authority.contains("@"))
+                || !TextUtils.isEmpty(uri.getEncodedQuery())
+                || !TextUtils.isEmpty(uri.getEncodedFragment())) {
+            return null;
+        }
+
+        String path = uri.getEncodedPath();
+        if (!TextUtils.isEmpty(path) && !"/".equals(path)) {
+            return null;
+        }
+
+        return normalizedScheme + "://" + normalizedHost + ":" + port;
+    }
+}

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain>127.0.0.1</domain>
+        <domain>localhost</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
[RAOfflineProxy](https://raofflineproxy.com/) is an Android app that proxies RetroAchievements traffic through `127.0.0.1`, enabling offline softcore achievement play through local caching and later sync.

On Android, controlling the RetroAchievements host override through a broadcast receiver is a cleaner integration point than relying on external tools to patch runtime config files directly.

This makes the host override controllable by the app at runtime instead of requiring external file edits, which is more brittle and harder to integrate cleanly on Android.

## Summary

- add an Android broadcast receiver for setting and clearing the RetroAchievements host override
- persist the override across app restarts and allow loopback cleartext traffic for `127.0.0.1` / `localhost`
- apply the override through the native RetroAchievements client and disable hardcore while active
- restore the default host and prior hardcore preference when clearing the override
- restart the live RetroAchievements client after host changes so both patch and revert take effect immediately

## Testing

- built and installed `:app:installUnrestrictedDebug`
- verified `SET_RETROACHIEVEMENTS_HOST_OVERRIDE` routes RetroAchievements traffic through the local proxy on device
- verified `CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE` removes the stored override and restores direct traffic after relaunch
- verified offline play works through RAOfflineProxy while the override is active

## Related

- mirrors the same Android broadcast-driven host override support already merged for [PPSSPP](https://github.com/hrydgard/ppsspp/pull/21760)
- follows the same goal as the existing PRs for [melonDS](https://github.com/rafaelvcaetano/melonDS-android/pull/1633) and [Dolphin](https://github.com/dolphin-emu/dolphin/pull/14671)
