### PR TITLE
iOS: Improve settings UX and graphics compatibility controls

### DIFF
--- a/app/src/main/cpp/ARMSX2Bridge.h
+++ b/app/src/main/cpp/ARMSX2Bridge.h
@@ -109,6 +109,7 @@ typedef void (^ARMSX2RetroAchievementsCompletion)(BOOL success, NSString * _Nonn
 + (nonnull NSArray<NSString *> *)availableISOs;
 + (nonnull NSDictionary<NSString *, NSString *> *)gameMetadataForISO:(nonnull NSString *)isoName;
 + (nonnull NSDictionary<NSString *, id> *)gameSettingsForISO:(nonnull NSString *)isoName NS_SWIFT_NAME(gameSettings(forISO:));
++ (nullable NSDictionary<NSString *, id> *)gameSettingsForCurrentGame;
 + (void)setGameSettingsForISO:(nonnull NSString *)isoName
                        enabled:(BOOL)enabled
              upscaleMultiplier:(float)upscaleMultiplier
@@ -117,13 +118,61 @@ typedef void (^ARMSX2RetroAchievementsCompletion)(BOOL success, NSString * _Nonn
             hardwareMipmapping:(BOOL)hardwareMipmapping
               blendingAccuracy:(int)blendingAccuracy
                interlaceMode:(int)interlaceMode
+        trilinearFiltering:(int)trilinearFiltering
+          halfPixelOffset:(int)halfPixelOffset
+              roundSprite:(int)roundSprite
+      alignSpriteOverride:(BOOL)alignSpriteOverride
+              alignSprite:(BOOL)alignSprite
+      mergeSpriteOverride:(BOOL)mergeSpriteOverride
+              mergeSprite:(BOOL)mergeSprite
+    wildArmsOffsetOverride:(BOOL)wildArmsOffsetOverride
+           wildArmsOffset:(BOOL)wildArmsOffset
+    textureOffsetXOverride:(BOOL)textureOffsetXOverride
+           textureOffsetX:(int)textureOffsetX
+    textureOffsetYOverride:(BOOL)textureOffsetYOverride
+           textureOffsetY:(int)textureOffsetY
+     skipDrawStartOverride:(BOOL)skipDrawStartOverride
+            skipDrawStart:(int)skipDrawStart
+       skipDrawEndOverride:(BOOL)skipDrawEndOverride
+              skipDrawEnd:(int)skipDrawEnd
                     eeCoreType:(int)eeCoreType
                           mtvu:(BOOL)mtvu
                   enableCheats:(BOOL)enableCheats
                  enablePatches:(BOOL)enablePatches
               enableGameFixes:(BOOL)enableGameFixes
     enableGameDBHardwareFixes:(BOOL)enableGameDBHardwareFixes
-    NS_SWIFT_NAME(setGameSettings(forISO:enabled:upscaleMultiplier:aspectRatio:textureFiltering:hardwareMipmapping:blendingAccuracy:interlaceMode:eeCoreType:mtvu:enableCheats:enablePatches:enableGameFixes:enableGameDBHardwareFixes:));
+    NS_SWIFT_NAME(setGameSettings(forISO:enabled:upscaleMultiplier:aspectRatio:textureFiltering:hardwareMipmapping:blendingAccuracy:interlaceMode:trilinearFiltering:halfPixelOffset:roundSprite:alignSpriteOverride:alignSprite:mergeSpriteOverride:mergeSprite:wildArmsOffsetOverride:wildArmsOffset:textureOffsetXOverride:textureOffsetX:textureOffsetYOverride:textureOffsetY:skipDrawStartOverride:skipDrawStart:skipDrawEndOverride:skipDrawEnd:eeCoreType:mtvu:enableCheats:enablePatches:enableGameFixes:enableGameDBHardwareFixes:));
++ (void)setGameSettingsForCurrentGameWithEnabled:(BOOL)enabled
+                               upscaleMultiplier:(float)upscaleMultiplier
+                                     aspectRatio:(nonnull NSString *)aspectRatio
+                                textureFiltering:(int)textureFiltering
+                              hardwareMipmapping:(BOOL)hardwareMipmapping
+                                blendingAccuracy:(int)blendingAccuracy
+                                   interlaceMode:(int)interlaceMode
+                              trilinearFiltering:(int)trilinearFiltering
+                                 halfPixelOffset:(int)halfPixelOffset
+                                     roundSprite:(int)roundSprite
+                             alignSpriteOverride:(BOOL)alignSpriteOverride
+                                     alignSprite:(BOOL)alignSprite
+                             mergeSpriteOverride:(BOOL)mergeSpriteOverride
+                                     mergeSprite:(BOOL)mergeSprite
+                           wildArmsOffsetOverride:(BOOL)wildArmsOffsetOverride
+                                  wildArmsOffset:(BOOL)wildArmsOffset
+                           textureOffsetXOverride:(BOOL)textureOffsetXOverride
+                                  textureOffsetX:(int)textureOffsetX
+                           textureOffsetYOverride:(BOOL)textureOffsetYOverride
+                                  textureOffsetY:(int)textureOffsetY
+                            skipDrawStartOverride:(BOOL)skipDrawStartOverride
+                                   skipDrawStart:(int)skipDrawStart
+                              skipDrawEndOverride:(BOOL)skipDrawEndOverride
+                                     skipDrawEnd:(int)skipDrawEnd
+                                      eeCoreType:(int)eeCoreType
+                                            mtvu:(BOOL)mtvu
+                                    enableCheats:(BOOL)enableCheats
+                                   enablePatches:(BOOL)enablePatches
+                                 enableGameFixes:(BOOL)enableGameFixes
+                      enableGameDBHardwareFixes:(BOOL)enableGameDBHardwareFixes
+    NS_SWIFT_NAME(setGameSettingsForCurrentGame(enabled:upscaleMultiplier:aspectRatio:textureFiltering:hardwareMipmapping:blendingAccuracy:interlaceMode:trilinearFiltering:halfPixelOffset:roundSprite:alignSpriteOverride:alignSprite:mergeSpriteOverride:mergeSprite:wildArmsOffsetOverride:wildArmsOffset:textureOffsetXOverride:textureOffsetX:textureOffsetYOverride:textureOffsetY:skipDrawStartOverride:skipDrawStart:skipDrawEndOverride:skipDrawEnd:eeCoreType:mtvu:enableCheats:enablePatches:enableGameFixes:enableGameDBHardwareFixes:));
 + (nonnull NSString *)clearCacheForISO:(nonnull NSString *)isoName NS_SWIFT_NAME(clearCache(forISO:));
 + (nonnull NSString *)deleteGameDataForISO:(nonnull NSString *)isoName NS_SWIFT_NAME(deleteGameData(forISO:));
 + (BOOL)deleteISO:(nonnull NSString *)isoName deleteGameData:(BOOL)deleteGameData NS_SWIFT_NAME(deleteISO(_:deleteGameData:));

--- a/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/app/src/main/cpp/ARMSX2Bridge.mm
@@ -34,6 +34,7 @@ extern "C" void ARMSX2_SetSDLFullscreen(bool enabled);
 #include <cstring>
 #include <functional>
 #include <future>
+#include <limits>
 #include <optional>
 #include <string_view>
 #include <vector>
@@ -65,6 +66,13 @@ static NSString* const ARMSX2CompatibilityProfileMoves = @"moves";
 static NSString* const ARMSX2CompatibilityProfileIntegerALU = @"integeralu";
 static NSString* const ARMSX2CompatibilityProfileBranches = @"branches";
 static NSString* const ARMSX2CompatibilityProfileCustom = @"custom";
+static constexpr int ARMSX2UseGlobalIntSentinel = -1;
+static constexpr int ARMSX2TriFilterUseGlobalSentinel = std::numeric_limits<int>::min();
+
+static int ARMSX2ClampInt(int value, int minValue, int maxValue)
+{
+    return std::min(std::max(value, minValue), maxValue);
+}
 
 static NSString* ARMSX2NSStringFromStdString(const std::string& value);
 
@@ -974,6 +982,288 @@ static void ARMSX2ApplyLiveFloatSetting(const char* section, const char* key, fl
     }
 }
 
+// Builds the per-game settings dictionary seeded with the current global values.
+static NSMutableDictionary<NSString*, id>* ARMSX2BuildGlobalGameSettingsResult()
+{
+    const float globalUpscale = g_p44_settings_interface ? g_p44_settings_interface->GetFloatValue("EmuCore/GS", "upscale_multiplier", 1.0f) : 1.0f;
+    const std::string globalAspect = g_p44_settings_interface ? g_p44_settings_interface->GetStringValue("EmuCore/GS", "AspectRatio", "Auto 4:3/3:2") : std::string("Auto 4:3/3:2");
+    const int globalTextureFiltering = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "filter", 2) : 2;
+    const bool globalHardwareMipmapping = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore/GS", "hw_mipmap", true) : true;
+    const int globalBlendingAccuracy = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "accurate_blending_unit", 1) : 1;
+    const int globalInterlaceMode = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "deinterlace_mode", 7) : 7;
+    const int globalTrilinearFiltering = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "TriFilter", -1) : -1;
+    const int globalHalfPixelOffset = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "UserHacks_HalfPixelOffset", 0) : 0;
+    const int globalRoundSprite = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "UserHacks_round_sprite_offset", 0) : 0;
+    const bool globalAlignSprite = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore/GS", "UserHacks_align_sprite_X", false) : false;
+    const bool globalMergeSprite = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore/GS", "UserHacks_merge_pp_sprite", false) : false;
+    const bool globalWildArmsOffset = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore/GS", "UserHacks_ForceEvenSpritePosition", false) : false;
+    const int globalTextureOffsetX = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "UserHacks_TCOffsetX", 0) : 0;
+    const int globalTextureOffsetY = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "UserHacks_TCOffsetY", 0) : 0;
+    const int globalSkipDrawStart = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "UserHacks_SkipDraw_Start", 0) : 0;
+    const int globalSkipDrawEnd = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "UserHacks_SkipDraw_End", 0) : 0;
+    const bool globalEnableCheats = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore", "EnableCheats", false) : false;
+    const bool globalEnablePatches = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore", "EnablePatches", true) : true;
+    const bool globalEnableGameFixes = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore", "EnableGameFixes", true) : true;
+    const bool globalEnableGameDBHardwareFixes = g_p44_settings_interface ? !g_p44_settings_interface->GetBoolValue("EmuCore/GS", "UserHacks", false) : true;
+    const int globalEECoreType = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/CPU", "CoreType", 2) : 2;
+    const bool globalMTVU = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore/Speedhacks", "vuThread", false) : false;
+    return [@{
+        @"enabled": @NO,
+        @"path": @"",
+        @"serial": @"",
+        @"crc": @"",
+        @"upscaleMultiplier": @(globalUpscale),
+        @"aspectRatio": ARMSX2NSStringFromStdString(globalAspect),
+        @"textureFiltering": @(globalTextureFiltering),
+        @"hardwareMipmapping": @(globalHardwareMipmapping),
+        @"blendingAccuracy": @(globalBlendingAccuracy),
+        @"interlaceMode": @(globalInterlaceMode),
+        @"trilinearFiltering": @(globalTrilinearFiltering),
+        @"hasTrilinearFilteringOverride": @NO,
+        @"halfPixelOffset": @(globalHalfPixelOffset),
+        @"hasHalfPixelOffsetOverride": @NO,
+        @"roundSprite": @(globalRoundSprite),
+        @"hasRoundSpriteOverride": @NO,
+        @"alignSprite": @(globalAlignSprite),
+        @"hasAlignSpriteOverride": @NO,
+        @"mergeSprite": @(globalMergeSprite),
+        @"hasMergeSpriteOverride": @NO,
+        @"wildArmsOffset": @(globalWildArmsOffset),
+        @"hasWildArmsOffsetOverride": @NO,
+        @"textureOffsetX": @(ARMSX2ClampInt(globalTextureOffsetX, -4096, 4096)),
+        @"hasTextureOffsetXOverride": @NO,
+        @"textureOffsetY": @(ARMSX2ClampInt(globalTextureOffsetY, -4096, 4096)),
+        @"hasTextureOffsetYOverride": @NO,
+        @"skipDrawStart": @(ARMSX2ClampInt(globalSkipDrawStart, 0, 5000)),
+        @"hasSkipDrawStartOverride": @NO,
+        @"skipDrawEnd": @(ARMSX2ClampInt(globalSkipDrawEnd, 0, 5000)),
+        @"hasSkipDrawEndOverride": @NO,
+        @"enableCheats": @(globalEnableCheats),
+        @"enablePatches": @(globalEnablePatches),
+        @"enableGameFixes": @(globalEnableGameFixes),
+        @"enableGameDBHardwareFixes": @(globalEnableGameDBHardwareFixes),
+        @"eeCoreType": @(globalEECoreType),
+        @"mtvu": @(globalMTVU),
+    } mutableCopy];
+}
+
+// Overlays per-game INI overrides for the given serial/crc onto a globals-seeded result.
+// Sourcing serial/crc from the caller avoids re-scanning the disc image (which is unsafe
+// while the VM is actively reading the same disc).
+static void ARMSX2ApplyPerGameSettingsOverrides(NSMutableDictionary<NSString*, id>* result, const std::string& serial, u32 crc)
+{
+    const std::string settingsPath = VMManager::GetGameSettingsPath(serial, crc);
+    result[@"path"] = ARMSX2NSStringFromStdString(settingsPath);
+    result[@"serial"] = ARMSX2NSStringFromStdString(serial);
+    result[@"crc"] = [NSString stringWithFormat:@"%08X", crc];
+
+    INISettingsInterface si(settingsPath);
+    if (!si.Load())
+        return;
+
+    const bool hasKnownOverride =
+        si.GetBoolValue("ARMSX2iOS/PerGame", "Enabled", false) ||
+        si.ContainsValue("EmuCore/GS", "upscale_multiplier") ||
+        si.ContainsValue("EmuCore/GS", "AspectRatio") ||
+        si.ContainsValue("EmuCore/GS", "filter") ||
+        si.ContainsValue("EmuCore/GS", "hw_mipmap") ||
+        si.ContainsValue("EmuCore/GS", "accurate_blending_unit") ||
+        si.ContainsValue("EmuCore/GS", "deinterlace_mode") ||
+        si.ContainsValue("EmuCore/GS", "TriFilter") ||
+        si.ContainsValue("EmuCore/GS", "UserHacks_HalfPixelOffset") ||
+        si.ContainsValue("EmuCore/GS", "UserHacks_round_sprite_offset") ||
+        si.ContainsValue("EmuCore/GS", "UserHacks_align_sprite_X") ||
+        si.ContainsValue("EmuCore/GS", "UserHacks_merge_pp_sprite") ||
+        si.ContainsValue("EmuCore/GS", "UserHacks_ForceEvenSpritePosition") ||
+        si.ContainsValue("EmuCore/GS", "UserHacks_TCOffsetX") ||
+        si.ContainsValue("EmuCore/GS", "UserHacks_TCOffsetY") ||
+        si.ContainsValue("EmuCore/GS", "UserHacks_SkipDraw_Start") ||
+        si.ContainsValue("EmuCore/GS", "UserHacks_SkipDraw_End") ||
+        si.ContainsValue("EmuCore", "EnableCheats") ||
+        si.ContainsValue("EmuCore", "EnablePatches") ||
+        si.ContainsValue("EmuCore", "EnableGameFixes") ||
+        si.ContainsValue("EmuCore/GS", "UserHacks") ||
+        si.ContainsValue("EmuCore/CPU", "CoreType") ||
+        si.ContainsValue("EmuCore/CPU", "UseArm64Dynarec") ||
+        si.ContainsValue("EmuCore/Speedhacks", "vuThread");
+
+    result[@"enabled"] = @(hasKnownOverride);
+    NSString* currentAspect = [result[@"aspectRatio"] isKindOfClass:NSString.class] ? result[@"aspectRatio"] : @"Auto 4:3/3:2";
+    result[@"upscaleMultiplier"] = @(si.GetFloatValue("EmuCore/GS", "upscale_multiplier", [result[@"upscaleMultiplier"] floatValue]));
+    result[@"aspectRatio"] = ARMSX2NSStringFromStdString(si.GetStringValue("EmuCore/GS", "AspectRatio", currentAspect.UTF8String));
+    result[@"textureFiltering"] = @(si.GetIntValue("EmuCore/GS", "filter", [result[@"textureFiltering"] intValue]));
+    result[@"hardwareMipmapping"] = @(si.GetBoolValue("EmuCore/GS", "hw_mipmap", [result[@"hardwareMipmapping"] boolValue]));
+    result[@"blendingAccuracy"] = @(si.GetIntValue("EmuCore/GS", "accurate_blending_unit", [result[@"blendingAccuracy"] intValue]));
+    result[@"interlaceMode"] = @(si.GetIntValue("EmuCore/GS", "deinterlace_mode", [result[@"interlaceMode"] intValue]));
+    result[@"hasTrilinearFilteringOverride"] = @(si.ContainsValue("EmuCore/GS", "TriFilter"));
+    result[@"trilinearFiltering"] = @(ARMSX2ClampInt(si.GetIntValue("EmuCore/GS", "TriFilter", [result[@"trilinearFiltering"] intValue]), -1, 2));
+    result[@"hasHalfPixelOffsetOverride"] = @(si.ContainsValue("EmuCore/GS", "UserHacks_HalfPixelOffset"));
+    result[@"halfPixelOffset"] = @(ARMSX2ClampInt(si.GetIntValue("EmuCore/GS", "UserHacks_HalfPixelOffset", [result[@"halfPixelOffset"] intValue]), 0, 5));
+    result[@"hasRoundSpriteOverride"] = @(si.ContainsValue("EmuCore/GS", "UserHacks_round_sprite_offset"));
+    result[@"roundSprite"] = @(ARMSX2ClampInt(si.GetIntValue("EmuCore/GS", "UserHacks_round_sprite_offset", [result[@"roundSprite"] intValue]), 0, 2));
+    result[@"hasAlignSpriteOverride"] = @(si.ContainsValue("EmuCore/GS", "UserHacks_align_sprite_X"));
+    result[@"alignSprite"] = @(si.GetBoolValue("EmuCore/GS", "UserHacks_align_sprite_X", [result[@"alignSprite"] boolValue]));
+    result[@"hasMergeSpriteOverride"] = @(si.ContainsValue("EmuCore/GS", "UserHacks_merge_pp_sprite"));
+    result[@"mergeSprite"] = @(si.GetBoolValue("EmuCore/GS", "UserHacks_merge_pp_sprite", [result[@"mergeSprite"] boolValue]));
+    result[@"hasWildArmsOffsetOverride"] = @(si.ContainsValue("EmuCore/GS", "UserHacks_ForceEvenSpritePosition"));
+    result[@"wildArmsOffset"] = @(si.GetBoolValue("EmuCore/GS", "UserHacks_ForceEvenSpritePosition", [result[@"wildArmsOffset"] boolValue]));
+    result[@"hasTextureOffsetXOverride"] = @(si.ContainsValue("EmuCore/GS", "UserHacks_TCOffsetX"));
+    result[@"textureOffsetX"] = @(ARMSX2ClampInt(si.GetIntValue("EmuCore/GS", "UserHacks_TCOffsetX", [result[@"textureOffsetX"] intValue]), -4096, 4096));
+    result[@"hasTextureOffsetYOverride"] = @(si.ContainsValue("EmuCore/GS", "UserHacks_TCOffsetY"));
+    result[@"textureOffsetY"] = @(ARMSX2ClampInt(si.GetIntValue("EmuCore/GS", "UserHacks_TCOffsetY", [result[@"textureOffsetY"] intValue]), -4096, 4096));
+    result[@"hasSkipDrawStartOverride"] = @(si.ContainsValue("EmuCore/GS", "UserHacks_SkipDraw_Start"));
+    result[@"skipDrawStart"] = @(ARMSX2ClampInt(si.GetIntValue("EmuCore/GS", "UserHacks_SkipDraw_Start", [result[@"skipDrawStart"] intValue]), 0, 5000));
+    result[@"hasSkipDrawEndOverride"] = @(si.ContainsValue("EmuCore/GS", "UserHacks_SkipDraw_End"));
+    result[@"skipDrawEnd"] = @(ARMSX2ClampInt(si.GetIntValue("EmuCore/GS", "UserHacks_SkipDraw_End", [result[@"skipDrawEnd"] intValue]), 0, 5000));
+    result[@"enableCheats"] = @(si.GetBoolValue("EmuCore", "EnableCheats", [result[@"enableCheats"] boolValue]));
+    result[@"enablePatches"] = @(si.GetBoolValue("EmuCore", "EnablePatches", [result[@"enablePatches"] boolValue]));
+    result[@"enableGameFixes"] = @(si.GetBoolValue("EmuCore", "EnableGameFixes", [result[@"enableGameFixes"] boolValue]));
+    result[@"enableGameDBHardwareFixes"] = @(!si.GetBoolValue("EmuCore/GS", "UserHacks", ![result[@"enableGameDBHardwareFixes"] boolValue]));
+    result[@"eeCoreType"] = @(si.GetIntValue("EmuCore/CPU", "CoreType", [result[@"eeCoreType"] intValue]));
+    result[@"mtvu"] = @(si.GetBoolValue("EmuCore/Speedhacks", "vuThread", [result[@"mtvu"] boolValue]));
+}
+
+static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
+                                                u32 crc,
+                                                BOOL enabled,
+                                                float upscaleMultiplier,
+                                                NSString* aspectRatio,
+                                                int textureFiltering,
+                                                BOOL hardwareMipmapping,
+                                                int blendingAccuracy,
+                                                int interlaceMode,
+                                                int trilinearFiltering,
+                                                int halfPixelOffset,
+                                                int roundSprite,
+                                                BOOL alignSpriteOverride,
+                                                BOOL alignSprite,
+                                                BOOL mergeSpriteOverride,
+                                                BOOL mergeSprite,
+                                                BOOL wildArmsOffsetOverride,
+                                                BOOL wildArmsOffset,
+                                                BOOL textureOffsetXOverride,
+                                                int textureOffsetX,
+                                                BOOL textureOffsetYOverride,
+                                                int textureOffsetY,
+                                                BOOL skipDrawStartOverride,
+                                                int skipDrawStart,
+                                                BOOL skipDrawEndOverride,
+                                                int skipDrawEnd,
+                                                int eeCoreType,
+                                                BOOL mtvu,
+                                                BOOL enableCheats,
+                                                BOOL enablePatches,
+                                                BOOL enableGameFixes,
+                                                BOOL enableGameDBHardwareFixes)
+{
+    FileSystem::CreateDirectoryPath(EmuFolders::GameSettings.c_str(), false);
+
+    const std::string settingsPath = VMManager::GetGameSettingsPath(serial, crc);
+    INISettingsInterface si(settingsPath);
+    si.Load();
+
+    if (enabled) {
+        si.SetBoolValue("ARMSX2iOS/PerGame", "Enabled", true);
+        si.SetFloatValue("EmuCore/GS", "upscale_multiplier", upscaleMultiplier);
+        si.SetStringValue("EmuCore/GS", "AspectRatio", aspectRatio.UTF8String ?: "Auto 4:3/3:2");
+        si.SetIntValue("EmuCore/GS", "filter", textureFiltering);
+        si.SetBoolValue("EmuCore/GS", "hw_mipmap", hardwareMipmapping);
+        si.SetIntValue("EmuCore/GS", "accurate_blending_unit", blendingAccuracy);
+        si.SetIntValue("EmuCore/GS", "deinterlace_mode", interlaceMode);
+        if (trilinearFiltering == ARMSX2TriFilterUseGlobalSentinel)
+            si.DeleteValue("EmuCore/GS", "TriFilter");
+        else
+            si.SetIntValue("EmuCore/GS", "TriFilter", ARMSX2ClampInt(trilinearFiltering, -1, 2));
+
+        if (halfPixelOffset == ARMSX2UseGlobalIntSentinel)
+            si.DeleteValue("EmuCore/GS", "UserHacks_HalfPixelOffset");
+        else
+            si.SetIntValue("EmuCore/GS", "UserHacks_HalfPixelOffset", ARMSX2ClampInt(halfPixelOffset, 0, 5));
+
+        if (roundSprite == ARMSX2UseGlobalIntSentinel)
+            si.DeleteValue("EmuCore/GS", "UserHacks_round_sprite_offset");
+        else
+            si.SetIntValue("EmuCore/GS", "UserHacks_round_sprite_offset", ARMSX2ClampInt(roundSprite, 0, 2));
+
+        if (alignSpriteOverride)
+            si.SetBoolValue("EmuCore/GS", "UserHacks_align_sprite_X", alignSprite);
+        else
+            si.DeleteValue("EmuCore/GS", "UserHacks_align_sprite_X");
+
+        if (mergeSpriteOverride)
+            si.SetBoolValue("EmuCore/GS", "UserHacks_merge_pp_sprite", mergeSprite);
+        else
+            si.DeleteValue("EmuCore/GS", "UserHacks_merge_pp_sprite");
+
+        if (wildArmsOffsetOverride)
+            si.SetBoolValue("EmuCore/GS", "UserHacks_ForceEvenSpritePosition", wildArmsOffset);
+        else
+            si.DeleteValue("EmuCore/GS", "UserHacks_ForceEvenSpritePosition");
+
+        if (textureOffsetXOverride)
+            si.SetIntValue("EmuCore/GS", "UserHacks_TCOffsetX", ARMSX2ClampInt(textureOffsetX, -4096, 4096));
+        else
+            si.DeleteValue("EmuCore/GS", "UserHacks_TCOffsetX");
+
+        if (textureOffsetYOverride)
+            si.SetIntValue("EmuCore/GS", "UserHacks_TCOffsetY", ARMSX2ClampInt(textureOffsetY, -4096, 4096));
+        else
+            si.DeleteValue("EmuCore/GS", "UserHacks_TCOffsetY");
+
+        if (skipDrawStartOverride)
+            si.SetIntValue("EmuCore/GS", "UserHacks_SkipDraw_Start", ARMSX2ClampInt(skipDrawStart, 0, 5000));
+        else
+            si.DeleteValue("EmuCore/GS", "UserHacks_SkipDraw_Start");
+
+        if (skipDrawEndOverride)
+            si.SetIntValue("EmuCore/GS", "UserHacks_SkipDraw_End", ARMSX2ClampInt(skipDrawEnd, 0, 5000));
+        else
+            si.DeleteValue("EmuCore/GS", "UserHacks_SkipDraw_End");
+
+        si.SetBoolValue("EmuCore", "EnableCheats", enableCheats);
+        si.SetBoolValue("EmuCore", "EnablePatches", enablePatches);
+        si.SetBoolValue("EmuCore", "EnableGameFixes", enableGameFixes);
+        si.SetBoolValue("EmuCore/GS", "UserHacks", !enableGameDBHardwareFixes);
+        si.SetIntValue("EmuCore/CPU", "CoreType", eeCoreType);
+        si.SetBoolValue("EmuCore/CPU", "UseArm64Dynarec", eeCoreType == 2);
+        si.SetBoolValue("EmuCore/Speedhacks", "vuThread", mtvu);
+    } else {
+        si.DeleteValue("ARMSX2iOS/PerGame", "Enabled");
+        si.DeleteValue("EmuCore/GS", "upscale_multiplier");
+        si.DeleteValue("EmuCore/GS", "AspectRatio");
+        si.DeleteValue("EmuCore/GS", "filter");
+        si.DeleteValue("EmuCore/GS", "hw_mipmap");
+        si.DeleteValue("EmuCore/GS", "accurate_blending_unit");
+        si.DeleteValue("EmuCore/GS", "deinterlace_mode");
+        si.DeleteValue("EmuCore/GS", "TriFilter");
+        si.DeleteValue("EmuCore/GS", "UserHacks_HalfPixelOffset");
+        si.DeleteValue("EmuCore/GS", "UserHacks_round_sprite_offset");
+        si.DeleteValue("EmuCore/GS", "UserHacks_align_sprite_X");
+        si.DeleteValue("EmuCore/GS", "UserHacks_merge_pp_sprite");
+        si.DeleteValue("EmuCore/GS", "UserHacks_ForceEvenSpritePosition");
+        si.DeleteValue("EmuCore/GS", "UserHacks_TCOffsetX");
+        si.DeleteValue("EmuCore/GS", "UserHacks_TCOffsetY");
+        si.DeleteValue("EmuCore/GS", "UserHacks_SkipDraw_Start");
+        si.DeleteValue("EmuCore/GS", "UserHacks_SkipDraw_End");
+        si.DeleteValue("EmuCore", "EnableCheats");
+        si.DeleteValue("EmuCore", "EnablePatches");
+        si.DeleteValue("EmuCore", "EnableGameFixes");
+        si.DeleteValue("EmuCore/GS", "UserHacks");
+        si.DeleteValue("EmuCore/CPU", "CoreType");
+        si.DeleteValue("EmuCore/CPU", "UseArm64Dynarec");
+        si.DeleteValue("EmuCore/Speedhacks", "vuThread");
+        si.RemoveEmptySections();
+    }
+
+    Error error;
+    const bool saved = si.Save(&error);
+    NSLog(@"[ARMSX2Bridge] Game settings %@ serial=%@ crc=%08X path=%@ result=%d",
+          enabled ? @"saved" : @"cleared", ARMSX2NSStringFromStdString(serial),
+          crc, ARMSX2NSStringFromStdString(settingsPath), saved ? 1 : 0);
+    if (!saved)
+        NSLog(@"[ARMSX2Bridge] Game settings save error: %@", ARMSX2NSStringFromStdString(error.GetDescription()));
+}
+
 @implementation ARMSX2Bridge
 
 + (UIView *)gameRenderView {
@@ -1334,83 +1624,33 @@ static void ARMSX2ApplyLiveFloatSetting(const char* section, const char* key, fl
 }
 
 + (nonnull NSDictionary<NSString *, id> *)gameSettingsForISO:(nonnull NSString *)isoName {
+    NSMutableDictionary<NSString*, id>* result = ARMSX2BuildGlobalGameSettingsResult();
+
     GameList::Entry entry;
     NSString* resolvedPath = nil;
-    const float globalUpscale = g_p44_settings_interface ? g_p44_settings_interface->GetFloatValue("EmuCore/GS", "upscale_multiplier", 1.0f) : 1.0f;
-    const std::string globalAspect = g_p44_settings_interface ? g_p44_settings_interface->GetStringValue("EmuCore/GS", "AspectRatio", "Auto 4:3/3:2") : std::string("Auto 4:3/3:2");
-    const int globalTextureFiltering = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "filter", 2) : 2;
-    const bool globalHardwareMipmapping = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore/GS", "hw_mipmap", true) : true;
-    const int globalBlendingAccuracy = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "accurate_blending_unit", 1) : 1;
-    const int globalInterlaceMode = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "deinterlace_mode", 7) : 7;
-    const bool globalEnableCheats = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore", "EnableCheats", false) : false;
-    const bool globalEnablePatches = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore", "EnablePatches", true) : true;
-    const bool globalEnableGameFixes = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore", "EnableGameFixes", true) : true;
-    const bool globalEnableGameDBHardwareFixes = g_p44_settings_interface ? !g_p44_settings_interface->GetBoolValue("EmuCore/GS", "UserHacks", false) : true;
-    const int globalEECoreType = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/CPU", "CoreType", 2) : 2;
-    const bool globalMTVU = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore/Speedhacks", "vuThread", false) : false;
-    NSMutableDictionary<NSString*, id>* result = [@{
-        @"enabled": @NO,
-        @"path": @"",
-        @"serial": @"",
-        @"crc": @"",
-        @"upscaleMultiplier": @(globalUpscale),
-        @"aspectRatio": ARMSX2NSStringFromStdString(globalAspect),
-        @"textureFiltering": @(globalTextureFiltering),
-        @"hardwareMipmapping": @(globalHardwareMipmapping),
-        @"blendingAccuracy": @(globalBlendingAccuracy),
-        @"interlaceMode": @(globalInterlaceMode),
-        @"enableCheats": @(globalEnableCheats),
-        @"enablePatches": @(globalEnablePatches),
-        @"enableGameFixes": @(globalEnableGameFixes),
-        @"enableGameDBHardwareFixes": @(globalEnableGameDBHardwareFixes),
-        @"eeCoreType": @(globalEECoreType),
-        @"mtvu": @(globalMTVU),
-    } mutableCopy];
-
     if (!ARMSX2PopulateGameListEntryForISO(isoName, &entry, &resolvedPath) || entry.crc == 0) {
         NSLog(@"[ARMSX2Bridge] Game settings unavailable for %@ path=%@", isoName, resolvedPath ?: @"");
         return result;
     }
 
