### PR TITLE
iOS: Improve import and cover setup safety

### DIFF
--- a/app/src/main/swift/Models/CoverStore.swift
+++ b/app/src/main/swift/Models/CoverStore.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 import Foundation
+import ImageIO
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -27,7 +28,7 @@ final class CoverStore: @unchecked Sendable {
 
     static let imageExtensions: [String] = ["jpg", "jpeg", "png", "webp", "heic", "heif"]
     static let coverContentTypes: [UTType] = {
-        var types: [UTType] = [.image]
+        var types: [UTType] = [.item, .data, .content, .image]
         for ext in imageExtensions {
             if let type = UTType(filenameExtension: ext), !types.contains(type) {
                 types.append(type)
@@ -136,7 +137,10 @@ final class CoverStore: @unchecked Sendable {
         }
 
         if showResult {
-            lastCoverMessage = "Downloaded \(downloaded) cover(s). Skipped \(skipped) existing. Failed \(failed)."
+            let summary = "Downloaded \(downloaded) cover(s). Skipped \(skipped) existing. Failed \(failed)."
+            lastCoverMessage = failed > 0
+                ? "\(summary)\nCheck your connection and Cover Source, or choose a local cover."
+                : summary
             showCoverAlert = true
         } else {
             NSLog("[ARMSX2 iOS Covers] auto-download finished downloaded=%d skipped=%d failed=%d", downloaded, skipped, failed)
@@ -175,10 +179,9 @@ final class CoverStore: @unchecked Sendable {
 
             let destination = primaryCoverDirectory.appendingPathComponent(baseName).appendingPathExtension(ext)
             do {
-                if fileManager.fileExists(atPath: destination.path) {
-                    try fileManager.removeItem(at: destination)
+                try replaceCover(at: destination) {
+                    try fileManager.copyItem(at: sourceURL, to: destination)
                 }
-                try fileManager.copyItem(at: sourceURL, to: destination)
                 imported.append(sourceURL.lastPathComponent)
                 NSLog("[ARMSX2 iOS Covers] imported %@ -> %@", sourceURL.lastPathComponent, destination.path)
             } catch {
@@ -200,6 +203,35 @@ final class CoverStore: @unchecked Sendable {
         }
 
         let message = lines.isEmpty ? "No covers imported." : lines.joined(separator: "\n")
+        lastCoverMessage = message
+        showCoverAlert = true
+        return message
+    }
+
+    @discardableResult
+    func importCoverData(_ data: Data, forGameNamed gameName: String) -> String {
+        guard let ext = imageExtension(for: data) else {
+            let message = "The selected photo is not a supported image."
+            lastCoverMessage = message
+            showCoverAlert = true
+            return message
+        }
+
+        removeManagedCovers(forGameNamed: gameName)
+        let baseName = preferredManagedCoverBaseName(forGameName: gameName)
+        let destination = primaryCoverDirectory.appendingPathComponent(baseName).appendingPathExtension(ext)
+        let message: String
+        do {
+            try replaceCover(at: destination) {
+                try data.write(to: destination, options: .atomic)
+            }
+            message = "Assigned cover from Photos."
+            NSLog("[ARMSX2 iOS Covers] imported photo -> %@", destination.path)
+        } catch {
+            message = "Cover import failed: \(error.localizedDescription)"
+            NSLog("[ARMSX2 iOS Covers] photo import failed -> %@ error=%@", destination.path, error.localizedDescription)
+        }
+
         lastCoverMessage = message
         showCoverAlert = true
         return message
@@ -444,6 +476,24 @@ final class CoverStore: @unchecked Sendable {
             return ext == "jpeg" ? "jpg" : ext
         }
         return "jpg"
+    }
+
+    private func imageExtension(for data: Data) -> String? {
+        guard let imageSource = CGImageSourceCreateWithData(data as CFData, nil),
+              let typeIdentifier = CGImageSourceGetType(imageSource),
+              let ext = UTType(typeIdentifier as String)?.preferredFilenameExtension?.lowercased() else {
+            return nil
+        }
+
+        let normalized = ext == "jpeg" ? "jpg" : ext
+        return Self.imageExtensions.contains(normalized) ? normalized : nil
+    }
+
+    private func replaceCover(at destination: URL, write: () throws -> Void) throws {
+        if fileManager.fileExists(atPath: destination.path) {
+            try fileManager.removeItem(at: destination)
+        }
+        try write()
     }
 
     private func preferredManagedCoverBaseName(forGameName gameName: String) -> String {

--- a/app/src/main/swift/Models/FileImportHandler.swift
+++ b/app/src/main/swift/Models/FileImportHandler.swift
@@ -49,12 +49,24 @@ final class FileImportHandler: @unchecked Sendable {
     }
 
     @discardableResult
-    func handleURLs(_ urls: [URL], preferredDestination: ImportDestination = .automatic) -> [ImportedGame] {
-        importURLs(urls, preferredDestination: preferredDestination)
+    func handleURLs(
+        _ urls: [URL],
+        preferredDestination: ImportDestination = .automatic,
+        allowReplacingExistingFiles: Bool = true
+    ) -> [ImportedGame] {
+        importURLs(
+            urls,
+            preferredDestination: preferredDestination,
+            allowReplacingExistingFiles: allowReplacingExistingFiles
+        )
     }
 
     @discardableResult
-    func importURLs(_ urls: [URL], preferredDestination: ImportDestination = .automatic) -> [ImportedGame] {
+    func importURLs(
+        _ urls: [URL],
+        preferredDestination: ImportDestination = .automatic,
+        allowReplacingExistingFiles: Bool = true
+    ) -> [ImportedGame] {
         NSLog("[ARMSX2 iOS Import] importing %d file(s), destination=%@", urls.count, String(describing: preferredDestination))
 
         var imported: [String] = []
@@ -63,7 +75,11 @@ final class FileImportHandler: @unchecked Sendable {
         var failed: [String] = []
 
         for url in urls {
-            switch importFile(url, preferredDestination: preferredDestination) {
+            switch importFile(
+                url,
+                preferredDestination: preferredDestination,
+                allowReplacingExistingFiles: allowReplacingExistingFiles
+            ) {
             case .success(let message, let importedGame):
                 imported.append(message)
                 if let importedGame {
@@ -89,6 +105,50 @@ final class FileImportHandler: @unchecked Sendable {
 
         presentImportResult(lines.isEmpty ? "No files imported." : lines.joined(separator: "\n"))
         return importedGames
+    }
+
+    func existingFileNames(for urls: [URL], preferredDestination: ImportDestination) -> [String] {
+        let directoryName: String
+        let supportedExtensions: Set<String>
+        switch preferredDestination {
+        case .game:
+            directoryName = "iso"
+            supportedExtensions = Self.gameExtensions
+        case .bios:
+            directoryName = "bios"
+            supportedExtensions = Self.biosExtensions
+        default:
+            return []
+        }
+
+        let docsPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
+        let destinationDirectory = (docsPath as NSString).appendingPathComponent(directoryName)
+        var existingFileNames: [String] = []
+        var seenFileNames = Set<String>()
+
+        for url in urls where supportedExtensions.contains(url.pathExtension.lowercased()) {
+            let fileName = url.lastPathComponent
+            let destinationPath = (destinationDirectory as NSString).appendingPathComponent(fileName)
+            if FileManager.default.fileExists(atPath: destinationPath),
+               seenFileNames.insert(fileName).inserted {
+                existingFileNames.append(fileName)
+            }
+        }
+        return existingFileNames
+    }
+
+    static func replacementConfirmationMessage(for fileNames: [String]) -> String {
+        let visibleFileNames = fileNames.prefix(3)
+        var lines = [
+            "Some selected files already exist. Replacing them will overwrite the current copies.",
+            "",
+            fileNames.count == 1 ? "Existing file:" : "Existing files:"
+        ]
+        lines.append(contentsOf: visibleFileNames)
+        if fileNames.count > visibleFileNames.count {
+            lines.append("...and \(fileNames.count - visibleFileNames.count) more.")
+        }
+        return lines.joined(separator: "\n")
     }
 
     @discardableResult
@@ -135,7 +195,11 @@ final class FileImportHandler: @unchecked Sendable {
         case failure(String)
     }
 
-    private func importFile(_ url: URL, preferredDestination: ImportDestination) -> ImportResult {
+    private func importFile(
+        _ url: URL,
+        preferredDestination: ImportDestination,
+        allowReplacingExistingFiles: Bool
+    ) -> ImportResult {
         let accessing = url.startAccessingSecurityScopedResource()
         defer { if accessing { url.stopAccessingSecurityScopedResource() } }
 
@@ -203,6 +267,9 @@ final class FileImportHandler: @unchecked Sendable {
         // Copy file
         do {
             if FileManager.default.fileExists(atPath: destPath) {
+                guard allowReplacingExistingFiles else {
+                    return .failure("\(fileName) already exists. Import it again and choose Replace to overwrite the current copy.")
+                }
                 try FileManager.default.removeItem(atPath: destPath)
             }
             try copyImportedFile(from: url, to: URL(fileURLWithPath: destPath))

--- a/app/src/main/swift/Views/BIOSListView.swift
+++ b/app/src/main/swift/Views/BIOSListView.swift
@@ -11,6 +11,9 @@ struct BIOSListView: View {
     @State private var fileImporter = FileImportHandler.shared
     @State private var showBIOSImporter = false
     @State private var showBIOSCompatibilityImporter = false
+    @State private var showBIOSReplacementAlert = false
+    @State private var pendingBIOSImportURLs: [URL] = []
+    @State private var existingBIOSImportFileNames: [String] = []
 
     var body: some View {
         NavigationStack {
@@ -74,6 +77,17 @@ struct BIOSListView: View {
                     showBIOSCompatibilityImporter = false
                     handleBIOSPickerResult(result, source: "compatibility")
                 }
+            }
+            .alert(settings.localized("Replace existing files?"), isPresented: $showBIOSReplacementAlert) {
+                Button(settings.localized("Cancel"), role: .cancel) {
+                    clearPendingBIOSImport()
+                }
+                Button(settings.localized("Replace"), role: .destructive) {
+                    importBIOSFiles(pendingBIOSImportURLs, allowReplacingExistingFiles: true)
+                    clearPendingBIOSImport()
+                }
+            } message: {
+                Text(FileImportHandler.replacementConfirmationMessage(for: existingBIOSImportFileNames))
             }
         }
         .onAppear { loadBIOSes() }
@@ -161,21 +175,7 @@ struct BIOSListView: View {
         switch result {
         case .success(let urls):
             NSLog("[ARMSX2 iOS BIOS] %@ picker completed with %d URL(s)", source, urls.count)
-            fileImporter.handleURLs(urls, preferredDestination: .bios)
-            loadBIOSes()
-            if defaultBIOS.isEmpty, let firstBIOS = bioses.first(where: { $0.valid })?.fileName {
-                ARMSX2Bridge.setDefaultBIOS(firstBIOS)
-                defaultBIOS = firstBIOS
-            }
-            if !bioses.contains(where: { $0.valid }), !urls.isEmpty {
-                let message = [
-                    fileImporter.lastImportMessage,
-                    "No bootable PS2 BIOS was found after import. Companion ROMs may be listed, but select a valid boot BIOS dump."
-                ]
-                .compactMap { $0 }
-                .joined(separator: "\n")
-                fileImporter.presentImportResult(message)
-            }
+            prepareBIOSImport(urls)
         case .failure(let error):
             if !FileImportHandler.isUserCancelledPickerError(error) {
                 fileImporter.presentImportResult(FileImportHandler.failedBIOSPickerMessage(errorDescription: error.localizedDescription))
@@ -183,9 +183,80 @@ struct BIOSListView: View {
         }
     }
 
+    private func prepareBIOSImport(_ urls: [URL]) {
+        let existingFileNames = fileImporter.existingFileNames(for: urls, preferredDestination: .bios)
+        guard !existingFileNames.isEmpty else {
+            importBIOSFiles(urls, allowReplacingExistingFiles: false)
+            return
+        }
+
+        pendingBIOSImportURLs = urls
+        existingBIOSImportFileNames = existingFileNames
+        showBIOSReplacementAlert = true
+    }
+
+    private func importBIOSFiles(_ urls: [URL], allowReplacingExistingFiles: Bool) {
+        fileImporter.handleURLs(
+            urls,
+            preferredDestination: .bios,
+            allowReplacingExistingFiles: allowReplacingExistingFiles
+        )
+        loadBIOSes()
+        if defaultBIOS.isEmpty, let firstBIOS = bioses.first(where: { $0.valid })?.fileName {
+            ARMSX2Bridge.setDefaultBIOS(firstBIOS)
+            defaultBIOS = firstBIOS
+        }
+        if let guidance = nonBootableImportGuidance(for: urls) {
+            let message = [
+                fileImporter.lastImportMessage,
+                guidance
+            ]
+            .compactMap { $0 }
+            .joined(separator: "\n")
+            fileImporter.presentImportResult(message)
+        } else if !bioses.contains(where: { $0.valid }), !urls.isEmpty {
+            let message = [
+                fileImporter.lastImportMessage,
+                "No bootable PS2 BIOS was found. Import a valid PS2 BIOS dump before starting games."
+            ]
+            .compactMap { $0 }
+            .joined(separator: "\n")
+            fileImporter.presentImportResult(message)
+        }
+    }
+
+    private func clearPendingBIOSImport() {
+        pendingBIOSImportURLs = []
+        existingBIOSImportFileNames = []
+    }
+
     private func loadBIOSes() {
         bioses = ARMSX2Bridge.availableBIOSInfos()
         defaultBIOS = ARMSX2Bridge.defaultBIOSName()
+    }
+
+    private func nonBootableImportGuidance(for urls: [URL]) -> String? {
+        let selectedFileNames = Set(urls.map(\.lastPathComponent))
+        let nonBootableFileNames = bioses
+            .filter { !$0.valid && selectedFileNames.contains($0.fileName) }
+            .map(\.fileName)
+
+        guard !nonBootableFileNames.isEmpty else { return nil }
+
+        let fileMessage: String
+        let setupMessage: String
+        if nonBootableFileNames.count == 1 {
+            fileMessage = "\(nonBootableFileNames[0]) is in your BIOS folder, but it is not a bootable PS2 BIOS. It may be a companion ROM or unsupported BIOS-related file."
+            setupMessage = "A bootable BIOS is already installed, but this selected file cannot be used to boot games."
+        } else {
+            fileMessage = "These selected files are in your BIOS folder, but they are not bootable PS2 BIOS files: \(nonBootableFileNames.joined(separator: ", ")). They may be companion ROMs or unsupported BIOS-related files."
+            setupMessage = "A bootable BIOS is already installed, but these files cannot be used to boot games."
+        }
+
+        if bioses.contains(where: { $0.valid }) {
+            return "\(fileMessage)\n\(setupMessage)"
+        }
+        return "\(fileMessage)\nNo bootable PS2 BIOS was found. Import a valid PS2 BIOS dump before starting games."
     }
 
     private func regionBadge(for bios: ARMSX2BIOSInfo) -> some View {
@@ -203,7 +274,7 @@ struct BIOSListView: View {
                     .foregroundStyle(.secondary)
             }
         }
-        .accessibilityLabel(bios.valid ? "\(bios.regionName) BIOS" : "Unknown BIOS region")
+        .accessibilityLabel(bios.valid ? "\(bios.regionName) BIOS" : settings.localized("Not a boot BIOS"))
     }
 
     private func flagEmoji(for countryCode: String) -> String? {

--- a/app/src/main/swift/Views/GameListView.swift
+++ b/app/src/main/swift/Views/GameListView.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 import SwiftUI
+import PhotosUI
 import UniformTypeIdentifiers
 import UIKit
 
@@ -28,13 +29,19 @@ struct GameListView: View {
     @State private var coverStore = CoverStore.shared
     @State private var showGameImporter = false
     @State private var showCoverImporter = false
+    @State private var showCoverPhotoPicker = false
     @State private var showRestartAlert = false
     @State private var showStopAlert = false
     @State private var showCoverTemplateEditor = false
     @State private var showPNACHImporter = false
+    @State private var showGameReplacementAlert = false
     @State private var coverTemplateDraft = CoverStore.defaultCoverURLTemplate
     @State private var pendingGameName: String = ""
+    @State private var pendingGameImportURLs: [URL] = []
+    @State private var existingGameImportFileNames: [String] = []
     @State private var pendingCoverGameName: String?
+    @State private var pendingCoverPhotoGameName: String?
+    @State private var selectedCoverPhotoItem: PhotosPickerItem?
     @State private var pendingPNACHGameName: String?
     @State private var gameInfoTarget: ISOEntry?
     @State private var gameSettingsTarget: ISOEntry?
@@ -242,6 +249,17 @@ struct GameListView: View {
             } message: {
                 Text(gameActionMessage ?? "")
             }
+            .alert(settings.localized("Replace existing files?"), isPresented: $showGameReplacementAlert) {
+                Button(settings.localized("Cancel"), role: .cancel) {
+                    clearPendingGameImport()
+                }
+                Button(settings.localized("Replace"), role: .destructive) {
+                    importGames(pendingGameImportURLs, allowReplacingExistingFiles: true)
+                    clearPendingGameImport()
+                }
+            } message: {
+                Text(FileImportHandler.replacementConfirmationMessage(for: existingGameImportFileNames))
+            }
             .sheet(isPresented: $showGameImporter) {
                 ImportDocumentPicker(
                     allowedContentTypes: FileImportHandler.gameContentTypes,
@@ -250,9 +268,7 @@ struct GameListView: View {
                     showGameImporter = false
                     switch result {
                     case .success(let urls):
-                        let importedGames = fileImporter.importURLs(urls, preferredDestination: .game)
-                        loadGames()
-                        autoDownloadCovers(for: importedGames)
+                        prepareGameImport(urls)
                     case .failure(let error):
                         if !FileImportHandler.isUserCancelledPickerError(error) {
                             fileImporter.presentImportResult(FileImportHandler.failedGamePickerMessage(errorDescription: error.localizedDescription))
@@ -260,21 +276,36 @@ struct GameListView: View {
                     }
                 }
             }
-            .fileImporter(
-                isPresented: $showCoverImporter,
-                allowedContentTypes: CoverStore.coverContentTypes,
-                allowsMultipleSelection: pendingCoverGameName == nil
-            ) { result in
-                switch result {
-                case .success(let urls):
-                    coverStore.importCoverURLs(urls, forGameNamed: pendingCoverGameName)
-                    pendingCoverGameName = nil
-                    loadGames()
-                case .failure(let error):
-                    coverStore.lastCoverMessage = "Cover import failed: \(error.localizedDescription)"
-                    coverStore.showCoverAlert = true
-                    pendingCoverGameName = nil
+            .sheet(isPresented: $showCoverImporter) {
+                ImportDocumentPicker(
+                    allowedContentTypes: CoverStore.coverContentTypes,
+                    allowsMultipleSelection: pendingCoverGameName == nil
+                ) { result in
+                    showCoverImporter = false
+                    switch result {
+                    case .success(let urls):
+                        coverStore.importCoverURLs(urls, forGameNamed: pendingCoverGameName)
+                        pendingCoverGameName = nil
+                        loadGames()
+                    case .failure(let error):
+                        if !FileImportHandler.isUserCancelledPickerError(error) {
+                            coverStore.lastCoverMessage = "Cover import failed: \(error.localizedDescription)"
+                            coverStore.showCoverAlert = true
+                        }
+                        pendingCoverGameName = nil
+                    }
                 }
+            }
+            .photosPicker(
+                isPresented: $showCoverPhotoPicker,
+                selection: $selectedCoverPhotoItem,
+                matching: .images
+            )
+            .onChange(of: selectedCoverPhotoItem) { _, photoItem in
+                guard let photoItem, let gameName = pendingCoverPhotoGameName else { return }
+                selectedCoverPhotoItem = nil
+                pendingCoverPhotoGameName = nil
+                importCoverPhoto(photoItem, forGameNamed: gameName)
             }
             .sheet(isPresented: $showPNACHImporter) {
                 ImportDocumentPicker(
@@ -701,10 +732,17 @@ struct GameListView: View {
             .disabled(coverStore.isDownloadingCovers)
 
             Button {
+                pendingCoverPhotoGameName = game.name
+                showCoverPhotoPicker = true
+            } label: {
+                Label(settings.localized("Choose from Photos"), systemImage: "photo.on.rectangle")
+            }
+
+            Button {
                 pendingCoverGameName = game.name
                 showCoverImporter = true
             } label: {
-                Label(settings.localized("Choose Cover"), systemImage: "photo")
+                Label(settings.localized("Choose from Files"), systemImage: "folder")
             }
 
             if game.coverURL != nil {
@@ -810,10 +848,54 @@ struct GameListView: View {
         }
     }
 
+    private func prepareGameImport(_ urls: [URL]) {
+        let existingFileNames = fileImporter.existingFileNames(for: urls, preferredDestination: .game)
+        guard !existingFileNames.isEmpty else {
+            importGames(urls, allowReplacingExistingFiles: false)
+            return
+        }
+
+        pendingGameImportURLs = urls
+        existingGameImportFileNames = existingFileNames
+        showGameReplacementAlert = true
+    }
+
+    private func importGames(_ urls: [URL], allowReplacingExistingFiles: Bool) {
+        let importedGames = fileImporter.importURLs(
+            urls,
+            preferredDestination: .game,
+            allowReplacingExistingFiles: allowReplacingExistingFiles
+        )
+        loadGames()
+        autoDownloadCovers(for: importedGames)
+    }
+
+    private func clearPendingGameImport() {
+        pendingGameImportURLs = []
+        existingGameImportFileNames = []
+    }
+
     private func downloadCover(for game: ISOEntry) {
         Task {
             _ = await coverStore.downloadMissingCovers(for: [game.coverInfo])
             loadGames()
+        }
+    }
+
+    private func importCoverPhoto(_ photoItem: PhotosPickerItem, forGameNamed gameName: String) {
+        Task {
+            do {
+                guard let data = try await photoItem.loadTransferable(type: Data.self) else {
+                    coverStore.lastCoverMessage = "The selected photo could not be loaded."
+                    coverStore.showCoverAlert = true
+                    return
+                }
+                coverStore.importCoverData(data, forGameNamed: gameName)
+                loadGames()
+            } catch {
+                coverStore.lastCoverMessage = "Cover import failed: \(error.localizedDescription)"
+                coverStore.showCoverAlert = true
+            }
         }
     }
 


### PR DESCRIPTION
This update improves the iOS import and setup experience.

BIOS imports now give clearer feedback when a copied BIOS-related file is not actually bootable. If a companion ROM or unsupported BIOS dump is imported, the app explains that it cannot be used to boot games instead of making the import look fully successful.

Game and BIOS imports now warn before replacing existing files with the same name. Cancelling keeps the current files untouched, while Replace imports the selected batch intentionally.

Cover download failures now give clearer guidance about what to check next. Local cover selection has also been improved: users can choose covers from Photos, and the Files picker now uses the same reliable picker flow as the game and BIOS import screens.

Validation:
- IPA tested successfully.
- Valid BIOS import still works.
- Invalid BIOS feedback checked.
- Same-name game and BIOS replacement Cancel/Replace flows checked.
- Cover download failure guidance checked.
- Local cover selection from Photos and Files checked.
- Picker cancellation checked.

Thanks to miilkai for testing the IPA and confirming the new flows work.