### PR TITLE
Achievements: preserve token on transient login failures

### DIFF
--- a/app/src/main/cpp/pcsx2/Achievements.cpp
+++ b/app/src/main/cpp/pcsx2/Achievements.cpp
@@ -1836,10 +1836,14 @@ void Achievements::ClientLoginWithTokenCallback(int result, const char* error_me
 	if (result != RC_OK)
 	{
 		ReportFmtError("Login failed: {}", error_message);
-		Host::RemoveBaseSettingValue("Achievements", "Token");
-		Host::RemoveBaseSettingValue("Achievements", "LoginTimestamp");
-		Host::CommitBaseSettingChanges();
-		Host::OnAchievementsLoginRequested(LoginRequestReason::TokenInvalid);
+
+		if (result == RC_INVALID_CREDENTIALS || result == RC_EXPIRED_TOKEN)
+		{
+			Host::RemoveBaseSettingValue("Achievements", "Token");
+			Host::RemoveBaseSettingValue("Achievements", "LoginTimestamp");
+			Host::CommitBaseSettingChanges();
+			Host::OnAchievementsLoginRequested(LoginRequestReason::TokenInvalid);
+		}
 		return;
 	}
 


### PR DESCRIPTION
Follow-up to #164.

The Android RetroAchievements host override from #164 restarts the live achievements client when the host is set or cleared so the change takes effect immediately. That exposed an existing issue in the token-login failure path: any failed token login currently clears the saved token and prompts for re-login, even when the failure is transient and does not indicate an invalid token.

On Android, those transient failures can happen during runtime host switching, but the same problem also applies more generally to temporary network loss or server availability issues. In those cases, clearing saved credentials is stricter than necessary and logs the user out unnecessarily.

This change keeps the current behavior for real authentication failures, but preserves the saved token for generic transport and availability failures.

## Summary

- preserve saved RetroAchievements credentials on generic token-login failure
- only clear the saved token for `RC_INVALID_CREDENTIALS` and `RC_EXPIRED_TOKEN`
- keep prompting for re-login when the server explicitly rejects the token