-    const std::string settingsPath = VMManager::GetGameSettingsPath(entry.serial, entry.crc);
-    result[@"path"] = ARMSX2NSStringFromStdString(settingsPath);
-    result[@"serial"] = ARMSX2NSStringFromStdString(entry.serial);
-    result[@"crc"] = [NSString stringWithFormat:@"%08X", entry.crc];
+    ARMSX2ApplyPerGameSettingsOverrides(result, entry.serial, entry.crc);
+    return result;
+}
 
-    INISettingsInterface si(settingsPath);
-    if (!si.Load())
+// VM-safe per-game settings for the running title. Reads the serial/crc the VM already
+// holds in memory instead of re-scanning the disc image, which is what previously
+// disturbed audio/loading when the runtime panel was opened over an active game.
++ (nullable NSDictionary<NSString *, id> *)gameSettingsForCurrentGame {
+    if (!VMManager::HasValidVM())
+        return nil;
+
+    NSMutableDictionary<NSString*, id>* result = ARMSX2BuildGlobalGameSettingsResult();
+    const std::string serial = VMManager::GetDiscSerial();
+    const u32 crc = VMManager::GetDiscCRC();
+    if (serial.empty() && crc == 0)
         return result;
 
-    const bool hasKnownOverride =
-        si.GetBoolValue("ARMSX2iOS/PerGame", "Enabled", false) ||
-        si.ContainsValue("EmuCore/GS", "upscale_multiplier") ||
-        si.ContainsValue("EmuCore/GS", "AspectRatio") ||
-        si.ContainsValue("EmuCore/GS", "filter") ||
-        si.ContainsValue("EmuCore/GS", "hw_mipmap") ||
-        si.ContainsValue("EmuCore/GS", "accurate_blending_unit") ||
-        si.ContainsValue("EmuCore/GS", "deinterlace_mode") ||
-        si.ContainsValue("EmuCore", "EnableCheats") ||
-        si.ContainsValue("EmuCore", "EnablePatches") ||
-        si.ContainsValue("EmuCore", "EnableGameFixes") ||
-        si.ContainsValue("EmuCore/GS", "UserHacks") ||
-        si.ContainsValue("EmuCore/CPU", "CoreType") ||
-        si.ContainsValue("EmuCore/CPU", "UseArm64Dynarec") ||
-        si.ContainsValue("EmuCore/Speedhacks", "vuThread");
-
-    result[@"enabled"] = @(hasKnownOverride);
-    NSString* currentAspect = [result[@"aspectRatio"] isKindOfClass:NSString.class] ? result[@"aspectRatio"] : @"Auto 4:3/3:2";
-    result[@"upscaleMultiplier"] = @(si.GetFloatValue("EmuCore/GS", "upscale_multiplier", [result[@"upscaleMultiplier"] floatValue]));
-    result[@"aspectRatio"] = ARMSX2NSStringFromStdString(si.GetStringValue("EmuCore/GS", "AspectRatio", currentAspect.UTF8String));
-    result[@"textureFiltering"] = @(si.GetIntValue("EmuCore/GS", "filter", [result[@"textureFiltering"] intValue]));
-    result[@"hardwareMipmapping"] = @(si.GetBoolValue("EmuCore/GS", "hw_mipmap", [result[@"hardwareMipmapping"] boolValue]));
-    result[@"blendingAccuracy"] = @(si.GetIntValue("EmuCore/GS", "accurate_blending_unit", [result[@"blendingAccuracy"] intValue]));
-    result[@"interlaceMode"] = @(si.GetIntValue("EmuCore/GS", "deinterlace_mode", [result[@"interlaceMode"] intValue]));
-    result[@"enableCheats"] = @(si.GetBoolValue("EmuCore", "EnableCheats", [result[@"enableCheats"] boolValue]));
-    result[@"enablePatches"] = @(si.GetBoolValue("EmuCore", "EnablePatches", [result[@"enablePatches"] boolValue]));
-    result[@"enableGameFixes"] = @(si.GetBoolValue("EmuCore", "EnableGameFixes", [result[@"enableGameFixes"] boolValue]));
-    result[@"enableGameDBHardwareFixes"] = @(!si.GetBoolValue("EmuCore/GS", "UserHacks", ![result[@"enableGameDBHardwareFixes"] boolValue]));
-    result[@"eeCoreType"] = @(si.GetIntValue("EmuCore/CPU", "CoreType", [result[@"eeCoreType"] intValue]));
-    result[@"mtvu"] = @(si.GetBoolValue("EmuCore/Speedhacks", "vuThread", [result[@"mtvu"] boolValue]));
+    ARMSX2ApplyPerGameSettingsOverrides(result, serial, crc);
     return result;
 }
 
