### PR TITLE
iOS: Add per-game settings and controller-aware V-Pad behavior

### DIFF
--- a/app/src/main/cpp/ARMSX2Bridge.h
+++ b/app/src/main/cpp/ARMSX2Bridge.h
@@ -116,12 +116,14 @@ typedef void (^ARMSX2RetroAchievementsCompletion)(BOOL success, NSString * _Nonn
               textureFiltering:(int)textureFiltering
             hardwareMipmapping:(BOOL)hardwareMipmapping
               blendingAccuracy:(int)blendingAccuracy
+               interlaceMode:(int)interlaceMode
                     eeCoreType:(int)eeCoreType
+                          mtvu:(BOOL)mtvu
                   enableCheats:(BOOL)enableCheats
                  enablePatches:(BOOL)enablePatches
               enableGameFixes:(BOOL)enableGameFixes
     enableGameDBHardwareFixes:(BOOL)enableGameDBHardwareFixes
-    NS_SWIFT_NAME(setGameSettings(forISO:enabled:upscaleMultiplier:aspectRatio:textureFiltering:hardwareMipmapping:blendingAccuracy:eeCoreType:enableCheats:enablePatches:enableGameFixes:enableGameDBHardwareFixes:));
+    NS_SWIFT_NAME(setGameSettings(forISO:enabled:upscaleMultiplier:aspectRatio:textureFiltering:hardwareMipmapping:blendingAccuracy:interlaceMode:eeCoreType:mtvu:enableCheats:enablePatches:enableGameFixes:enableGameDBHardwareFixes:));
 + (nonnull NSString *)clearCacheForISO:(nonnull NSString *)isoName NS_SWIFT_NAME(clearCache(forISO:));
 + (nonnull NSString *)deleteGameDataForISO:(nonnull NSString *)isoName NS_SWIFT_NAME(deleteGameData(forISO:));
 + (BOOL)deleteISO:(nonnull NSString *)isoName deleteGameData:(BOOL)deleteGameData NS_SWIFT_NAME(deleteISO(_:deleteGameData:));

--- a/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/app/src/main/cpp/ARMSX2Bridge.mm
@@ -1341,11 +1341,13 @@ static void ARMSX2ApplyLiveFloatSetting(const char* section, const char* key, fl
     const int globalTextureFiltering = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "filter", 2) : 2;
     const bool globalHardwareMipmapping = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore/GS", "hw_mipmap", true) : true;
     const int globalBlendingAccuracy = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "accurate_blending_unit", 1) : 1;
+    const int globalInterlaceMode = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "deinterlace_mode", 7) : 7;
     const bool globalEnableCheats = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore", "EnableCheats", false) : false;
     const bool globalEnablePatches = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore", "EnablePatches", true) : true;
     const bool globalEnableGameFixes = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore", "EnableGameFixes", true) : true;
     const bool globalEnableGameDBHardwareFixes = g_p44_settings_interface ? !g_p44_settings_interface->GetBoolValue("EmuCore/GS", "UserHacks", false) : true;
     const int globalEECoreType = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/CPU", "CoreType", 2) : 2;