@@ -1422,6 +1662,23 @@ static void ARMSX2ApplyLiveFloatSetting(const char* section, const char* key, fl
             hardwareMipmapping:(BOOL)hardwareMipmapping
               blendingAccuracy:(int)blendingAccuracy
                interlaceMode:(int)interlaceMode
+        trilinearFiltering:(int)trilinearFiltering
+          halfPixelOffset:(int)halfPixelOffset
+              roundSprite:(int)roundSprite
+      alignSpriteOverride:(BOOL)alignSpriteOverride
+              alignSprite:(BOOL)alignSprite
+      mergeSpriteOverride:(BOOL)mergeSpriteOverride
+              mergeSprite:(BOOL)mergeSprite
+    wildArmsOffsetOverride:(BOOL)wildArmsOffsetOverride
+           wildArmsOffset:(BOOL)wildArmsOffset
+    textureOffsetXOverride:(BOOL)textureOffsetXOverride
+           textureOffsetX:(int)textureOffsetX
+    textureOffsetYOverride:(BOOL)textureOffsetYOverride
+           textureOffsetY:(int)textureOffsetY
+     skipDrawStartOverride:(BOOL)skipDrawStartOverride
+            skipDrawStart:(int)skipDrawStart
+       skipDrawEndOverride:(BOOL)skipDrawEndOverride
+              skipDrawEnd:(int)skipDrawEnd
                     eeCoreType:(int)eeCoreType
                           mtvu:(BOOL)mtvu
                   enableCheats:(BOOL)enableCheats
@@ -1435,52 +1692,67 @@ static void ARMSX2ApplyLiveFloatSetting(const char* section, const char* key, fl
         return;
     }
 
-    FileSystem::CreateDirectoryPath(EmuFolders::GameSettings.c_str(), false);
+    ARMSX2WriteGameSettingsForIdentity(entry.serial, entry.crc, enabled, upscaleMultiplier, aspectRatio,
+                                        textureFiltering, hardwareMipmapping, blendingAccuracy, interlaceMode,
+                                        trilinearFiltering, halfPixelOffset, roundSprite, alignSpriteOverride,
+                                        alignSprite, mergeSpriteOverride, mergeSprite, wildArmsOffsetOverride,
+                                        wildArmsOffset, textureOffsetXOverride, textureOffsetX,
+                                        textureOffsetYOverride, textureOffsetY, skipDrawStartOverride,
+                                        skipDrawStart, skipDrawEndOverride, skipDrawEnd, eeCoreType, mtvu,
+                                        enableCheats, enablePatches, enableGameFixes, enableGameDBHardwareFixes);
+}
 
-    const std::string settingsPath = VMManager::GetGameSettingsPath(entry.serial, entry.crc);
-    INISettingsInterface si(settingsPath);
-    si.Load();
-
-    if (enabled) {
-        si.SetBoolValue("ARMSX2iOS/PerGame", "Enabled", true);
-        si.SetFloatValue("EmuCore/GS", "upscale_multiplier", upscaleMultiplier);
-        si.SetStringValue("EmuCore/GS", "AspectRatio", aspectRatio.UTF8String ?: "Auto 4:3/3:2");
-        si.SetIntValue("EmuCore/GS", "filter", textureFiltering);
-        si.SetBoolValue("EmuCore/GS", "hw_mipmap", hardwareMipmapping);
-        si.SetIntValue("EmuCore/GS", "accurate_blending_unit", blendingAccuracy);
-        si.SetIntValue("EmuCore/GS", "deinterlace_mode", interlaceMode);
-        si.SetBoolValue("EmuCore", "EnableCheats", enableCheats);
-        si.SetBoolValue("EmuCore", "EnablePatches", enablePatches);
-        si.SetBoolValue("EmuCore", "EnableGameFixes", enableGameFixes);
-        si.SetBoolValue("EmuCore/GS", "UserHacks", !enableGameDBHardwareFixes);
-        si.SetIntValue("EmuCore/CPU", "CoreType", eeCoreType);
-        si.SetBoolValue("EmuCore/CPU", "UseArm64Dynarec", eeCoreType == 2);
-        si.SetBoolValue("EmuCore/Speedhacks", "vuThread", mtvu);
-    } else {
-        si.DeleteValue("ARMSX2iOS/PerGame", "Enabled");
-        si.DeleteValue("EmuCore/GS", "upscale_multiplier");
-        si.DeleteValue("EmuCore/GS", "AspectRatio");
-        si.DeleteValue("EmuCore/GS", "filter");
-        si.DeleteValue("EmuCore/GS", "hw_mipmap");
-        si.DeleteValue("EmuCore/GS", "accurate_blending_unit");
-        si.DeleteValue("EmuCore/GS", "deinterlace_mode");
-        si.DeleteValue("EmuCore", "EnableCheats");
-        si.DeleteValue("EmuCore", "EnablePatches");
-        si.DeleteValue("EmuCore", "EnableGameFixes");
-        si.DeleteValue("EmuCore/GS", "UserHacks");
-        si.DeleteValue("EmuCore/CPU", "CoreType");
-        si.DeleteValue("EmuCore/CPU", "UseArm64Dynarec");
-        si.DeleteValue("EmuCore/Speedhacks", "vuThread");
-        si.RemoveEmptySections();
++ (void)setGameSettingsForCurrentGameWithEnabled:(BOOL)enabled
+                               upscaleMultiplier:(float)upscaleMultiplier
+                                     aspectRatio:(nonnull NSString *)aspectRatio
+                                textureFiltering:(int)textureFiltering
+                              hardwareMipmapping:(BOOL)hardwareMipmapping
+                                blendingAccuracy:(int)blendingAccuracy
+                                   interlaceMode:(int)interlaceMode
+                              trilinearFiltering:(int)trilinearFiltering
+                                 halfPixelOffset:(int)halfPixelOffset
+                                     roundSprite:(int)roundSprite
+                             alignSpriteOverride:(BOOL)alignSpriteOverride
+                                     alignSprite:(BOOL)alignSprite
+                             mergeSpriteOverride:(BOOL)mergeSpriteOverride
+                                     mergeSprite:(BOOL)mergeSprite
+                           wildArmsOffsetOverride:(BOOL)wildArmsOffsetOverride
+                                  wildArmsOffset:(BOOL)wildArmsOffset
+                           textureOffsetXOverride:(BOOL)textureOffsetXOverride
+                                  textureOffsetX:(int)textureOffsetX
+                           textureOffsetYOverride:(BOOL)textureOffsetYOverride
+                                  textureOffsetY:(int)textureOffsetY
+                            skipDrawStartOverride:(BOOL)skipDrawStartOverride
+                                   skipDrawStart:(int)skipDrawStart
+                              skipDrawEndOverride:(BOOL)skipDrawEndOverride
+                                     skipDrawEnd:(int)skipDrawEnd
+                                      eeCoreType:(int)eeCoreType
+                                            mtvu:(BOOL)mtvu
+                                    enableCheats:(BOOL)enableCheats
+                                   enablePatches:(BOOL)enablePatches
+                                 enableGameFixes:(BOOL)enableGameFixes
+                      enableGameDBHardwareFixes:(BOOL)enableGameDBHardwareFixes {
+    if (!VMManager::HasValidVM()) {
+        NSLog(@"[ARMSX2Bridge] Current game settings save rejected: no valid VM");
+        return;
     }
 
-    Error error;
-    const bool saved = si.Save(&error);
-    NSLog(@"[ARMSX2Bridge] Game settings %@ iso=%@ serial=%@ crc=%08X path=%@ result=%d",
-          enabled ? @"saved" : @"cleared", isoName, ARMSX2NSStringFromStdString(entry.serial),
-          entry.crc, ARMSX2NSStringFromStdString(settingsPath), saved ? 1 : 0);
-    if (!saved)
-        NSLog(@"[ARMSX2Bridge] Game settings save error: %@", ARMSX2NSStringFromStdString(error.GetDescription()));
+    const std::string serial = VMManager::GetDiscSerial();
+    const u32 crc = VMManager::GetDiscCRC();
+    if (crc == 0) {
+        NSLog(@"[ARMSX2Bridge] Current game settings save rejected serial=%@ crc=%08X",
+              ARMSX2NSStringFromStdString(serial), crc);
+        return;
+    }
+
+    ARMSX2WriteGameSettingsForIdentity(serial, crc, enabled, upscaleMultiplier, aspectRatio,
+                                        textureFiltering, hardwareMipmapping, blendingAccuracy, interlaceMode,
+                                        trilinearFiltering, halfPixelOffset, roundSprite, alignSpriteOverride,
+                                        alignSprite, mergeSpriteOverride, mergeSprite, wildArmsOffsetOverride,
+                                        wildArmsOffset, textureOffsetXOverride, textureOffsetX,
+                                        textureOffsetYOverride, textureOffsetY, skipDrawStartOverride,
+                                        skipDrawStart, skipDrawEndOverride, skipDrawEnd, eeCoreType, mtvu,
+                                        enableCheats, enablePatches, enableGameFixes, enableGameDBHardwareFixes);
 }
 
 + (nonnull NSString *)clearCacheForISO:(nonnull NSString *)isoName {

--- a/app/src/main/swift/Models/SettingsStore.swift
+++ b/app/src/main/swift/Models/SettingsStore.swift
@@ -27,6 +27,8 @@ final class SettingsStore: @unchecked Sendable {
     static let minTargetFPS: Float = 15.0
     static let maxTargetFPS: Float = 120.0
     static let defaultTargetFPS: Float = 60.0
+    static let textureOffsetRange = -4096...4096
+    static let skipDrawRange = 0...5000
 
     @ObservationIgnored private var suppressINIWrites = false
 
@@ -158,6 +160,64 @@ final class SettingsStore: @unchecked Sendable {
     }
     var dithering: Int {
         didSet { ARMSX2Bridge.setINIInt("EmuCore/GS", key: "dithering_ps2", value: Int32(dithering)) }
+    }
+    var trilinearFiltering: Int {
+        didSet { ARMSX2Bridge.setINIInt("EmuCore/GS", key: "TriFilter", value: Int32(trilinearFiltering)) }
+    }
+    var halfPixelOffset: Int {
+        didSet { ARMSX2Bridge.setINIInt("EmuCore/GS", key: "UserHacks_HalfPixelOffset", value: Int32(halfPixelOffset)) }
+    }
+    var roundSprite: Int {
+        didSet { ARMSX2Bridge.setINIInt("EmuCore/GS", key: "UserHacks_round_sprite_offset", value: Int32(roundSprite)) }
+    }
+    var alignSprite: Bool {
+        didSet { ARMSX2Bridge.setINIBool("EmuCore/GS", key: "UserHacks_align_sprite_X", value: alignSprite) }
+    }
+    var mergeSprite: Bool {
+        didSet { ARMSX2Bridge.setINIBool("EmuCore/GS", key: "UserHacks_merge_pp_sprite", value: mergeSprite) }
+    }
+    var wildArmsOffset: Bool {
+        didSet { ARMSX2Bridge.setINIBool("EmuCore/GS", key: "UserHacks_ForceEvenSpritePosition", value: wildArmsOffset) }
+    }
+    var textureOffsetX: Int {
+        didSet {
+            let normalized = Self.clampedTextureOffset(textureOffsetX)
+            guard textureOffsetX == normalized else {
+                textureOffsetX = normalized
+                return
+            }
+            ARMSX2Bridge.setINIInt("EmuCore/GS", key: "UserHacks_TCOffsetX", value: Int32(textureOffsetX))
+        }
+    }
+    var textureOffsetY: Int {
+        didSet {
+            let normalized = Self.clampedTextureOffset(textureOffsetY)
+            guard textureOffsetY == normalized else {
+                textureOffsetY = normalized
+                return
+            }
+            ARMSX2Bridge.setINIInt("EmuCore/GS", key: "UserHacks_TCOffsetY", value: Int32(textureOffsetY))
+        }
+    }
+    var skipDrawStart: Int {
+        didSet {
+            let normalized = Self.clampedSkipDraw(skipDrawStart)
+            guard skipDrawStart == normalized else {
+                skipDrawStart = normalized
+                return
+            }
+            ARMSX2Bridge.setINIInt("EmuCore/GS", key: "UserHacks_SkipDraw_Start", value: Int32(skipDrawStart))
+        }
+    }
+    var skipDrawEnd: Int {
+        didSet {
+            let normalized = Self.clampedSkipDraw(skipDrawEnd)
+            guard skipDrawEnd == normalized else {
+                skipDrawEnd = normalized
+                return
+            }
+            ARMSX2Bridge.setINIInt("EmuCore/GS", key: "UserHacks_SkipDraw_End", value: Int32(skipDrawEnd))
+        }
     }
     var loadTextureReplacements: Bool {
         didSet { ARMSX2Bridge.setINIBool("EmuCore/GS", key: "LoadTextureReplacements", value: loadTextureReplacements) }
@@ -414,6 +474,20 @@ final class SettingsStore: @unchecked Sendable {
         aspectRatio = Self.aspectRatioValue(from: ARMSX2Bridge.getINIString("EmuCore/GS", key: "AspectRatio", defaultValue: "Auto 4:3/3:2"))
         blendingAccuracy = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "accurate_blending_unit", defaultValue: 1))
         dithering = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "dithering_ps2", defaultValue: 2))
+        trilinearFiltering = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "TriFilter", defaultValue: -1))
+        halfPixelOffset = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "UserHacks_HalfPixelOffset", defaultValue: 0))
+        roundSprite = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "UserHacks_round_sprite_offset", defaultValue: 0))
+        alignSprite = ARMSX2Bridge.getINIBool("EmuCore/GS", key: "UserHacks_align_sprite_X", defaultValue: false)
+        mergeSprite = ARMSX2Bridge.getINIBool("EmuCore/GS", key: "UserHacks_merge_pp_sprite", defaultValue: false)
+        wildArmsOffset = ARMSX2Bridge.getINIBool("EmuCore/GS", key: "UserHacks_ForceEvenSpritePosition", defaultValue: false)
+        textureOffsetX = Self.clampedTextureOffset(Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "UserHacks_TCOffsetX", defaultValue: 0)))
+        textureOffsetY = Self.clampedTextureOffset(Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "UserHacks_TCOffsetY", defaultValue: 0)))
+        let loadedSkipDrawStart = Self.clampedSkipDraw(Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "UserHacks_SkipDraw_Start", defaultValue: 0)))
+        skipDrawStart = loadedSkipDrawStart
+        skipDrawEnd = Self.normalizedSkipDrawEnd(
+            start: loadedSkipDrawStart,
+            end: Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "UserHacks_SkipDraw_End", defaultValue: 0))
+        )
         loadTextureReplacements = ARMSX2Bridge.getINIBool("EmuCore/GS", key: "LoadTextureReplacements", defaultValue: false)
         loadTextureReplacementsAsync = ARMSX2Bridge.getINIBool("EmuCore/GS", key: "LoadTextureReplacementsAsync", defaultValue: true)
         precacheTextureReplacements = ARMSX2Bridge.getINIBool("EmuCore/GS", key: "PrecacheTextureReplacements", defaultValue: false)
@@ -511,6 +585,20 @@ final class SettingsStore: @unchecked Sendable {
         aspectRatio = Self.aspectRatioValue(from: ARMSX2Bridge.getINIString("EmuCore/GS", key: "AspectRatio", defaultValue: "Auto 4:3/3:2"))
         blendingAccuracy = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "accurate_blending_unit", defaultValue: 1))
         dithering = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "dithering_ps2", defaultValue: 2))