+    const bool globalMTVU = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore/Speedhacks", "vuThread", false) : false;
     NSMutableDictionary<NSString*, id>* result = [@{
         @"enabled": @NO,
         @"path": @"",
@@ -1356,11 +1358,13 @@ static void ARMSX2ApplyLiveFloatSetting(const char* section, const char* key, fl
         @"textureFiltering": @(globalTextureFiltering),
         @"hardwareMipmapping": @(globalHardwareMipmapping),
         @"blendingAccuracy": @(globalBlendingAccuracy),
+        @"interlaceMode": @(globalInterlaceMode),
         @"enableCheats": @(globalEnableCheats),
         @"enablePatches": @(globalEnablePatches),
         @"enableGameFixes": @(globalEnableGameFixes),
         @"enableGameDBHardwareFixes": @(globalEnableGameDBHardwareFixes),
         @"eeCoreType": @(globalEECoreType),
+        @"mtvu": @(globalMTVU),
     } mutableCopy];
 
     if (!ARMSX2PopulateGameListEntryForISO(isoName, &entry, &resolvedPath) || entry.crc == 0) {
@@ -1384,12 +1388,14 @@ static void ARMSX2ApplyLiveFloatSetting(const char* section, const char* key, fl
         si.ContainsValue("EmuCore/GS", "filter") ||
         si.ContainsValue("EmuCore/GS", "hw_mipmap") ||
         si.ContainsValue("EmuCore/GS", "accurate_blending_unit") ||
+        si.ContainsValue("EmuCore/GS", "deinterlace_mode") ||
         si.ContainsValue("EmuCore", "EnableCheats") ||
         si.ContainsValue("EmuCore", "EnablePatches") ||
         si.ContainsValue("EmuCore", "EnableGameFixes") ||
         si.ContainsValue("EmuCore/GS", "UserHacks") ||
         si.ContainsValue("EmuCore/CPU", "CoreType") ||
-        si.ContainsValue("EmuCore/CPU", "UseArm64Dynarec");
+        si.ContainsValue("EmuCore/CPU", "UseArm64Dynarec") ||
+        si.ContainsValue("EmuCore/Speedhacks", "vuThread");
 
     result[@"enabled"] = @(hasKnownOverride);
     NSString* currentAspect = [result[@"aspectRatio"] isKindOfClass:NSString.class] ? result[@"aspectRatio"] : @"Auto 4:3/3:2";
@@ -1398,11 +1404,13 @@ static void ARMSX2ApplyLiveFloatSetting(const char* section, const char* key, fl
     result[@"textureFiltering"] = @(si.GetIntValue("EmuCore/GS", "filter", [result[@"textureFiltering"] intValue]));
     result[@"hardwareMipmapping"] = @(si.GetBoolValue("EmuCore/GS", "hw_mipmap", [result[@"hardwareMipmapping"] boolValue]));
     result[@"blendingAccuracy"] = @(si.GetIntValue("EmuCore/GS", "accurate_blending_unit", [result[@"blendingAccuracy"] intValue]));
+    result[@"interlaceMode"] = @(si.GetIntValue("EmuCore/GS", "deinterlace_mode", [result[@"interlaceMode"] intValue]));
     result[@"enableCheats"] = @(si.GetBoolValue("EmuCore", "EnableCheats", [result[@"enableCheats"] boolValue]));
     result[@"enablePatches"] = @(si.GetBoolValue("EmuCore", "EnablePatches", [result[@"enablePatches"] boolValue]));
     result[@"enableGameFixes"] = @(si.GetBoolValue("EmuCore", "EnableGameFixes", [result[@"enableGameFixes"] boolValue]));
     result[@"enableGameDBHardwareFixes"] = @(!si.GetBoolValue("EmuCore/GS", "UserHacks", ![result[@"enableGameDBHardwareFixes"] boolValue]));
     result[@"eeCoreType"] = @(si.GetIntValue("EmuCore/CPU", "CoreType", [result[@"eeCoreType"] intValue]));
+    result[@"mtvu"] = @(si.GetBoolValue("EmuCore/Speedhacks", "vuThread", [result[@"mtvu"] boolValue]));
     return result;
 }
 
@@ -1413,7 +1421,9 @@ static void ARMSX2ApplyLiveFloatSetting(const char* section, const char* key, fl
               textureFiltering:(int)textureFiltering
             hardwareMipmapping:(BOOL)hardwareMipmapping
               blendingAccuracy:(int)blendingAccuracy
+               interlaceMode:(int)interlaceMode
                     eeCoreType:(int)eeCoreType
+                          mtvu:(BOOL)mtvu
                   enableCheats:(BOOL)enableCheats
                  enablePatches:(BOOL)enablePatches
               enableGameFixes:(BOOL)enableGameFixes
@@ -1438,12 +1448,14 @@ static void ARMSX2ApplyLiveFloatSetting(const char* section, const char* key, fl
         si.SetIntValue("EmuCore/GS", "filter", textureFiltering);
         si.SetBoolValue("EmuCore/GS", "hw_mipmap", hardwareMipmapping);
         si.SetIntValue("EmuCore/GS", "accurate_blending_unit", blendingAccuracy);
+        si.SetIntValue("EmuCore/GS", "deinterlace_mode", interlaceMode);
         si.SetBoolValue("EmuCore", "EnableCheats", enableCheats);
         si.SetBoolValue("EmuCore", "EnablePatches", enablePatches);
         si.SetBoolValue("EmuCore", "EnableGameFixes", enableGameFixes);
         si.SetBoolValue("EmuCore/GS", "UserHacks", !enableGameDBHardwareFixes);
         si.SetIntValue("EmuCore/CPU", "CoreType", eeCoreType);
         si.SetBoolValue("EmuCore/CPU", "UseArm64Dynarec", eeCoreType == 2);
+        si.SetBoolValue("EmuCore/Speedhacks", "vuThread", mtvu);
     } else {
         si.DeleteValue("ARMSX2iOS/PerGame", "Enabled");
         si.DeleteValue("EmuCore/GS", "upscale_multiplier");
@@ -1451,12 +1463,14 @@ static void ARMSX2ApplyLiveFloatSetting(const char* section, const char* key, fl
         si.DeleteValue("EmuCore/GS", "filter");
         si.DeleteValue("EmuCore/GS", "hw_mipmap");
         si.DeleteValue("EmuCore/GS", "accurate_blending_unit");
+        si.DeleteValue("EmuCore/GS", "deinterlace_mode");
         si.DeleteValue("EmuCore", "EnableCheats");
         si.DeleteValue("EmuCore", "EnablePatches");
         si.DeleteValue("EmuCore", "EnableGameFixes");
         si.DeleteValue("EmuCore/GS", "UserHacks");
         si.DeleteValue("EmuCore/CPU", "CoreType");
         si.DeleteValue("EmuCore/CPU", "UseArm64Dynarec");
+        si.DeleteValue("EmuCore/Speedhacks", "vuThread");
         si.RemoveEmptySections();
     }
 

--- a/app/src/main/swift/Models/SettingsStore.swift
+++ b/app/src/main/swift/Models/SettingsStore.swift
@@ -250,6 +250,12 @@ final class SettingsStore: @unchecked Sendable {
     var virtualPadSkin: VirtualPadSkin {
         didSet { ARMSX2Bridge.setINIInt("ARMSX2iOS/UI", key: "VirtualPadSkin", value: Int32(virtualPadSkin.rawValue)) }
     }
+    var autoHideVirtualPadWhenControllerConnected: Bool {
+        didSet {
+            guard !suppressINIWrites else { return }
+            ARMSX2Bridge.setINIBool("ARMSX2iOS/UI", key: "AutoHideVirtualPadWhenControllerConnected", value: autoHideVirtualPadWhenControllerConnected)
+        }
+    }
     var autoFullscreen: Bool {
         didSet {
             guard !suppressINIWrites else { return }
@@ -439,6 +445,7 @@ final class SettingsStore: @unchecked Sendable {
         padOpacity = ARMSX2Bridge.getINIFloat("ARMSX2iOS/UI", key: "PadOpacity", defaultValue: 0.6)
         hapticFeedback = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "HapticFeedback", defaultValue: true)
         virtualPadSkin = VirtualPadSkin(rawValue: Int(ARMSX2Bridge.getINIInt("ARMSX2iOS/UI", key: "VirtualPadSkin", defaultValue: 0))) ?? .armsx2Refresh
+        autoHideVirtualPadWhenControllerConnected = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "AutoHideVirtualPadWhenControllerConnected", defaultValue: true)
         autoFullscreen = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "AutoFullscreen", defaultValue: false)
         hideMenuButton = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "HideMenuButton", defaultValue: false)
         analogStickScale = Self.clampedAnalogStickScale(ARMSX2Bridge.getINIFloat("ARMSX2iOS/UI", key: "AnalogStickScale", defaultValue: 1.0))
@@ -532,6 +539,7 @@ final class SettingsStore: @unchecked Sendable {
         padOpacity = ARMSX2Bridge.getINIFloat("ARMSX2iOS/UI", key: "PadOpacity", defaultValue: 0.6)
         hapticFeedback = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "HapticFeedback", defaultValue: true)
         virtualPadSkin = VirtualPadSkin(rawValue: Int(ARMSX2Bridge.getINIInt("ARMSX2iOS/UI", key: "VirtualPadSkin", defaultValue: 0))) ?? .armsx2Refresh
+        autoHideVirtualPadWhenControllerConnected = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "AutoHideVirtualPadWhenControllerConnected", defaultValue: true)
         autoFullscreen = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "AutoFullscreen", defaultValue: false)
         hideMenuButton = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "HideMenuButton", defaultValue: false)
         analogStickScale = Self.clampedAnalogStickScale(ARMSX2Bridge.getINIFloat("ARMSX2iOS/UI", key: "AnalogStickScale", defaultValue: 1.0))

--- a/app/src/main/swift/Views/GameListView.swift
+++ b/app/src/main/swift/Views/GameListView.swift
@@ -1194,6 +1194,22 @@ struct PerGameSettingsPanel: View {
     @Environment(\.dismiss) private var dismiss
     @State private var settings = SettingsStore.shared
 
+    private struct PickerOption: Identifiable {
+        let id: Int
+        let title: String
+    }
+
+    private static let deinterlaceOptions = [
+        PickerOption(id: 0, title: "None"),
+        PickerOption(id: 1, title: "Weave (TFF)"),
+        PickerOption(id: 2, title: "Weave (BFF)"),
+        PickerOption(id: 3, title: "Bob (TFF)"),
+        PickerOption(id: 4, title: "Bob (BFF)"),
+        PickerOption(id: 5, title: "Blend (TFF)"),
+        PickerOption(id: 6, title: "Blend (BFF)"),
+        PickerOption(id: 7, title: "Adaptive (Default)")
+    ]
+
     let game: ISOEntry
     let onDone: (() -> Void)?
 
@@ -1203,7 +1219,9 @@ struct PerGameSettingsPanel: View {
     @State private var textureFiltering: Int
     @State private var hardwareMipmapping: Bool
     @State private var blendingAccuracy: Int
+    @State private var interlaceMode: Int
     @State private var eeCoreType: Int
+    @State private var mtvu: Bool
     @State private var enableCheats: Bool
     @State private var enablePatches: Bool
     @State private var enableGameFixes: Bool
@@ -1220,7 +1238,9 @@ struct PerGameSettingsPanel: View {
         _textureFiltering = State(initialValue: Self.intValue(info["textureFiltering"], defaultValue: 2))
         _hardwareMipmapping = State(initialValue: Self.boolValue(info["hardwareMipmapping"], defaultValue: true))
         _blendingAccuracy = State(initialValue: Self.intValue(info["blendingAccuracy"], defaultValue: 1))
+        _interlaceMode = State(initialValue: Self.intValue(info["interlaceMode"], defaultValue: 7))
         _eeCoreType = State(initialValue: Self.intValue(info["eeCoreType"], defaultValue: 2))
+        _mtvu = State(initialValue: Self.boolValue(info["mtvu"], defaultValue: false))
         _enableCheats = State(initialValue: Self.boolValue(info["enableCheats"], defaultValue: false))
         _enablePatches = State(initialValue: Self.boolValue(info["enablePatches"], defaultValue: true))
         _enableGameFixes = State(initialValue: Self.boolValue(info["enableGameFixes"], defaultValue: true))
@@ -1245,6 +1265,12 @@ struct PerGameSettingsPanel: View {
                     .disabled(!enabled)
 
                     Text(settings.localized("Interpreter is slower, but can help isolate EE JIT crashes for specific games. Reset/relaunch after changing it."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Toggle("MTVU", isOn: $mtvu)
+                        .disabled(!enabled)
+                    Text(settings.localized("MTVU can improve performance in some games, but may cause compatibility issues. Reset/relaunch after changing it."))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -1291,6 +1317,13 @@ struct PerGameSettingsPanel: View {
                         Text("High").tag(3)
                         Text("Full").tag(4)
                         Text("Ultra").tag(5)
+                    }
+                    .disabled(!enabled)
+
+                    Picker(settings.localized("Deinterlace"), selection: $interlaceMode) {
+                        ForEach(Self.deinterlaceOptions) { option in
+                            Text(settings.localized(option.title)).tag(option.id)
+                        }
                     }
                     .disabled(!enabled)
                 }
@@ -1346,7 +1379,9 @@ struct PerGameSettingsPanel: View {
             textureFiltering: Int32(textureFiltering),
             hardwareMipmapping: hardwareMipmapping,
             blendingAccuracy: Int32(blendingAccuracy),
+            interlaceMode: Int32(interlaceMode),
             eeCoreType: Int32(eeCoreType),
+            mtvu: mtvu,
             enableCheats: enableCheats,
             enablePatches: enablePatches,
             enableGameFixes: enableGameFixes,

--- a/app/src/main/swift/Views/GameScreenView.swift
+++ b/app/src/main/swift/Views/GameScreenView.swift
@@ -3,6 +3,7 @@
 
 import SwiftUI
 import UIKit
+import GameController
 
 private let runtimeMenuStateChangedNotification = Notification.Name("ARMSX2iOSRuntimeMenuStateChanged")
 
@@ -29,7 +30,8 @@ struct GameScreenView: View {
     @State private var appState = AppState.shared
     @State private var settings = SettingsStore.shared
     @State private var fileImporter = FileImportHandler.shared
-    @State private var padVisible = true
+    @State private var userVirtualPadVisible = true
+    @State private var externalControllerConnected = false
     @State private var fullScreen = false
     @State private var menuButtonHidden = false
     @State private var vmMenuAvailable = false
@@ -62,7 +64,7 @@ struct GameScreenView: View {
                 // so that pad coordinates match the layout editor exactly.
                 ZStack {
                     MetalGameView()
-                    if padVisible {
+                    if effectiveVirtualPadVisible {
                         VirtualControllerView(isLandscape: true)
                     }
                     menuOverlay(isLandscape: true)
@@ -77,7 +79,7 @@ struct GameScreenView: View {
                     VStack(spacing: 0) {
                         MetalGameView()
                             .frame(height: geo.size.height / 2)
-                        if padVisible {
+                        if effectiveVirtualPadVisible {
                             VirtualControllerView()
                                 .frame(height: geo.size.height / 2)
                         } else {
@@ -149,6 +151,7 @@ struct GameScreenView: View {
         .onAppear {
             enterGameplaySystemChromeMode()
             applyGameScreenPreferences()
+            refreshExternalControllerConnectionState()
             refreshRuntimeMenuState()
         }
         .onDisappear {
@@ -167,6 +170,12 @@ struct GameScreenView: View {
         .onChange(of: showPadLayoutEditor) { _, _ in updateRuntimeOverlayPause() }
         .onReceive(NotificationCenter.default.publisher(for: runtimeMenuStateChangedNotification)) { _ in
             refreshRuntimeMenuState()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .GCControllerDidConnect)) { _ in
+            refreshExternalControllerConnectionState()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .GCControllerDidDisconnect)) { _ in
+            refreshExternalControllerConnectionState()
         }
         .onReceive(Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()) { _ in
             refreshRuntimeMenuState()
@@ -214,8 +223,11 @@ struct GameScreenView: View {
             )) {
                 Label(settings.localized("OSD"), systemImage: "speedometer")
             }
-            Toggle(isOn: $padVisible) {
+            Toggle(isOn: $userVirtualPadVisible) {
                 Label(settings.localized("Virtual Pad"), systemImage: "gamecontroller")
+            }
+            if virtualPadHiddenByController {
+                Text(settings.localized("Hidden while controller is connected"))
             }
             Toggle(isOn: $fullScreen) {
                 Label(settings.localized("Full Screen"), systemImage: "arrow.up.left.and.arrow.down.right")
@@ -361,6 +373,21 @@ struct GameScreenView: View {
         menuButtonHidden = false
         settings.hideMenuButton = false
         presentSaveStateStatus(settings.localized("Menu button shown"))
+    }
+
+    private var effectiveVirtualPadVisible: Bool {
+        userVirtualPadVisible && (!settings.autoHideVirtualPadWhenControllerConnected || !externalControllerConnected)
+    }
+
+    private var virtualPadHiddenByController: Bool {
+        userVirtualPadVisible && settings.autoHideVirtualPadWhenControllerConnected && externalControllerConnected
+    }
+
+    private func refreshExternalControllerConnectionState() {
+        let connected = !GCController.controllers().isEmpty
+        if externalControllerConnected != connected {
+            externalControllerConnected = connected
+        }
     }
 
     @ViewBuilder

--- a/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift
+++ b/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift
@@ -32,6 +32,11 @@ struct VirtualPadSettingsView: View {
             }
 
             Section(settings.localized("Gameplay")) {
+                Toggle(settings.localized("Hide Virtual Pad When Controller Is Connected"), isOn: $settings.autoHideVirtualPadWhenControllerConnected)
+                Text(settings.localized("Automatically hides the on-screen controls while an external controller is connected."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
                 Toggle(settings.localized("Auto Full Screen"), isOn: $settings.autoFullscreen)
                 Toggle(settings.localized("Hide Menu Button"), isOn: $settings.hideMenuButton)
 


### PR DESCRIPTION
## Summary

Adds two user-requested iOS improvements:

- MTVU and deinterlacing are now available in Per-Game Settings.
- The Virtual Pad can now automatically hide when an external controller is connected.

This keeps the changes focused on iOS UI/settings behavior and uses the existing settings paths instead of changing emulator-core behavior.

## What changed

### Per-game MTVU and deinterlacing

MTVU can now be enabled or disabled per game from iOS Per-Game Settings.

Deinterlacing can now also be configured per game using the existing deinterlacing modes.

Both options use the existing per-game override flow:

- When **Use Per-Game Overrides** is enabled, the game can use its own MTVU and deinterlacing values.
- When **Use Per-Game Overrides** is disabled, the game falls back to the global settings.
- The changes apply after resetting or relaunching the game, like the existing per-game options.

### Controller-aware Virtual Pad behavior

Added a new Virtual Pad setting:

**Hide Virtual Pad When Controller Is Connected**

This is enabled by default. When an external controller is connected, the on-screen Virtual Pad hides automatically. When the controller disconnects, the Virtual Pad returns only if the user’s normal Virtual Pad toggle is still enabled.

This does not overwrite the user’s preference. If the user manually turns the Virtual Pad off, connecting or disconnecting a controller will not force it back on.

The runtime menu also shows a small note when the Virtual Pad is hidden because a controller is connected.

## What was intentionally not changed

- No global MTVU or deinterlacing defaults were changed.
- No emulator-core behavior was changed.
- No renderer behavior was changed.
- No GameDB or compatibility policy was changed.
- No controller mapping or rumble behavior was changed.
- No workflow files are included in this PR.

## Validation

IPA tested successfully by @xXTheCrimsonFuckerXx.