+        trilinearFiltering = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "TriFilter", defaultValue: -1))
+        halfPixelOffset = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "UserHacks_HalfPixelOffset", defaultValue: 0))
+        roundSprite = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "UserHacks_round_sprite_offset", defaultValue: 0))
+        alignSprite = ARMSX2Bridge.getINIBool("EmuCore/GS", key: "UserHacks_align_sprite_X", defaultValue: false)
+        mergeSprite = ARMSX2Bridge.getINIBool("EmuCore/GS", key: "UserHacks_merge_pp_sprite", defaultValue: false)
+        wildArmsOffset = ARMSX2Bridge.getINIBool("EmuCore/GS", key: "UserHacks_ForceEvenSpritePosition", defaultValue: false)
+        textureOffsetX = Self.clampedTextureOffset(Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "UserHacks_TCOffsetX", defaultValue: 0)))
+        textureOffsetY = Self.clampedTextureOffset(Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "UserHacks_TCOffsetY", defaultValue: 0)))
+        let loadedSkipDrawStart = Self.clampedSkipDraw(Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "UserHacks_SkipDraw_Start", defaultValue: 0)))
+        skipDrawStart = loadedSkipDrawStart
+        skipDrawEnd = Self.normalizedSkipDrawEnd(
+            start: loadedSkipDrawStart,
+            end: Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "UserHacks_SkipDraw_End", defaultValue: 0))
+        )
         loadTextureReplacements = ARMSX2Bridge.getINIBool("EmuCore/GS", key: "LoadTextureReplacements", defaultValue: false)
         loadTextureReplacementsAsync = ARMSX2Bridge.getINIBool("EmuCore/GS", key: "LoadTextureReplacementsAsync", defaultValue: true)
         precacheTextureReplacements = ARMSX2Bridge.getINIBool("EmuCore/GS", key: "PrecacheTextureReplacements", defaultValue: false)
@@ -572,6 +660,20 @@ final class SettingsStore: @unchecked Sendable {
     private static func clampedAnalogStickScale(_ scale: Float) -> Float {
         guard scale.isFinite else { return 1.0 }
         return min(max(scale, 0.8), 1.6)
+    }
+
+    private static func clampedTextureOffset(_ offset: Int) -> Int {
+        min(max(offset, textureOffsetRange.lowerBound), textureOffsetRange.upperBound)
+    }
+
+    private static func clampedSkipDraw(_ value: Int) -> Int {
+        min(max(value, skipDrawRange.lowerBound), skipDrawRange.upperBound)
+    }
+
+    static func normalizedSkipDrawEnd(start: Int, end: Int) -> Int {
+        let clampedStart = clampedSkipDraw(start)
+        let clampedEnd = clampedSkipDraw(end)
+        return clampedStart > 0 && clampedEnd < clampedStart ? clampedStart : clampedEnd
     }
 
     private static func targetFPS(fromNominalScalar scalar: Float, baseFramerate: Float) -> Float {
@@ -701,6 +803,16 @@ final class SettingsStore: @unchecked Sendable {
         aspectRatio = 1         // Auto 4:3/3:2
         blendingAccuracy = 1    // Basic
         dithering = 2           // Scaled
+        trilinearFiltering = -1 // Automatic
+        halfPixelOffset = 0
+        roundSprite = 0
+        alignSprite = false
+        mergeSprite = false
+        wildArmsOffset = false
+        textureOffsetX = 0
+        textureOffsetY = 0
+        skipDrawStart = 0
+        skipDrawEnd = 0
         // Texture pack and dump toggles are intentionally preserved.
     }
 }

--- a/app/src/main/swift/Views/GameListView.swift
+++ b/app/src/main/swift/Views/GameListView.swift
@@ -336,6 +336,9 @@ struct GameListView: View {
             .sheet(item: $gameSettingsTarget) { game in
                 PerGameSettingsPanel(game: game)
                     .presentationDetents([.large])
+                    .presentationDragIndicator(.visible)
+                    .presentationBackground(.regularMaterial)
+                    .presentationCornerRadius(34)
             }
             .sheet(item: $gameCompatibilityTarget) { game in
                 GameCompatibilityPanel(game: game)
@@ -1199,6 +1202,9 @@ struct PerGameSettingsPanel: View {
         let title: String
     }
 
+    private static let useGlobalSentinel = -1
+    private static let trilinearUseGlobalSentinel = Int(Int32.min)
+
     private static let deinterlaceOptions = [
         PickerOption(id: 0, title: "None"),
         PickerOption(id: 1, title: "Weave (TFF)"),
@@ -1209,9 +1215,32 @@ struct PerGameSettingsPanel: View {
         PickerOption(id: 6, title: "Blend (BFF)"),
         PickerOption(id: 7, title: "Adaptive (Default)")
     ]
+    private static let trilinearFilteringOptions = [
+        PickerOption(id: trilinearUseGlobalSentinel, title: "Use Global"),
+        PickerOption(id: -1, title: "Automatic / Default"),
+        PickerOption(id: 0, title: "Off"),
+        PickerOption(id: 1, title: "PS2"),
+        PickerOption(id: 2, title: "Forced")
+    ]
+    private static let halfPixelOffsetOptions = [
+        PickerOption(id: useGlobalSentinel, title: "Use Global"),
+        PickerOption(id: 0, title: "Off"),
+        PickerOption(id: 1, title: "Normal / Vertex"),
+        PickerOption(id: 2, title: "Special / Texture"),
+        PickerOption(id: 3, title: "Special / Texture Aggressive"),
+        PickerOption(id: 4, title: "Align to Native"),
+        PickerOption(id: 5, title: "Align to Native + Texture Offset")
+    ]
+    private static let roundSpriteOptions = [
+        PickerOption(id: useGlobalSentinel, title: "Use Global"),
+        PickerOption(id: 0, title: "Off"),
+        PickerOption(id: 1, title: "Half"),
+        PickerOption(id: 2, title: "Full")
+    ]
 
     let game: ISOEntry
     let onDone: (() -> Void)?
+    let savesToRunningGame: Bool
 
     @State private var enabled: Bool
     @State private var upscaleMultiplier: Float
@@ -1220,6 +1249,23 @@ struct PerGameSettingsPanel: View {
     @State private var hardwareMipmapping: Bool
     @State private var blendingAccuracy: Int
     @State private var interlaceMode: Int
+    @State private var trilinearFiltering: Int
+    @State private var halfPixelOffset: Int
+    @State private var roundSprite: Int
+    @State private var alignSpriteOverride: Bool
+    @State private var alignSprite: Bool
+    @State private var mergeSpriteOverride: Bool
+    @State private var mergeSprite: Bool
+    @State private var wildArmsOffsetOverride: Bool
+    @State private var wildArmsOffset: Bool
+    @State private var textureOffsetXOverride: Bool
+    @State private var textureOffsetX: Int
+    @State private var textureOffsetYOverride: Bool
+    @State private var textureOffsetY: Int
+    @State private var skipDrawStartOverride: Bool
+    @State private var skipDrawStart: Int
+    @State private var skipDrawEndOverride: Bool
+    @State private var skipDrawEnd: Int
     @State private var eeCoreType: Int
     @State private var mtvu: Bool
     @State private var enableCheats: Bool
@@ -1228,10 +1274,18 @@ struct PerGameSettingsPanel: View {
     @State private var enableGameDBHardwareFixes: Bool
     @State private var statusMessage: String?
 
-    init(game: ISOEntry, onDone: (() -> Void)? = nil) {
+    init(
+        game: ISOEntry,
+        preloadedSettings: [String: Any]? = nil,
+        savesToRunningGame: Bool = false,
+        onDone: (() -> Void)? = nil
+    ) {
         self.game = game
         self.onDone = onDone
-        let info = ARMSX2Bridge.gameSettings(forISO: game.name)
+        self.savesToRunningGame = savesToRunningGame
+        // The runtime caller passes settings it already loaded through a VM-safe path so
+        // this view never re-scans the disc image during init while a game is running.
+        let info = preloadedSettings ?? ARMSX2Bridge.gameSettings(forISO: game.name)
         _enabled = State(initialValue: Self.boolValue(info["enabled"], defaultValue: false))
         _upscaleMultiplier = State(initialValue: Self.floatValue(info["upscaleMultiplier"], defaultValue: 1.0))
         _aspectRatio = State(initialValue: Self.normalizedAspect(info["aspectRatio"] as? String))
@@ -1239,6 +1293,32 @@ struct PerGameSettingsPanel: View {
         _hardwareMipmapping = State(initialValue: Self.boolValue(info["hardwareMipmapping"], defaultValue: true))
         _blendingAccuracy = State(initialValue: Self.intValue(info["blendingAccuracy"], defaultValue: 1))
         _interlaceMode = State(initialValue: Self.intValue(info["interlaceMode"], defaultValue: 7))
+        _trilinearFiltering = State(initialValue: Self.boolValue(info["hasTrilinearFilteringOverride"], defaultValue: false) ? Self.intValue(info["trilinearFiltering"], defaultValue: -1) : Self.trilinearUseGlobalSentinel)
+        _halfPixelOffset = State(initialValue: Self.boolValue(info["hasHalfPixelOffsetOverride"], defaultValue: false) ? Self.intValue(info["halfPixelOffset"], defaultValue: 0) : Self.useGlobalSentinel)
+        _roundSprite = State(initialValue: Self.boolValue(info["hasRoundSpriteOverride"], defaultValue: false) ? Self.intValue(info["roundSprite"], defaultValue: 0) : Self.useGlobalSentinel)
+        _alignSpriteOverride = State(initialValue: Self.boolValue(info["hasAlignSpriteOverride"], defaultValue: false))
+        _alignSprite = State(initialValue: Self.boolValue(info["alignSprite"], defaultValue: false))
+        _mergeSpriteOverride = State(initialValue: Self.boolValue(info["hasMergeSpriteOverride"], defaultValue: false))
+        _mergeSprite = State(initialValue: Self.boolValue(info["mergeSprite"], defaultValue: false))
+        _wildArmsOffsetOverride = State(initialValue: Self.boolValue(info["hasWildArmsOffsetOverride"], defaultValue: false))
+        _wildArmsOffset = State(initialValue: Self.boolValue(info["wildArmsOffset"], defaultValue: false))
+        _textureOffsetXOverride = State(initialValue: Self.boolValue(info["hasTextureOffsetXOverride"], defaultValue: false))
+        _textureOffsetX = State(initialValue: Self.clampedTextureOffset(Self.intValue(info["textureOffsetX"], defaultValue: 0)))
+        _textureOffsetYOverride = State(initialValue: Self.boolValue(info["hasTextureOffsetYOverride"], defaultValue: false))
+        _textureOffsetY = State(initialValue: Self.clampedTextureOffset(Self.intValue(info["textureOffsetY"], defaultValue: 0)))
+        let hasSkipDrawStartOverride = Self.boolValue(info["hasSkipDrawStartOverride"], defaultValue: false)
+        let hasSkipDrawEndOverride = Self.boolValue(info["hasSkipDrawEndOverride"], defaultValue: false)
+        let initialSkipDrawStart = Self.clampedSkipDraw(Self.intValue(info["skipDrawStart"], defaultValue: 0))
+        let initialSkipDrawEnd = Self.normalizedSkipDrawEnd(
+            start: initialSkipDrawStart,
+            end: Self.intValue(info["skipDrawEnd"], defaultValue: 0),
+            startOverride: hasSkipDrawStartOverride,
+            endOverride: hasSkipDrawEndOverride
+        )
+        _skipDrawStartOverride = State(initialValue: hasSkipDrawStartOverride)
+        _skipDrawStart = State(initialValue: initialSkipDrawStart)
+        _skipDrawEndOverride = State(initialValue: hasSkipDrawEndOverride)
+        _skipDrawEnd = State(initialValue: initialSkipDrawEnd)
         _eeCoreType = State(initialValue: Self.intValue(info["eeCoreType"], defaultValue: 2))
         _mtvu = State(initialValue: Self.boolValue(info["mtvu"], defaultValue: false))
         _enableCheats = State(initialValue: Self.boolValue(info["enableCheats"], defaultValue: false))
@@ -1247,9 +1327,58 @@ struct PerGameSettingsPanel: View {
         _enableGameDBHardwareFixes = State(initialValue: Self.boolValue(info["enableGameDBHardwareFixes"], defaultValue: true))
     }
 
+    private var manualAdvancedHacksEnabled: Bool {
+        enabled && !enableGameDBHardwareFixes
+    }
+
+    private var skipDrawStartBinding: Binding<Int> {
+        Binding(
+            get: { skipDrawStart },
+            set: { newValue in
+                skipDrawStart = Self.clampedSkipDraw(newValue)
+                normalizeSkipDrawRangeIfNeeded()
+            }
+        )
+    }
+
+    private var skipDrawEndBinding: Binding<Int> {
+        Binding(
+            get: { skipDrawEnd },
+            set: { newValue in
+                skipDrawEnd = Self.normalizedSkipDrawEnd(
+                    start: skipDrawStart,
+                    end: newValue,
+                    startOverride: skipDrawStartOverride,
+                    endOverride: skipDrawEndOverride
+                )
+            }
+        )
+    }
+
     var body: some View {
         NavigationStack {
             Form {
+                Section {
+                    HStack(spacing: 12) {
+                        Image(systemName: enabled ? "slider.horizontal.3" : "power")
+                            .font(.title3)
+                            .foregroundStyle(enabled ? Color.accentColor : Color.secondary)
+                            .frame(width: 32, height: 32)
+                            .background(Color.accentColor.opacity(enabled ? 0.14 : 0), in: Circle())
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(displayName)
+                                .font(.headline)
+                                .lineLimit(2)
+                            Text(settings.localized("Saved changes apply to this game only. Done leaves without saving."))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+
                 Section {
                     Toggle(settings.localized("Use Per-Game Overrides"), isOn: $enabled)
                     Text(settings.localized("Overrides are saved for this game only and apply on the next boot/reset of this title."))
@@ -1270,7 +1399,7 @@ struct PerGameSettingsPanel: View {
 
                     Toggle("MTVU", isOn: $mtvu)
                         .disabled(!enabled)
-                    Text(settings.localized("MTVU can improve performance in some games, but may cause compatibility issues. Reset/relaunch after changing it."))
+                    Text(settings.localized("MTVU can improve performance and may help some visual issues, but can cause compatibility problems. Reset/relaunch after changing it."))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -1328,6 +1457,95 @@ struct PerGameSettingsPanel: View {
                     .disabled(!enabled)
                 }
 
+                Section(settings.localized("Advanced Upscaling Hacks")) {
+                    Text(settings.localized("Manual advanced hacks only apply when Use Per-Game Overrides is on and GameDB Graphics Fixes is off. Save, then reset or relaunch the game."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    if enabled && enableGameDBHardwareFixes {
+                        Text(settings.localized("GameDB Graphics Fixes is on, so manual advanced hacks are saved but ignored until it is turned off for this game."))
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
+
+                    Picker(settings.localized("Trilinear Filtering"), selection: $trilinearFiltering) {
+                        ForEach(Self.trilinearFilteringOptions) { option in
+                            Text(settings.localized(option.title)).tag(option.id)
+                        }
+                    }
+                    .disabled(!enabled)
+
+                    if trilinearFiltering != Self.trilinearUseGlobalSentinel && trilinearFiltering != -1 {
+                        Text(settings.localized("Non-automatic trilinear filtering may break textures in some games."))
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
+
+                    Picker(settings.localized("Half-pixel Offset"), selection: $halfPixelOffset) {
+                        ForEach(Self.halfPixelOffsetOptions) { option in
+                            Text(settings.localized(option.title)).tag(option.id)
+                        }
+                    }
+                    .disabled(!manualAdvancedHacksEnabled)
+
+                    Picker(settings.localized("Round Sprite"), selection: $roundSprite) {
+                        ForEach(Self.roundSpriteOptions) { option in
+                            Text(settings.localized(option.title)).tag(option.id)
+                        }
+                    }
+                    .disabled(!manualAdvancedHacksEnabled)
+
+                    Toggle(settings.localized("Override Align Sprite"), isOn: $alignSpriteOverride)
+                        .disabled(!manualAdvancedHacksEnabled)
+                    if alignSpriteOverride {
+                        Toggle(settings.localized("Align Sprite"), isOn: $alignSprite)
+                            .disabled(!manualAdvancedHacksEnabled)
+                    }
+
+                    Toggle(settings.localized("Override Merge Sprite"), isOn: $mergeSpriteOverride)
+                        .disabled(!manualAdvancedHacksEnabled)
+                    if mergeSpriteOverride {
+                        Toggle(settings.localized("Merge Sprite"), isOn: $mergeSprite)
+                            .disabled(!manualAdvancedHacksEnabled)
+                    }
+
+                    Toggle(settings.localized("Override Wild Arms Offset"), isOn: $wildArmsOffsetOverride)
+                        .disabled(!manualAdvancedHacksEnabled)
+                    if wildArmsOffsetOverride {
+                        Toggle(settings.localized("Wild Arms Offset"), isOn: $wildArmsOffset)
+                            .disabled(!manualAdvancedHacksEnabled)
+                    }
+
+                    Toggle(settings.localized("Override Texture Offset X"), isOn: $textureOffsetXOverride)
+                        .disabled(!manualAdvancedHacksEnabled)
+                    if textureOffsetXOverride {
+                        ClampedIntField(title: settings.localized("Texture Offset X"), value: $textureOffsetX, range: SettingsStore.textureOffsetRange, isEnabled: manualAdvancedHacksEnabled)
+                    }
+
+                    Toggle(settings.localized("Override Texture Offset Y"), isOn: $textureOffsetYOverride)
+                        .disabled(!manualAdvancedHacksEnabled)
+                    if textureOffsetYOverride {
+                        ClampedIntField(title: settings.localized("Texture Offset Y"), value: $textureOffsetY, range: SettingsStore.textureOffsetRange, isEnabled: manualAdvancedHacksEnabled)
+                    }
+
+                    Toggle(settings.localized("Override Skipdraw Start"), isOn: $skipDrawStartOverride)
+                        .disabled(!manualAdvancedHacksEnabled)
+                    if skipDrawStartOverride {
+                        ClampedIntField(title: settings.localized("Skipdraw Start"), value: skipDrawStartBinding, range: SettingsStore.skipDrawRange, isEnabled: manualAdvancedHacksEnabled)
+                    }
+
+                    Toggle(settings.localized("Override Skipdraw End"), isOn: $skipDrawEndOverride)
+                        .disabled(!manualAdvancedHacksEnabled)
+                    if skipDrawEndOverride {
+                        ClampedIntField(title: settings.localized("Skipdraw End"), value: skipDrawEndBinding, range: SettingsStore.skipDrawRange, isEnabled: manualAdvancedHacksEnabled)
+                    }
+                    if skipDrawStartOverride || skipDrawEndOverride {
+                        Text(settings.localized("For Skipdraw 1, use Start 1 and End 1. Changes apply after reset/relaunch."))
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
+                }
+
                 Section(settings.localized("Patches & Cheats")) {
                     Toggle(settings.localized("Enable PNACH Cheats"), isOn: $enableCheats)
                         .disabled(!enabled)
@@ -1350,7 +1568,10 @@ struct PerGameSettingsPanel: View {
                     }
                 }
             }
+            .scrollContentBackground(.hidden)
+            .background(Color(.systemGroupedBackground))
             .navigationTitle(settings.localized("Per-Game Settings"))
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(settings.localized("Done")) {
@@ -1368,26 +1589,121 @@ struct PerGameSettingsPanel: View {
                 }
             }
         }
+        .background(Color(.systemGroupedBackground))
+    }
+
+    private var displayName: String {
+        let name = ((game.name as NSString).deletingPathExtension as String).trimmingCharacters(in: .whitespacesAndNewlines)
+        let serial = game.metadata["serial"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        if name.isEmpty {
+            return serial.isEmpty ? settings.localized("Current Game") : serial
+        }
+        if serial.isEmpty {
+            return name
+        }
+        return "\(name) - \(serial)"
     }
 
     private func save() {
-        ARMSX2Bridge.setGameSettings(
-            forISO: game.name,
-            enabled: enabled,
-            upscaleMultiplier: upscaleMultiplier,
-            aspectRatio: aspectRatio,
-            textureFiltering: Int32(textureFiltering),
-            hardwareMipmapping: hardwareMipmapping,
-            blendingAccuracy: Int32(blendingAccuracy),
-            interlaceMode: Int32(interlaceMode),
-            eeCoreType: Int32(eeCoreType),
-            mtvu: mtvu,
-            enableCheats: enableCheats,
-            enablePatches: enablePatches,
-            enableGameFixes: enableGameFixes,
-            enableGameDBHardwareFixes: enableGameDBHardwareFixes
-        )
+        let normalizedSkipDraw = normalizedSkipDrawValues()
+        if skipDrawStart != normalizedSkipDraw.start {
+            skipDrawStart = normalizedSkipDraw.start
+        }
+        if skipDrawEnd != normalizedSkipDraw.end {
+            skipDrawEnd = normalizedSkipDraw.end
+        }
+
+        if savesToRunningGame {
+            ARMSX2Bridge.setGameSettingsForCurrentGame(
+                enabled: enabled,
+                upscaleMultiplier: upscaleMultiplier,
+                aspectRatio: aspectRatio,
+                textureFiltering: Int32(textureFiltering),
+                hardwareMipmapping: hardwareMipmapping,
+                blendingAccuracy: Int32(blendingAccuracy),
+                interlaceMode: Int32(interlaceMode),
+                trilinearFiltering: Int32(trilinearFiltering),
+                halfPixelOffset: Int32(halfPixelOffset),
+                roundSprite: Int32(roundSprite),
+                alignSpriteOverride: alignSpriteOverride,
+                alignSprite: alignSprite,
+                mergeSpriteOverride: mergeSpriteOverride,
+                mergeSprite: mergeSprite,
+                wildArmsOffsetOverride: wildArmsOffsetOverride,
+                wildArmsOffset: wildArmsOffset,
+                textureOffsetXOverride: textureOffsetXOverride,
+                textureOffsetX: Int32(textureOffsetX),
+                textureOffsetYOverride: textureOffsetYOverride,
+                textureOffsetY: Int32(textureOffsetY),
+                skipDrawStartOverride: skipDrawStartOverride,
+                skipDrawStart: Int32(normalizedSkipDraw.start),
+                skipDrawEndOverride: skipDrawEndOverride,
+                skipDrawEnd: Int32(normalizedSkipDraw.end),
+                eeCoreType: Int32(eeCoreType),
+                mtvu: mtvu,
+                enableCheats: enableCheats,
+                enablePatches: enablePatches,
+                enableGameFixes: enableGameFixes,
+                enableGameDBHardwareFixes: enableGameDBHardwareFixes
+            )
+        } else {
+            ARMSX2Bridge.setGameSettings(
+                forISO: game.name,
+                enabled: enabled,
+                upscaleMultiplier: upscaleMultiplier,
+                aspectRatio: aspectRatio,
+                textureFiltering: Int32(textureFiltering),
+                hardwareMipmapping: hardwareMipmapping,
+                blendingAccuracy: Int32(blendingAccuracy),
+                interlaceMode: Int32(interlaceMode),
+                trilinearFiltering: Int32(trilinearFiltering),
+                halfPixelOffset: Int32(halfPixelOffset),
+                roundSprite: Int32(roundSprite),
+                alignSpriteOverride: alignSpriteOverride,
+                alignSprite: alignSprite,
+                mergeSpriteOverride: mergeSpriteOverride,
+                mergeSprite: mergeSprite,
+                wildArmsOffsetOverride: wildArmsOffsetOverride,
+                wildArmsOffset: wildArmsOffset,
+                textureOffsetXOverride: textureOffsetXOverride,
+                textureOffsetX: Int32(textureOffsetX),
+                textureOffsetYOverride: textureOffsetYOverride,
+                textureOffsetY: Int32(textureOffsetY),
+                skipDrawStartOverride: skipDrawStartOverride,
+                skipDrawStart: Int32(normalizedSkipDraw.start),
+                skipDrawEndOverride: skipDrawEndOverride,
+                skipDrawEnd: Int32(normalizedSkipDraw.end),
+                eeCoreType: Int32(eeCoreType),
+                mtvu: mtvu,
+                enableCheats: enableCheats,
+                enablePatches: enablePatches,
+                enableGameFixes: enableGameFixes,
+                enableGameDBHardwareFixes: enableGameDBHardwareFixes
+            )
+        }
         statusMessage = enabled ? "\(settings.localized("Saved for")) \(game.metadata["serial"] ?? game.name). \(settings.localized("Reset or relaunch the game to apply."))" : settings.localized("Per-game overrides cleared.")
+    }
+
+    private func normalizeSkipDrawRangeIfNeeded() {
+        let normalized = normalizedSkipDrawValues()
+        if skipDrawStart != normalized.start {
+            skipDrawStart = normalized.start
+        }
+        if skipDrawEnd != normalized.end {
+            skipDrawEnd = normalized.end
+        }
+    }
+
+    private func normalizedSkipDrawValues() -> (start: Int, end: Int) {
+        let start = Self.clampedSkipDraw(skipDrawStart)
+        let end = Self.normalizedSkipDrawEnd(
+            start: start,
+            end: skipDrawEnd,
+            startOverride: skipDrawStartOverride,
+            endOverride: skipDrawEndOverride
+        )
+        return (start, end)
     }
 
     private static func normalizedAspect(_ value: String?) -> String {
@@ -1421,6 +1737,22 @@ struct PerGameSettingsPanel: View {
             return number.floatValue
         }
         return defaultValue
+    }
+
+    private static func clampedTextureOffset(_ offset: Int) -> Int {
+        min(max(offset, SettingsStore.textureOffsetRange.lowerBound), SettingsStore.textureOffsetRange.upperBound)
+    }
+
+    private static func clampedSkipDraw(_ value: Int) -> Int {
+        min(max(value, SettingsStore.skipDrawRange.lowerBound), SettingsStore.skipDrawRange.upperBound)
+    }
+
+    private static func normalizedSkipDrawEnd(start: Int, end: Int, startOverride: Bool, endOverride: Bool) -> Int {
+        let clampedEnd = clampedSkipDraw(end)
+        guard startOverride && endOverride else {
+            return clampedEnd
+        }
+        return SettingsStore.normalizedSkipDrawEnd(start: start, end: clampedEnd)
     }
 }
 

--- a/app/src/main/swift/Views/GameScreenView.swift
+++ b/app/src/main/swift/Views/GameScreenView.swift
@@ -44,6 +44,7 @@ struct GameScreenView: View {
     @State private var showPadLayoutEditor = false
     @State private var showResetConfirmation = false
     @State private var runtimePerGameSettingsEntry: ISOEntry?
+    @State private var runtimePerGameSettings: [String: Any]?
     @State private var compatibilityPresetKey = "off"
     @State private var compatibilityIdentity = ""
     @State private var compatibilityAutoPresets = true
@@ -134,11 +135,12 @@ struct GameScreenView: View {
         .overlay(alignment: .bottom) {
             saveStateToast
         }
-        .overlay {
-            if showPerGameSettings {
-                runtimePerGameSettingsOverlay
-                    .transition(.opacity)
-            }
+        .sheet(isPresented: $showPerGameSettings) {
+            runtimePerGameSettingsContent
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+                .presentationBackground(.regularMaterial)
+                .presentationCornerRadius(34)
         }
         .alert(settings.localized("Reset ROM?"), isPresented: $showResetConfirmation) {
             Button(settings.localized("Cancel"), role: .cancel) {}
@@ -393,7 +395,7 @@ struct GameScreenView: View {
     @ViewBuilder
     private var runtimePerGameSettingsContent: some View {
         if let runtimePerGameSettingsEntry {
-            PerGameSettingsPanel(game: runtimePerGameSettingsEntry) {
+            PerGameSettingsPanel(game: runtimePerGameSettingsEntry, preloadedSettings: runtimePerGameSettings, savesToRunningGame: true) {
                 closePerGameSettingsOverlay()
             }
         } else {
@@ -415,25 +417,6 @@ struct GameScreenView: View {
         }
     }
 
-    private var runtimePerGameSettingsOverlay: some View {
-        GeometryReader { geo in
-            let isLandscape = geo.size.width > geo.size.height
-
-            ZStack {
-                Color.black.opacity(0.42)
-                    .ignoresSafeArea()
-
-                runtimePerGameSettingsContent
-                    .frame(maxWidth: isLandscape ? 760 : .infinity, maxHeight: isLandscape ? 560 : .infinity)
-                    .background(Color(.systemBackground), in: RoundedRectangle(cornerRadius: 34, style: .continuous))
-                    .clipShape(RoundedRectangle(cornerRadius: 34, style: .continuous))
-                    .shadow(color: .black.opacity(0.35), radius: 24, y: 12)
-                    .padding(.horizontal, isLandscape ? 28 : 12)
-                    .padding(.vertical, isLandscape ? 18 : 8)
-            }
-        }
-    }
-
     private func refreshRuntimeMenuState() {
         let vmRunning = ARMSX2Bridge.isVMRunning()
         let gameReady = ARMSX2Bridge.hasValidSaveStateGame()
@@ -447,29 +430,43 @@ struct GameScreenView: View {
     }
 
     private func openPerGameSettingsForCurrentGame() {
-        guard let entry = makeRuntimePerGameSettingsEntry() else {
+        // Load the running game's settings through the VM-safe bridge path (no disc-image
+        // scan) and build a lightweight entry from data the VM already holds, so opening
+        // the panel does not disturb audio/loading on the active game.
+        guard let gameName = currentRuntimeGameName(),
+              let info = ARMSX2Bridge.gameSettingsForCurrentGame() else {
             runtimePerGameSettingsEntry = nil
-            showPerGameSettings = true
+            runtimePerGameSettings = nil
+            withAnimation(.spring(response: 0.32, dampingFraction: 0.88)) {
+                showPerGameSettings = true
+            }
             presentImportantSaveStateStatus(settings.localized("Per-game settings need a running game."))
             return
         }
 
-        runtimePerGameSettingsEntry = entry
-        showPerGameSettings = true
+        let serial = (info["serial"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        runtimePerGameSettingsEntry = ISOEntry(
+            name: gameName,
+            fileURL: nil,
+            coverURL: nil,
+            coverSignature: nil,
+            metadata: serial.isEmpty ? [:] : ["serial": serial],
+            size: 0,
+            isFavorite: false
+        )
+        runtimePerGameSettings = info
+        withAnimation(.spring(response: 0.32, dampingFraction: 0.88)) {
+            showPerGameSettings = true
+        }
     }
 
     private func closePerGameSettingsOverlay() {
-        runtimePerGameSettingsEntry = nil
-        showPerGameSettings = false
-        refreshRuntimeMenuState()
-        ARMSX2Bridge.setFullScreen(fullScreen)
-        ARMSX2Bridge.prepareGameRenderViewForCurrentRenderer()
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
-            ARMSX2Bridge.setFullScreen(fullScreen)
-            ARMSX2Bridge.prepareGameRenderViewForCurrentRenderer()
-            refreshRuntimeMenuState()
+        withAnimation(.easeInOut(duration: 0.2)) {
+            showPerGameSettings = false
         }
+        runtimePerGameSettingsEntry = nil
+        runtimePerGameSettings = nil
+        refreshRuntimeMenuState()
     }
 
     private func updateRuntimeOverlayPause() {
@@ -480,34 +477,6 @@ struct GameScreenView: View {
         if ARMSX2Bridge.isVMRunning() {
             ARMSX2Bridge.setVMPaused(shouldPause)
         }
-    }
-
-    private func makeRuntimePerGameSettingsEntry() -> ISOEntry? {
-        guard let gameName = currentRuntimeGameName() else {
-            return nil
-        }
-
-        let isoDir = ARMSX2Bridge.isoDirectory()
-        let docsDir = ARMSX2Bridge.documentsDirectory()
-        let fm = FileManager.default
-        var path = (isoDir as NSString).appendingPathComponent(gameName)
-        if !fm.fileExists(atPath: path) {
-            path = (docsDir as NSString).appendingPathComponent(gameName)
-        }
-
-        let fileURL = fm.fileExists(atPath: path) ? URL(fileURLWithPath: path) : nil
-        let attrs = try? fm.attributesOfItem(atPath: path)
-        let size = attrs?[.size] as? UInt64 ?? 0
-        let metadata = ARMSX2Bridge.gameMetadata(forISO: gameName)
-        return ISOEntry(
-            name: gameName,
-            fileURL: fileURL,
-            coverURL: nil,
-            coverSignature: nil,
-            metadata: metadata,
-            size: size,
-            isFavorite: ARMSX2Bridge.isFavorite(gameName)
-        )
     }
 
     private func currentRuntimeGameName() -> String? {

--- a/app/src/main/swift/Views/HelpView.swift
+++ b/app/src/main/swift/Views/HelpView.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 import SwiftUI
+import UIKit
 
 struct HelpSection: Identifiable {
     let id = UUID()
@@ -104,6 +105,7 @@ private let helpData: [HelpSection] = [
 
 struct HelpView: View {
     @State private var settings = SettingsStore.shared
+    @State private var copyStatusMessage: String?
 #if targetEnvironment(macCatalyst)
     @State private var selectedTopic: HelpTopic? = .item(section: 0, item: 0)
 #endif
@@ -168,6 +170,16 @@ struct HelpView: View {
                             .foregroundStyle(.secondary)
                             .font(.caption)
                     }
+                    Button {
+                        copyTroubleshootingInfo()
+                    } label: {
+                        Label(settings.localized("Copy Troubleshooting Info"), systemImage: "doc.on.doc")
+                    }
+                    if let copyStatusMessage {
+                        Text(settings.localized(copyStatusMessage))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 } header: {
                     Label(settings.localized("About"), systemImage: "info.circle")
                 }
@@ -212,6 +224,16 @@ struct HelpView: View {
                             .foregroundStyle(.secondary)
                             .font(.caption)
                     }
+                    Button {
+                        copyTroubleshootingInfo()
+                    } label: {
+                        Label(settings.localized("Copy Troubleshooting Info"), systemImage: "doc.on.doc")
+                    }
+                    if let copyStatusMessage {
+                        Text(settings.localized(copyStatusMessage))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
             .navigationTitle(settings.localized("About"))
@@ -228,5 +250,29 @@ struct HelpView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+    }
+
+    private func copyTroubleshootingInfo() {
+        UIPasteboard.general.string = troubleshootingInfoText()
+        copyStatusMessage = "Troubleshooting info copied."
+    }
+
+    private func troubleshootingInfoText() -> String {
+        let bundle = Bundle.main
+        let appName = bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
+            ?? bundle.object(forInfoDictionaryKey: "CFBundleName") as? String
+            ?? "ARMSX2 iOS"
+        let appVersion = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "Unknown"
+        let buildNumber = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "Unknown"
+        let device = UIDevice.current
+
+        return [
+            "App: \(appName)",
+            "Version: \(appVersion)",
+            "Build: \(buildNumber)",
+            "Platform: iOS",
+            "iOS Version: \(device.systemVersion)",
+            "Device Type: \(device.model)"
+        ].joined(separator: "\n")
     }
 }

--- a/app/src/main/swift/Views/RootView.swift
+++ b/app/src/main/swift/Views/RootView.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 import SwiftUI
+import UIKit
 
 struct RootView: View {
     @State private var appState = AppState.shared
@@ -78,26 +79,34 @@ struct MenuTabView: View {
         .tint(.blue)
 #else
         TabView(selection: $selectedTab) {
-            GameListView()
+            SafeAreaProtectedMenuTabContent {
+                GameListView()
+            }
                 .tabItem {
                     Label(settings.localized("Games"), systemImage: "gamecontroller")
                 }
                 .tag(0)
 
-            BIOSListView()
+            SafeAreaProtectedMenuTabContent {
+                BIOSListView()
+            }
                 .tabItem {
                     Label(settings.localized("BIOS"), systemImage: "cpu")
                 }
                 .tag(1)
 
-            HelpView()
+            SafeAreaProtectedMenuTabContent {
+                HelpView()
+            }
                 .tabItem {
                     Label(settings.localized("Help"), systemImage: "questionmark.circle")
                 }
                 .tag(2)
 
-            NavigationStack {
-                SettingsRootView()
+            SafeAreaProtectedMenuTabContent {
+                NavigationStack {
+                    SettingsRootView()
+                }
             }
             .tabItem {
                 Label(settings.localized("Settings"), systemImage: "gearshape")
@@ -106,6 +115,84 @@ struct MenuTabView: View {
         }
         .tint(.blue)
 #endif
+    }
+}
+
+@MainActor
+private struct SafeAreaProtectedMenuTabContent<Content: View>: View {
+    @Environment(\.layoutDirection) private var layoutDirection
+    @State private var safeAreaInsets = KeyWindowSafeArea.horizontalInsets()
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        // SwiftUI's GeometryReader safe-area insets are unreliable inside a TabView
+        // page (the left/right notch/Dynamic Island insets read as zero in landscape),
+        // so read the real key-window insets instead and use the geometry size only as
+        // a reliable signal to recompute them on rotation. This keeps normal app tab
+        // content clear of the notch without touching gameplay or overlay surfaces.
+        GeometryReader { geometry in
+            let insets = NormalTabContentMargin.effectiveHorizontalInsets(
+                raw: safeAreaInsets,
+                isLandscape: geometry.size.width > geometry.size.height,
+                idiom: UIDevice.current.userInterfaceIdiom
+            )
+            content
+                .padding(.leading, layoutDirection == .rightToLeft ? insets.right : insets.left)
+                .padding(.trailing, layoutDirection == .rightToLeft ? insets.left : insets.right)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .onChange(of: geometry.size) { _, _ in
+                    safeAreaInsets = KeyWindowSafeArea.horizontalInsets()
+                }
+        }
+        .onAppear {
+            safeAreaInsets = KeyWindowSafeArea.horizontalInsets()
+        }
+    }
+}
+
+/// Reads the real left/right safe-area insets from the active key window. Used because
+/// SwiftUI-reported horizontal safe-area insets are unreliable inside a TabView page.
+private enum KeyWindowSafeArea {
+    @MainActor
+    static func horizontalInsets() -> (left: CGFloat, right: CGFloat) {
+        let insets = keyWindowInsets()
+        return (insets.left, insets.right)
+    }
+
+    @MainActor
+    private static func keyWindowInsets() -> UIEdgeInsets {
+        for case let scene as UIWindowScene in UIApplication.shared.connectedScenes {
+            guard scene.activationState == .foregroundActive || scene.activationState == .foregroundInactive else { continue }
+            if let window = scene.windows.first(where: { $0.isKeyWindow }) ?? scene.windows.first {
+                return window.safeAreaInsets
+            }
+        }
+        return .zero
+    }
+}
+
+/// Adds a small readable horizontal margin for normal app tabs in iPhone landscape.
+///
+/// The raw key-window safe-area insets only clear the hardware cutout (notch / Dynamic
+/// Island / sensor housing) by the minimum amount, which still leaves tab content cramped
+/// against the cutout in landscape. This applies a small minimum content margin on each
+/// side so Games, BIOS, Help, and Settings sit in a balanced, readable column. Portrait and
+/// iPad keep the raw insets unchanged, and gameplay surfaces never use this helper.
+private enum NormalTabContentMargin {
+    /// Minimum horizontal content margin for normal app tabs on an iPhone in landscape.
+    static let minimumLandscapeMargin: CGFloat = 20
+
+    static func effectiveHorizontalInsets(
+        raw: (left: CGFloat, right: CGFloat),
+        isLandscape: Bool,
+        idiom: UIUserInterfaceIdiom
+    ) -> (left: CGFloat, right: CGFloat) {
+        guard isLandscape, idiom == .phone else { return raw }
+        return (max(raw.left, minimumLandscapeMargin), max(raw.right, minimumLandscapeMargin))
     }
 }
 

--- a/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
+++ b/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
@@ -6,6 +6,29 @@ import SwiftUI
 struct GraphicsSettingsView: View {
     @State private var settings = SettingsStore.shared
 
+    private var manualAdvancedHacks: Bool {
+        !settings.enableGameDBHardwareFixes
+    }
+
+    private var skipDrawStartBinding: Binding<Int> {
+        Binding(
+            get: { settings.skipDrawStart },
+            set: { newValue in
+                settings.skipDrawStart = min(max(newValue, SettingsStore.skipDrawRange.lowerBound), SettingsStore.skipDrawRange.upperBound)
+                settings.skipDrawEnd = SettingsStore.normalizedSkipDrawEnd(start: settings.skipDrawStart, end: settings.skipDrawEnd)
+            }
+        )
+    }
+
+    private var skipDrawEndBinding: Binding<Int> {
+        Binding(
+            get: { settings.skipDrawEnd },
+            set: { newValue in
+                settings.skipDrawEnd = SettingsStore.normalizedSkipDrawEnd(start: settings.skipDrawStart, end: newValue)
+            }
+        )
+    }
+
     var body: some View {
         Form {
             Section(settings.localized("Renderer")) {
@@ -25,6 +48,13 @@ struct GraphicsSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
 #endif
+#if !targetEnvironment(macCatalyst)
+                if settings.renderer == 11 {
+                    Text(settings.localized("Null renderer may show no video output or a black screen. It is mainly useful for testing. Switch back to Metal and restart if selected by mistake."))
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+#endif
             }
 
             Section(settings.localized("Upscaling")) {
@@ -43,6 +73,11 @@ struct GraphicsSettingsView: View {
                 Text(settings.localized("Lower values can help performance on heavy games. Higher values improve visual quality but reduce performance significantly. Requires restart."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                if settings.upscaleMultiplier >= 4.0 {
+                    Text(settings.localized("4x and higher can cause poor performance, heat, stutter, or instability on iPhone and iPad."))
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
             }
 
             Section(settings.localized("Filtering")) {
@@ -125,9 +160,67 @@ struct GraphicsSettingsView: View {
                 }
             }
 
+            Section(settings.localized("Advanced Upscaling Hacks")) {
+                Toggle(settings.localized("Manual Advanced Hacks"), isOn: Binding(
+                    get: { manualAdvancedHacks },
+                    set: { settings.enableGameDBHardwareFixes = !$0 }
+                ))
+                Text(settings.localized("GameDB Graphics Fixes are safest for most games. Manual Advanced Hacks disable those automatic graphics fixes and allow the sprite, texture-offset, and Skipdraw values below. Reset/relaunch may be needed."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Picker(settings.localized("Trilinear Filtering"), selection: $settings.trilinearFiltering) {
+                    Text(settings.localized("Automatic / Default")).tag(-1)
+                    Text(settings.localized("Off")).tag(0)
+                    Text("PS2").tag(1)
+                    Text(settings.localized("Forced")).tag(2)
+                }
+                if settings.trilinearFiltering != -1 {
+                    Text(settings.localized("Non-automatic trilinear filtering may break textures in some games."))
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+
+                Picker(settings.localized("Half-pixel Offset"), selection: $settings.halfPixelOffset) {
+                    Text(settings.localized("Off")).tag(0)
+                    Text(settings.localized("Normal / Vertex")).tag(1)
+                    Text(settings.localized("Special / Texture")).tag(2)
+                    Text(settings.localized("Special / Texture Aggressive")).tag(3)
+                    Text(settings.localized("Align to Native")).tag(4)
+                    Text(settings.localized("Align to Native + Texture Offset")).tag(5)
+                }
+                .disabled(!manualAdvancedHacks)
+
+                Picker(settings.localized("Round Sprite"), selection: $settings.roundSprite) {
+                    Text(settings.localized("Off")).tag(0)
+                    Text(settings.localized("Half")).tag(1)
+                    Text(settings.localized("Full")).tag(2)
+                }
+                .disabled(!manualAdvancedHacks)
+
+                Toggle(settings.localized("Align Sprite"), isOn: $settings.alignSprite)
+                    .disabled(!manualAdvancedHacks)
+                Toggle(settings.localized("Merge Sprite"), isOn: $settings.mergeSprite)
+                    .disabled(!manualAdvancedHacks)
+                Toggle(settings.localized("Wild Arms Offset"), isOn: $settings.wildArmsOffset)
+                    .disabled(!manualAdvancedHacks)
+
+                ClampedIntField(title: settings.localized("Texture Offset X"), value: $settings.textureOffsetX, range: SettingsStore.textureOffsetRange, isEnabled: manualAdvancedHacks)
+                ClampedIntField(title: settings.localized("Texture Offset Y"), value: $settings.textureOffsetY, range: SettingsStore.textureOffsetRange, isEnabled: manualAdvancedHacks)
+                Text(settings.localized("Texture offsets are advanced troubleshooting values. Type a value and clamp to range. Default is 0."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                ClampedIntField(title: settings.localized("Skipdraw Start"), value: skipDrawStartBinding, range: SettingsStore.skipDrawRange, isEnabled: manualAdvancedHacks)
+                ClampedIntField(title: settings.localized("Skipdraw End"), value: skipDrawEndBinding, range: SettingsStore.skipDrawRange, isEnabled: manualAdvancedHacks)
+                Text(settings.localized("For Skipdraw 1, use Start 1 and End 1. Changes apply after reset/relaunch."))
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+
             Section(settings.localized("Texture Replacement")) {
                 Toggle(settings.localized("Load Replacement Textures"), isOn: $settings.loadTextureReplacements)
-                Text(settings.localized("Loads PNG or DDS texture packs from Documents/textures/[Game Serial]/replacements/. Requires restart."))
+                Text(settings.localized("Loads PNG or DDS texture packs from Documents/textures/[Game Serial]/replacements/. Texture packs use app storage and may be large. Requires restart."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
@@ -151,13 +244,23 @@ struct GraphicsSettingsView: View {
                 Text(settings.localized("Core texture preloading mode. Full can improve replacement behavior but may increase memory use."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                if settings.loadTextureReplacements && (settings.precacheTextureReplacements || settings.texturePreloading > 0) {
+                    Text(settings.localized("Large texture packs can use a lot of RAM when preload/precache is active and may cause stalls or crashes."))
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
             }
 
             Section(settings.localized("Texture Dumping")) {
                 Toggle(settings.localized("Dump Replaceable Textures"), isOn: $settings.dumpReplaceableTextures)
-                Text(settings.localized("Writes discovered textures to Documents/textures/[Game Serial]/dumps/. This can heavily reduce performance."))
+                Text(settings.localized("Writes discovered textures to Documents/textures/[Game Serial]/dumps/. This can heavily reduce performance and grow app storage quickly."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                if settings.dumpReplaceableTextures {
+                    Text(settings.localized("Texture dumping can heavily slow games and create very large dump folders. Turn it off after collecting the textures you need."))
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
 
                 Toggle(settings.localized("Dump Mipmaps"), isOn: $settings.dumpReplaceableMipmaps)
                     .disabled(!settings.dumpReplaceableTextures)
@@ -174,6 +277,11 @@ struct GraphicsSettingsView: View {
                 Text(settings.localized("Higher values reduce frame drops but increase latency."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                if settings.vsyncQueueSize >= 12 {
+                    Text(settings.localized("Large queues can make controls feel delayed and may increase stutter. The default is 8."))
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
             }
 
             Section {
@@ -185,5 +293,45 @@ struct GraphicsSettingsView: View {
         }
         .navigationTitle(settings.localized("Graphics"))
         .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+/// A typeable integer field for advanced/manual hack values. Text is committed when
+/// editing ends: valid input is clamped to `range`, and invalid input reverts to the
+/// last good value so a bad string can never be written or crash the field.
+struct ClampedIntField: View {
+    let title: String
+    @Binding var value: Int
+    let range: ClosedRange<Int>
+    var isEnabled: Bool = true
+
+    @State private var text: String = ""
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        HStack {
+            Text(title)
+            Spacer()
+            TextField("0", text: $text)
+                .keyboardType(.numbersAndPunctuation)
+                .multilineTextAlignment(.trailing)
+                .frame(maxWidth: 110)
+                .focused($focused)
+                .disabled(!isEnabled)
+        }
+        .onAppear { text = String(value) }
+        .onChange(of: value) { _, newValue in
+            if !focused { text = String(newValue) }
+        }
+        .onChange(of: focused) { _, isFocused in
+            if !isFocused { commit() }
+        }
+    }
+
+    private func commit() {
+        if let parsed = Int(text.trimmingCharacters(in: .whitespaces)) {
+            value = min(max(parsed, range.lowerBound), range.upperBound)
+        }
+        text = String(value)
     }
 }


### PR DESCRIPTION
## Summary

This PR is a broad iOS settings and runtime UX update focused on making ARMSX2 easier to tune, safer to troubleshoot, and more practical for per-game compatibility testing.

It improves the iOS Graphics settings, Per-Game Settings, in-game quick-menu behavior, landscape layout, troubleshooting info, and exposes several existing advanced graphics compatibility controls through the iOS UI.

The goal is not to change emulator behavior underneath. The PR exposes and organizes existing settings more clearly, fixes iOS-specific UI/runtime problems, and keeps compatibility/GameDB behavior intact.

---

## Highlights

### Graphics settings UX polish

Improved the iOS Graphics settings with clearer guidance around risky options and compatibility-sensitive settings.

This includes better warnings/help text for:

- high internal resolutions
- Null renderer
- texture preloading / precaching
- texture dumping and replacement storage impact
- large VSync queue sizes
- advanced upscaling/manual hack settings

The settings screen should now be easier to understand for testers and safer for regular users.

---

### Advanced graphics compatibility controls

Added an **Advanced Upscaling Hacks** section on iOS.

New or improved controls include:

- Half-pixel Offset
- Round Sprite
- Align Sprite
- Merge Sprite
- Wild Arms Offset
- Texture Offset X
- Texture Offset Y
- Trilinear Filtering
- Skipdraw Start
- Skipdraw End

These are exposed globally and through Per-Game Settings where appropriate.

Texture Offset X/Y and Skipdraw Start/End are now typeable numeric fields, so testers can enter exact values like `420`, `440`, or `1/1` without hundreds of taps.

---

### Skipdraw support and manual hack gating

Skipdraw Start/End are now exposed in the iOS UI for games that need draw-call skipping to hide broken post-processing, fog, overlay, or effect layers.

The UI now explains and enforces the important manual-hack gate:

- Use Per-Game Overrides must be ON
- GameDB Graphics Fixes must be OFF
- Save, then reset/relaunch the game

This avoids the confusing case where Skipdraw values are saved correctly but ignored by the core because manual hardware hacks are masked while GameDB fixes are enabled.

Skipdraw ranges are also normalized in the UI. For example, `Start=1, End=0` is corrected to `Start=1, End=1`, matching the expected “Skipdraw 1” behavior.

No renderer reset or live-apply behavior was added.

---

### Per-game settings polish

Per-Game Settings were cleaned up visually and behaviorally.

Improvements include:

- more polished library presentation
- cleaner runtime/in-game presentation
- clearer Save / Done wording
- better per-game advanced hack organization
- typeable Texture Offset and Skipdraw fields
- clearer guidance about reset/relaunch behavior
- per-game “Use Global” / override behavior preserved

Per-game advanced settings remain separate from automatic GameDB fixes.

---

### Runtime Per-Game Settings fixes

Fixed multiple runtime side effects when opening or saving Per-Game Settings from the in-game quick menu.

Previously, runtime Per-Game Settings could scan the active disc image while the VM was running. This could interfere with loading or streamed background music.

This PR changes the runtime path to use the running game identity already available from the VM:

- runtime open uses VM-safe current-game settings
- runtime save uses VMManager serial/CRC
- runtime save avoids disc rescans
- Done only dismisses/clears runtime state
- library Per-Game Settings still uses the normal ISO/library path

This keeps runtime Per-Game Settings safer while preserving existing library behavior.

---

### iPhone landscape layout improvements

Improved landscape layout for the normal app tabs on iPhone.

Covered tabs:

- Games
- BIOS
- Help
- Settings

The app now applies a polished landscape content margin so cards, labels, lists, and settings text do not sit underneath or directly against the notch/Dynamic Island/sensor area.

Both landscape orientations are handled.

Gameplay rendering, the Metal view, Virtual Pad, and full-screen gameplay overlays are intentionally untouched.

---

### Copyable troubleshooting info

Added **Copy Troubleshooting Info** under Help > About.

This copies basic privacy-safe diagnostic info such as:

- app name
- version
- build
- platform
- iOS version
- device type

It does not include game names, BIOS names, file paths, save data, controller names, logs, or personal identifiers.

---

## Behavior intentionally unchanged

This PR does not change:

- emulator-core behavior
- renderer internals
- audio internals
- GameDB policy
- Metal callback policy
- compatibility preset behavior
- saved setting key names
- existing defaults
- signing/build workflow files in the PR branch

The fork-local IPA workflow is not included in this PR branch.


