### PR TITLE
iOS: refresh 2.0 runtime polish pr

### DIFF
--- a/app/src/main/cpp/ARMSX2Bridge.h
+++ b/app/src/main/cpp/ARMSX2Bridge.h
@@ -86,6 +86,7 @@ typedef void (^ARMSX2RetroAchievementsCompletion)(BOOL success, NSString * _Nonn
 + (void)requestVMStop;
 + (void)setVMPaused:(BOOL)paused;
 + (void)setFullScreen:(BOOL)enabled;
++ (BOOL)isSDLFullscreen;
 
 // Info
 + (nonnull NSString *)biosName;

--- a/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/app/src/main/cpp/ARMSX2Bridge.mm
@@ -6,6 +6,7 @@
 #include <SDL3/SDL.h>
 
 extern "C" void ARMSX2_SetSDLFullscreen(bool enabled);
+extern "C" bool ARMSX2_IsSDLFullscreen();
 #include "Common.h"
 #include "CDVD/CDVD.h"
 #include "CDVD/CDVDcommon.h"
@@ -1760,6 +1761,10 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
 
 + (void)setFullScreen:(BOOL)enabled {
     ARMSX2_SetSDLFullscreen(enabled ? true : false);
+}
+
++ (BOOL)isSDLFullscreen {
+    return ARMSX2_IsSDLFullscreen() ? YES : NO;
 }
 
 + (nonnull NSString *)buildVersion {

--- a/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/app/src/main/cpp/ARMSX2Bridge.mm
@@ -10,6 +10,7 @@ extern "C" void ARMSX2_SetSDLFullscreen(bool enabled);
 #include "CDVD/CDVD.h"
 #include "CDVD/CDVDcommon.h"
 #include "VMManager.h"
+#include "pcsx2/MTGS.h"
 #include "Patch.h"
 #include "Achievements.h"
 #include "SIO/Pad/Pad.h"
@@ -1249,6 +1250,12 @@ static void ARMSX2ApplyLiveGSIntSetting(const char* section, const char* key, in
         const int clamped = std::clamp(value, 0, static_cast<int>(TexturePreloadingLevel::Full));
         EmuConfig.GS.TexturePreloading = static_cast<TexturePreloadingLevel>(clamped);
         GSConfig.TexturePreloading = static_cast<TexturePreloadingLevel>(clamped);
+    } else if (std::strcmp(key, "UserHacks_SkipDraw_Start") == 0) {
+        EmuConfig.GS.SkipDrawStart = value;
+        GSConfig.SkipDrawStart = value;
+    } else if (std::strcmp(key, "UserHacks_SkipDraw_End") == 0) {
+        EmuConfig.GS.SkipDrawEnd = std::max(EmuConfig.GS.SkipDrawStart, value);
+        GSConfig.SkipDrawEnd = EmuConfig.GS.SkipDrawEnd;
     }
 }
 
@@ -2183,6 +2190,12 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
                                         textureOffsetYOverride, textureOffsetY, skipDrawStartOverride,
                                         skipDrawStart, skipDrawEndOverride, skipDrawEnd, eeCoreType, mtvu,
                                         enableCheats, enablePatches, enableGameFixes, enableGameDBHardwareFixes);
+
+    if (VMManager::HasValidVM()) {
+        VMManager::ReloadGameSettings();
+        if (MTGS::IsOpen())
+            MTGS::ApplySettings();
+    }
 }
 
 + (nonnull NSString *)clearCacheForISO:(nonnull NSString *)isoName {

--- a/app/src/main/cpp/ios_main.mm
+++ b/app/src/main/cpp/ios_main.mm
@@ -2578,6 +2578,12 @@ extern "C" void ARMSX2_SetSDLFullscreen(bool enabled) {
         SDL_SetWindowFullscreen(Host::g_sdl_window, enabled);
 }
 
+extern "C" bool ARMSX2_IsSDLFullscreen() {
+    if (!Host::g_sdl_window)
+        return false;
+    return (SDL_GetWindowFlags(Host::g_sdl_window) & SDL_WINDOW_FULLSCREEN) != 0;
+}
+
 static void ARMSX2EnsureGameRenderViewOnMain(const char* reason) {
     if (g_gameRenderView)
         return;

--- a/app/src/main/cpp/pcsx2/Resources/Info.plist.in
+++ b/app/src/main/cpp/pcsx2/Resources/Info.plist.in
@@ -89,6 +89,8 @@
 	<string>${PCSX2_MICROPHONE_USAGE_DESCRIPTION}</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.games</string>
+	<key>LSSupportsGameMode</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>UTImportedTypeDeclarations</key>

--- a/app/src/main/swift/Models/FileImportHandler.swift
+++ b/app/src/main/swift/Models/FileImportHandler.swift
@@ -303,7 +303,16 @@ final class FileImportHandler: @unchecked Sendable {
                 return .failure(Self.unreadablePNACHImportMessage(for: fileName))
             }
 
-            let normalized = Self.normalizedPNACHText(text)
+            let patchLines = Self.normalizedPNACHPatchLines(from: text)
+            guard patchLines.contains(where: { $0.hasPrefix("patch=") }) else {
+                return .failure(Self.failedPNACHImportMessage(for: fileName, errorDescription: "No valid patch lines found."))
+            }
+
+            var normalized = patchLines.joined(separator: "\n")
+            if !normalized.hasSuffix("\n") {
+                normalized.append("\n")
+            }
+
             try FileManager.default.createDirectory(at: destinationURL.deletingLastPathComponent(), withIntermediateDirectories: true)
             if FileManager.default.fileExists(atPath: destinationURL.path) {
                 try FileManager.default.removeItem(at: destinationURL)
@@ -384,15 +393,21 @@ final class FileImportHandler: @unchecked Sendable {
         return "\(formats.dropLast().joined(separator: ", ")), or \(last)"
     }
 
-    private static func normalizedPNACHText(_ text: String) -> String {
-        var normalized = text
+    private static func normalizedPNACHPatchLines(from text: String) -> [String] {
+        let normalized = text
             .replacingOccurrences(of: "\r\n", with: "\n")
             .replacingOccurrences(of: "\r", with: "\n")
 
-        if !normalized.hasSuffix("\n") {
-            normalized.append("\n")
+        return normalized.components(separatedBy: "\n").compactMap { rawLine in
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            // Skip empty lines
+            guard !line.isEmpty else { return nil }
+            // Skip bracketed section headers like [Cheat Name]
+            if line.count > 2, line.first == "[", line.last == "]" {
+                return nil
+            }
+            // Preserve everything else (patch= lines, comments, gametitle, etc.)
+            return line
         }
-
-        return normalized
     }
 }

--- a/app/src/main/swift/Models/SettingsStore.swift
+++ b/app/src/main/swift/Models/SettingsStore.swift
@@ -255,7 +255,19 @@ final class SettingsStore: @unchecked Sendable {
     var osdPreset: OsdPreset {
         didSet {
             ARMSX2Bridge.setINIInt("ARMSX2iOS/UI", key: "OsdPreset", value: Int32(osdPreset.rawValue))
+            if osdPreset == .off {
+                if oldValue != .off {
+                    lastActiveOsdPreset = oldValue
+                }
+            } else {
+                lastActiveOsdPreset = osdPreset
+            }
             applyOsdPreset(osdPreset)
+        }
+    }
+    var lastActiveOsdPreset: OsdPreset {
+        didSet {
+            ARMSX2Bridge.setINIInt("ARMSX2iOS/UI", key: "LastActiveOsdPreset", value: Int32(lastActiveOsdPreset.rawValue))
         }
     }
     var osdPerformancePosition: Int {
@@ -510,6 +522,12 @@ final class SettingsStore: @unchecked Sendable {
         // OSD
         let loadedOsdPreset = OsdPreset(rawValue: Int(ARMSX2Bridge.getINIInt("ARMSX2iOS/UI", key: "OsdPreset", defaultValue: 0))) ?? .off
         osdPreset = loadedOsdPreset
+        let loadedLastActiveOsdPresetRaw = ARMSX2Bridge.getINIInt("ARMSX2iOS/UI", key: "LastActiveOsdPreset", defaultValue: -1)
+        if loadedLastActiveOsdPresetRaw >= 0 {
+            lastActiveOsdPreset = OsdPreset(rawValue: Int(loadedLastActiveOsdPresetRaw)) ?? .simple
+        } else {
+            lastActiveOsdPreset = loadedOsdPreset != .off ? loadedOsdPreset : .simple
+        }
         osdPerformancePosition = Self.normalizedOsdPerformancePosition(
             Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "OsdPerformancePos", defaultValue: Int32(Self.defaultOsdPerformancePosition)))
         )
@@ -623,6 +641,12 @@ final class SettingsStore: @unchecked Sendable {
         dumpDirectTextures = ARMSX2Bridge.getINIBool("EmuCore/GS", key: "DumpDirectTextures", defaultValue: true)
         dumpPaletteTextures = ARMSX2Bridge.getINIBool("EmuCore/GS", key: "DumpPaletteTextures", defaultValue: true)
         osdPreset = OsdPreset(rawValue: Int(ARMSX2Bridge.getINIInt("ARMSX2iOS/UI", key: "OsdPreset", defaultValue: 0))) ?? .off
+        let loadedLastActiveOsdPresetRaw = ARMSX2Bridge.getINIInt("ARMSX2iOS/UI", key: "LastActiveOsdPreset", defaultValue: -1)
+        if loadedLastActiveOsdPresetRaw >= 0 {
+            lastActiveOsdPreset = OsdPreset(rawValue: Int(loadedLastActiveOsdPresetRaw)) ?? .simple
+        } else {
+            lastActiveOsdPreset = osdPreset != .off ? osdPreset : .simple
+        }
         osdPerformancePosition = Self.normalizedOsdPerformancePosition(
             Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "OsdPerformancePos", defaultValue: Int32(Self.defaultOsdPerformancePosition)))
         )

--- a/app/src/main/swift/Models/SettingsStore.swift
+++ b/app/src/main/swift/Models/SettingsStore.swift
@@ -550,7 +550,7 @@ final class SettingsStore: @unchecked Sendable {
         hapticFeedback = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "HapticFeedback", defaultValue: true)
         virtualPadSkin = VirtualPadSkin(rawValue: Int(ARMSX2Bridge.getINIInt("ARMSX2iOS/UI", key: "VirtualPadSkin", defaultValue: 0))) ?? .armsx2Refresh
         autoHideVirtualPadWhenControllerConnected = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "AutoHideVirtualPadWhenControllerConnected", defaultValue: true)
-        autoFullscreen = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "AutoFullscreen", defaultValue: false)
+        autoFullscreen = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "AutoFullscreen", defaultValue: true)
         hideMenuButton = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "HideMenuButton", defaultValue: false)
         analogStickScale = Self.clampedAnalogStickScale(ARMSX2Bridge.getINIFloat("ARMSX2iOS/UI", key: "AnalogStickScale", defaultValue: 1.0))
         appLanguage = AppLanguage(rawValue: ARMSX2Bridge.getINIString("ARMSX2iOS/UI", key: "AppLanguage", defaultValue: AppLanguage.system.rawValue)) ?? .system
@@ -668,7 +668,7 @@ final class SettingsStore: @unchecked Sendable {
         hapticFeedback = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "HapticFeedback", defaultValue: true)
         virtualPadSkin = VirtualPadSkin(rawValue: Int(ARMSX2Bridge.getINIInt("ARMSX2iOS/UI", key: "VirtualPadSkin", defaultValue: 0))) ?? .armsx2Refresh
         autoHideVirtualPadWhenControllerConnected = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "AutoHideVirtualPadWhenControllerConnected", defaultValue: true)
-        autoFullscreen = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "AutoFullscreen", defaultValue: false)
+        autoFullscreen = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "AutoFullscreen", defaultValue: true)
         hideMenuButton = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "HideMenuButton", defaultValue: false)
         analogStickScale = Self.clampedAnalogStickScale(ARMSX2Bridge.getINIFloat("ARMSX2iOS/UI", key: "AnalogStickScale", defaultValue: 1.0))
         appLanguage = AppLanguage(rawValue: ARMSX2Bridge.getINIString("ARMSX2iOS/UI", key: "AppLanguage", defaultValue: AppLanguage.system.rawValue)) ?? .system

--- a/app/src/main/swift/Models/SwiftUIHost.swift
+++ b/app/src/main/swift/Models/SwiftUIHost.swift
@@ -24,12 +24,23 @@ class ARMSX2HostingController<Content: View>: UIHostingController<Content> {
             name: AppState.systemChromeNeedsUpdateNotification,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(systemChromeNeedsUpdate),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
     }
 
     deinit {
         NotificationCenter.default.removeObserver(
             self,
             name: AppState.systemChromeNeedsUpdateNotification,
+            object: nil
+        )
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIApplication.didBecomeActiveNotification,
             object: nil
         )
     }

--- a/app/src/main/swift/Views/GameScreenView.swift
+++ b/app/src/main/swift/Views/GameScreenView.swift
@@ -26,6 +26,13 @@ let compatibilityPresets: [CompatibilityPreset] = [
     CompatibilityPreset(id: "branches", title: "COP1 + EE Branches/Jumps", systemImage: "arrow.triangle.branch"),
 ]
 
+private struct GameScreenSizePreferenceKey: PreferenceKey {
+    static let defaultValue: CGSize = .zero
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+        value = nextValue()
+    }
+}
+
 struct GameScreenView: View {
     // MARK: - State & Constants
 
@@ -56,6 +63,8 @@ struct GameScreenView: View {
     @State private var runtimeOverlayPauseActive = false
     @State private var previousHideHomeIndicator = false
 
+    @Environment(\.scenePhase) private var scenePhase
+
     private static let briefStatusDisplayDuration: TimeInterval = 2.2
     private static let importantStatusDisplayDuration: TimeInterval = 6.0
 
@@ -65,37 +74,40 @@ struct GameScreenView: View {
         GeometryReader { geo in
             let isLandscape = geo.size.width > geo.size.height
 
-            if isLandscape {
-                // Landscape: full-screen layout so pad coordinates match the layout editor.
-                ZStack {
-                    MetalGameView()
-                    if effectiveVirtualPadVisible {
-                        VirtualControllerView(isLandscape: true)
-                    }
-                    menuButtonOverlay(isLandscape: true)
-                }
-                .ignoresSafeArea()
-            } else {
-                // Portrait: split layout. Full-phone skins are skipped until viewport metadata is parsed.
-                ZStack {
-                    VStack(spacing: 0) {
+            Group {
+                if isLandscape {
+                    // Landscape: full-screen layout so pad coordinates match the layout editor.
+                    ZStack {
                         MetalGameView()
-                            .frame(height: geo.size.height / 2)
                         if effectiveVirtualPadVisible {
-                            VirtualControllerView()
-                                .frame(height: geo.size.height / 2)
-                        } else {
-                            Spacer()
+                            VirtualControllerView(isLandscape: true)
                         }
+                        menuButtonOverlay(isLandscape: true)
                     }
-                    .overlay(alignment: .topTrailing) {
-                        menuButtonOverlay(isLandscape: false)
+                    .ignoresSafeArea()
+                } else {
+                    // Portrait: split layout. Full-phone skins are skipped until viewport metadata is parsed.
+                    ZStack {
+                        VStack(spacing: 0) {
+                            MetalGameView()
+                                .frame(height: geo.size.height / 2)
+                            if effectiveVirtualPadVisible {
+                                VirtualControllerView()
+                                    .frame(height: geo.size.height / 2)
+                            } else {
+                                Spacer()
+                            }
+                        }
+                        .overlay(alignment: .topTrailing) {
+                            menuButtonOverlay(isLandscape: false)
+                        }
                     }
                 }
             }
+            .preference(key: GameScreenSizePreferenceKey.self, value: geo.size)
         }
-        .onChange(of: fullScreen) { _, newValue in
-            ARMSX2Bridge.setFullScreen(newValue)
+        .onPreferenceChange(GameScreenSizePreferenceKey.self) { _ in
+            syncFullscreenStateFromWindow()
         }
         .sheet(isPresented: $showSaveStates) {
             SaveStatesPanel { message, isImportant in
@@ -153,7 +165,8 @@ struct GameScreenView: View {
         }
         .onAppear {
             enterGameplaySystemChromeMode()
-            applyGameScreenPreferences()
+            syncFullscreenStateFromWindow()
+            applyInitialFullscreenPreference()
             refreshExternalControllerConnectionState()
             refreshRuntimeMenuState()
         }
@@ -173,6 +186,11 @@ struct GameScreenView: View {
         .onChange(of: showPNACHImporter) { _, _ in updateRuntimeOverlayPause() }
         .onChange(of: showPadLayoutEditor) { _, _ in updateRuntimeOverlayPause() }
         .onChange(of: showResetConfirmation) { _, _ in updateRuntimeOverlayPause() }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                syncFullscreenStateFromWindow()
+            }
+        }
         .onReceive(NotificationCenter.default.publisher(for: runtimeMenuStateChangedNotification)) { _ in
             refreshRuntimeMenuState()
         }
@@ -227,7 +245,13 @@ struct GameScreenView: View {
             if virtualPadHiddenByController {
                 Text(settings.localized("Hidden while controller is connected"))
             }
-            Toggle(isOn: $fullScreen) {
+            Toggle(isOn: Binding(
+                get: { fullScreen },
+                set: { newValue in
+                    fullScreen = newValue
+                    ARMSX2Bridge.setFullScreen(newValue)
+                }
+            )) {
                 Label(settings.localized("Full Screen"), systemImage: "arrow.up.left.and.arrow.down.right")
             }
             Toggle(isOn: Binding(
@@ -560,11 +584,18 @@ struct GameScreenView: View {
         appState.hideHomeIndicator = previousHideHomeIndicator
     }
 
-    private func applyGameScreenPreferences() {
+    private func applyInitialFullscreenPreference() {
         menuButtonHidden = settings.hideMenuButton
-        if settings.autoFullscreen {
+        if settings.autoFullscreen && !ARMSX2Bridge.isSDLFullscreen() {
             fullScreen = true
             ARMSX2Bridge.setFullScreen(true)
+        }
+    }
+
+    private func syncFullscreenStateFromWindow() {
+        let sdlFullscreen = ARMSX2Bridge.isSDLFullscreen()
+        if fullScreen != sdlFullscreen {
+            fullScreen = sdlFullscreen
         }
     }
 

--- a/app/src/main/swift/Views/GameScreenView.swift
+++ b/app/src/main/swift/Views/GameScreenView.swift
@@ -211,7 +211,7 @@ struct GameScreenView: View {
                 get: { settings.osdPreset != .off },
                 set: { newValue in
                     if newValue {
-                        settings.osdPreset = .simple
+                        settings.osdPreset = settings.lastActiveOsdPreset
                         ARMSX2Bridge.setPerformanceOverlayVisible(true)
                     } else {
                         settings.osdPreset = .off

--- a/app/src/main/swift/Views/GameScreenView.swift
+++ b/app/src/main/swift/Views/GameScreenView.swift
@@ -27,6 +27,8 @@ let compatibilityPresets: [CompatibilityPreset] = [
 ]
 
 struct GameScreenView: View {
+    // MARK: - State & Constants
+
     @State private var appState = AppState.shared
     @State private var settings = SettingsStore.shared
     @State private var fileImporter = FileImportHandler.shared
@@ -48,34 +50,33 @@ struct GameScreenView: View {
     @State private var compatibilityPresetKey = "off"
     @State private var compatibilityIdentity = ""
     @State private var compatibilityAutoPresets = true
-    @State private var saveStateStatus: String? = nil
-    @State private var saveStateStatusGeneration = 0
+    @State private var statusMessage: String? = nil
+    @State private var statusMessageGeneration = 0
+    @State private var statusMessageDismissTask: Task<Void, Never>?
     @State private var runtimeOverlayPauseActive = false
     @State private var previousHideHomeIndicator = false
 
     private static let briefStatusDisplayDuration: TimeInterval = 2.2
     private static let importantStatusDisplayDuration: TimeInterval = 6.0
 
+    // MARK: - Body
+
     var body: some View {
         GeometryReader { geo in
             let isLandscape = geo.size.width > geo.size.height
 
             if isLandscape {
-                // Landscape: always use full screen area for Metal + pad
-                // so that pad coordinates match the layout editor exactly.
+                // Landscape: full-screen layout so pad coordinates match the layout editor.
                 ZStack {
                     MetalGameView()
                     if effectiveVirtualPadVisible {
                         VirtualControllerView(isLandscape: true)
                     }
-                    menuOverlay(isLandscape: true)
+                    menuButtonOverlay(isLandscape: true)
                 }
-                .ignoresSafeArea()  // Always fullscreen layout in landscape
+                .ignoresSafeArea()
             } else {
-                // Portrait: Metal top half, pad bottom half. Full-phone Manic
-                // skins are intentionally not drawn here until their info.json
-                // viewport metadata is parsed, otherwise they crop/stretch over
-                // gameplay and make the touch zones look wrong.
+                // Portrait: split layout. Full-phone skins are skipped until viewport metadata is parsed.
                 ZStack {
                     VStack(spacing: 0) {
                         MetalGameView()
@@ -88,7 +89,7 @@ struct GameScreenView: View {
                         }
                     }
                     .overlay(alignment: .topTrailing) {
-                        menuOverlay(isLandscape: false)
+                        menuButtonOverlay(isLandscape: false)
                     }
                 }
             }
@@ -98,7 +99,7 @@ struct GameScreenView: View {
         }
         .sheet(isPresented: $showSaveStates) {
             SaveStatesPanel { message, isImportant in
-                presentSaveStateStatus(
+                presentStatusMessage(
                     message,
                     displayDuration: isImportant ? Self.importantStatusDisplayDuration : Self.briefStatusDisplayDuration
                 )
@@ -133,7 +134,7 @@ struct GameScreenView: View {
             }
         }
         .overlay(alignment: .bottom) {
-            saveStateToast
+            statusToastOverlay
         }
         .sheet(isPresented: $showPerGameSettings) {
             runtimePerGameSettingsContent
@@ -157,6 +158,7 @@ struct GameScreenView: View {
             refreshRuntimeMenuState()
         }
         .onDisappear {
+            statusMessageDismissTask?.cancel()
             leaveGameplaySystemChromeMode()
         }
         .simultaneousGesture(
@@ -170,6 +172,7 @@ struct GameScreenView: View {
         .onChange(of: showPerGameSettings) { _, _ in updateRuntimeOverlayPause() }
         .onChange(of: showPNACHImporter) { _, _ in updateRuntimeOverlayPause() }
         .onChange(of: showPadLayoutEditor) { _, _ in updateRuntimeOverlayPause() }
+        .onChange(of: showResetConfirmation) { _, _ in updateRuntimeOverlayPause() }
         .onReceive(NotificationCenter.default.publisher(for: runtimeMenuStateChangedNotification)) { _ in
             refreshRuntimeMenuState()
         }
@@ -185,22 +188,15 @@ struct GameScreenView: View {
         .persistentSystemOverlays(.hidden)
     }
 
-    private func enterGameplaySystemChromeMode() {
-        previousHideHomeIndicator = appState.hideHomeIndicator
-        appState.hideHomeIndicator = true
-    }
-
-    private func leaveGameplaySystemChromeMode() {
-        appState.hideHomeIndicator = previousHideHomeIndicator
-    }
+    // MARK: - Layout Views
 
     @ViewBuilder
-    private func menuOverlay(isLandscape: Bool) -> some View {
+    private func menuButtonOverlay(isLandscape: Bool) -> some View {
         if !menuButtonHidden {
             VStack {
                 HStack {
                     Spacer()
-                    menuButton(isLandscape: isLandscape)
+                    menuButton()
                 }
                 .padding(.top, isLandscape ? 8 : 4)
                 .padding(.trailing, isLandscape ? 8 : 4)
@@ -209,7 +205,7 @@ struct GameScreenView: View {
         }
     }
 
-    private func menuButton(isLandscape: Bool) -> some View {
+    private func menuButton() -> some View {
         Menu {
             Toggle(isOn: Binding(
                 get: { settings.osdPreset != .off },
@@ -240,7 +236,7 @@ struct GameScreenView: View {
                     settings.hideMenuButton = newValue
                     menuButtonHidden = newValue
                     if newValue {
-                        presentSaveStateStatus(settings.localized("Double-tap empty gameplay space to show the menu button again."))
+                        presentStatusMessage(settings.localized("Double-tap empty gameplay space to show the menu button again."))
                     }
                 }
             )) {
@@ -304,44 +300,7 @@ struct GameScreenView: View {
             }
 
             if vmMenuAvailable {
-                Menu {
-                    Button {
-                        ejectDisc()
-                    } label: {
-                        Label(settings.localized("Eject Disc"), systemImage: "eject")
-                    }
-
-                    let discs = availableDiscSwapNames
-                    if discs.isEmpty {
-                        Text(settings.localized("No disc images found"))
-                    } else {
-                        Menu {
-                            ForEach(discs, id: \.self) { discName in
-                                Button {
-                                    changeDisc(to: discName)
-                                } label: {
-                                    Label(discName, systemImage: "opticaldisc")
-                                }
-                            }
-                        } label: {
-                            Label(settings.localized("Insert Disc (No Reboot)"), systemImage: "tray.and.arrow.down")
-                        }
-
-                        Menu {
-                            ForEach(discs, id: \.self) { discName in
-                                Button {
-                                    restartWithDisc(discName)
-                                } label: {
-                                    Label(discName, systemImage: "arrow.clockwise.circle")
-                                }
-                            }
-                        } label: {
-                            Label(settings.localized("Restart With Disc"), systemImage: "arrow.clockwise.circle")
-                        }
-                    }
-                } label: {
-                    Label(settings.localized("Change Disc"), systemImage: "opticaldisc")
-                }
+                discSwapMenu
             }
 
             if gameMenuAvailable {
@@ -382,34 +341,186 @@ struct GameScreenView: View {
         }
     }
 
-    private func applyGameScreenPreferences() {
-        menuButtonHidden = settings.hideMenuButton
-        if settings.autoFullscreen {
-            fullScreen = true
-            ARMSX2Bridge.setFullScreen(true)
+    private var discSwapMenu: some View {
+        Menu {
+            Button {
+                ejectDisc()
+            } label: {
+                Label(settings.localized("Eject Disc"), systemImage: "eject")
+            }
+
+            let discs = availableDiscSwapNames
+            if discs.isEmpty {
+                Text(settings.localized("No disc images found"))
+            } else {
+                Menu {
+                    ForEach(discs, id: \.self) { discName in
+                        Button {
+                            changeDisc(to: discName)
+                        } label: {
+                            Label(discName, systemImage: "opticaldisc")
+                        }
+                    }
+                } label: {
+                    Label(settings.localized("Insert Disc (No Reboot)"), systemImage: "tray.and.arrow.down")
+                }
+
+                Menu {
+                    ForEach(discs, id: \.self) { discName in
+                        Button {
+                            restartWithDisc(discName)
+                        } label: {
+                            Label(discName, systemImage: "arrow.clockwise.circle")
+                        }
+                    }
+                } label: {
+                    Label(settings.localized("Restart With Disc"), systemImage: "arrow.clockwise.circle")
+                }
+            }
+        } label: {
+            Label(settings.localized("Change Disc"), systemImage: "opticaldisc")
         }
     }
 
-    private func restoreMenuButtonIfHidden() {
-        guard menuButtonHidden else { return }
+    // MARK: - Runtime Panels
 
-        menuButtonHidden = false
-        settings.hideMenuButton = false
-        presentSaveStateStatus(settings.localized("Menu button shown"))
+    private var compatibilityLabPanel: some View {
+        NavigationStack {
+            Form {
+                compatibilityStatusSection
+                compatibilityResetSection
+                compatibilityFlagsSection
+                if !compatibilityIdentity.isEmpty {
+                    compatibilityForgetSection
+                }
+            }
+            .navigationTitle(settings.localized("Compatibility Lab"))
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(settings.localized("Done")) {
+                        showCompatibilityLab = false
+                    }
+                }
+            }
+            .onAppear(perform: refreshCompatibilityState)
+        }
     }
 
-    private var effectiveVirtualPadVisible: Bool {
-        userVirtualPadVisible && (!settings.autoHideVirtualPadWhenControllerConnected || !externalControllerConnected)
+    private var compatibilityStatusSection: some View {
+        let currentPreset = compatibilityPreset(for: compatibilityPresetKey)
+        return Section {
+            Toggle(isOn: Binding(
+                get: { compatibilityAutoPresets },
+                set: { newValue in
+                    compatibilityAutoPresets = newValue
+                    ARMSX2Bridge.setCompatibilityAutoGamePresetsEnabled(newValue)
+                    refreshCompatibilityState()
+                }
+            )) {
+                Label(settings.localized("Auto Game Presets"), systemImage: "sparkles")
+            }
+
+            LabeledContent(settings.localized("Current Mode")) {
+                Text(settings.localized(currentPreset.title))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.trailing)
+            }
+
+            if !compatibilityIdentity.isEmpty {
+                LabeledContent(settings.localized("Current Game")) {
+                    Text(compatibilityIdentity)
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                Text(settings.localized("Start a game to remember presets per title."))
+                    .foregroundStyle(.secondary)
+            }
+        } header: {
+            Text(settings.localized("Status"))
+        } footer: {
+            Text(settings.localized("Auto Game Presets applies known safe defaults. Manual flags below are remembered for the current game when a game is running."))
+        }
     }
 
-    private var virtualPadHiddenByController: Bool {
-        userVirtualPadVisible && settings.autoHideVirtualPadWhenControllerConnected && externalControllerConnected
+    private var compatibilityResetSection: some View {
+        Section {
+            Button {
+                applyCompatibilityPreset(compatibilityPreset(for: "off"))
+            } label: {
+                Label(settings.localized("Use Default / Clear Flags"), systemImage: "power")
+            }
+            .foregroundStyle(.primary)
+        } header: {
+            Text(settings.localized("Reset"))
+        } footer: {
+            Text(settings.localized("Use this when testing is done or a game behaves worse with compatibility flags enabled."))
+        }
     }
 
-    private func refreshExternalControllerConnectionState() {
-        let connected = !GCController.controllers().isEmpty
-        if externalControllerConnected != connected {
-            externalControllerConnected = connected
+    private var compatibilityFlagsSection: some View {
+        Section {
+            compatibilityLabToggle(
+                "COP1EverythingOnly",
+                title: "COP1 Everything Only",
+                systemImage: "function"
+            )
+            compatibilityLabToggle(
+                "COP1EverythingPlusLoadStore",
+                title: "COP1 Everything + EE Load/Store",
+                systemImage: "arrow.left.arrow.right"
+            )
+            compatibilityLabToggle(
+                "COP1EverythingPlusMMI",
+                title: "COP1 Everything + EE MMI",
+                systemImage: "rectangle.3.group"
+            )
+            compatibilityLabToggle(
+                "COP1EverythingPlusCOP2VU",
+                title: "COP1 Everything + EE COP2/VU Macro",
+                systemImage: "cube.transparent"
+            )
+            compatibilityLabToggle(
+                "COP1EverythingPlusMultDiv",
+                title: "COP1 Everything + EE Mult/Div",
+                systemImage: "multiply"
+            )
+            compatibilityLabToggle(
+                "COP1EverythingPlusShifts",
+                title: "COP1 Everything + EE Shifts",
+                systemImage: "arrow.left.and.right"
+            )
+            compatibilityLabToggle(
+                "COP1EverythingPlusMoves",
+                title: "COP1 Everything + EE Moves/HI-LO",
+                systemImage: "arrow.triangle.swap"
+            )
+            compatibilityLabToggle(
+                "COP1EverythingPlusIntegerALU",
+                title: "COP1 Everything + EE Integer ALU",
+                systemImage: "plus.forwardslash.minus"
+            )
+            compatibilityLabToggle(
+                "COP1EverythingPlusBranches",
+                title: "COP1 Everything + EE Branches/Jumps",
+                systemImage: "arrow.triangle.branch"
+            )
+        } header: {
+            Text(settings.localized("Manual Compatibility Flags"))
+        } footer: {
+            Text(settings.localized("Toggle one or more flags when a game needs compatibility help. Changing any flag switches this game to Custom Advanced Flags."))
+        }
+    }
+
+    private var compatibilityForgetSection: some View {
+        Section {
+            Button(role: .destructive) {
+                let identity = compatibilityIdentity
+                ARMSX2Bridge.forgetCompatibilityPresetForCurrentGame()
+                refreshCompatibilityState()
+                presentStatusMessage("\(settings.localized("Compatibility preset reset for")) \(identity)")
+            } label: {
+                Label(settings.localized("Forget This Game's Override"), systemImage: "trash")
+            }
         }
     }
 
@@ -438,6 +549,43 @@ struct GameScreenView: View {
         }
     }
 
+    // MARK: - Lifecycle & Events
+
+    private func enterGameplaySystemChromeMode() {
+        previousHideHomeIndicator = appState.hideHomeIndicator
+        appState.hideHomeIndicator = true
+    }
+
+    private func leaveGameplaySystemChromeMode() {
+        appState.hideHomeIndicator = previousHideHomeIndicator
+    }
+
+    private func applyGameScreenPreferences() {
+        menuButtonHidden = settings.hideMenuButton
+        if settings.autoFullscreen {
+            fullScreen = true
+            ARMSX2Bridge.setFullScreen(true)
+        }
+    }
+
+    private func restoreMenuButtonIfHidden() {
+        guard menuButtonHidden else { return }
+
+        menuButtonHidden = false
+        settings.hideMenuButton = false
+        presentStatusMessage(settings.localized("Menu button shown"))
+    }
+
+    private func updateRuntimeOverlayPause() {
+        let shouldPause = showSaveStates || showSpeedControl || showCompatibilityLab || showPerGameSettings || showPNACHImporter || showPadLayoutEditor || showResetConfirmation
+        guard runtimeOverlayPauseActive != shouldPause else { return }
+
+        runtimeOverlayPauseActive = shouldPause
+        if ARMSX2Bridge.isVMRunning() {
+            ARMSX2Bridge.setVMPaused(shouldPause)
+        }
+    }
+
     private func refreshRuntimeMenuState() {
         let vmRunning = ARMSX2Bridge.isVMRunning()
         let gameReady = ARMSX2Bridge.hasValidSaveStateGame()
@@ -450,56 +598,14 @@ struct GameScreenView: View {
         refreshCompatibilityState()
     }
 
-    private func openPerGameSettingsForCurrentGame() {
-        // Load the running game's settings through the VM-safe bridge path (no disc-image
-        // scan) and build a lightweight entry from data the VM already holds, so opening
-        // the panel does not disturb audio/loading on the active game.
-        guard let gameName = currentRuntimeGameName(),
-              let info = ARMSX2Bridge.gameSettingsForCurrentGame() else {
-            runtimePerGameSettingsEntry = nil
-            runtimePerGameSettings = nil
-            withAnimation(.spring(response: 0.32, dampingFraction: 0.88)) {
-                showPerGameSettings = true
-            }
-            presentImportantSaveStateStatus(settings.localized("Per-game settings need a running game."))
-            return
-        }
-
-        let serial = (info["serial"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        runtimePerGameSettingsEntry = ISOEntry(
-            name: gameName,
-            fileURL: nil,
-            bootPath: nil,
-            coverURL: nil,
-            coverSignature: nil,
-            metadata: serial.isEmpty ? [:] : ["serial": serial],
-            size: 0,
-            isFavorite: false
-        )
-        runtimePerGameSettings = info
-        withAnimation(.spring(response: 0.32, dampingFraction: 0.88)) {
-            showPerGameSettings = true
+    private func refreshExternalControllerConnectionState() {
+        let connected = !GCController.controllers().isEmpty
+        if externalControllerConnected != connected {
+            externalControllerConnected = connected
         }
     }
 
-    private func closePerGameSettingsOverlay() {
-        withAnimation(.easeInOut(duration: 0.2)) {
-            showPerGameSettings = false
-        }
-        runtimePerGameSettingsEntry = nil
-        runtimePerGameSettings = nil
-        refreshRuntimeMenuState()
-    }
-
-    private func updateRuntimeOverlayPause() {
-        let shouldPause = showSaveStates || showSpeedControl || showCompatibilityLab || showPerGameSettings || showPNACHImporter || showPadLayoutEditor
-        guard runtimeOverlayPauseActive != shouldPause else { return }
-
-        runtimeOverlayPauseActive = shouldPause
-        if ARMSX2Bridge.isVMRunning() {
-            ARMSX2Bridge.setVMPaused(shouldPause)
-        }
-    }
+    // MARK: - Game Identity Helpers
 
     private func currentRuntimeGameName() -> String? {
         if let gameName = normalizedRuntimeGameName(appState.runningGameName) {
@@ -569,148 +675,7 @@ struct GameScreenView: View {
             .uppercased()
     }
 
-    private var compatibilityLabPanel: some View {
-        NavigationStack {
-            Form {
-                let currentPreset = compatibilityPreset(for: compatibilityPresetKey)
-
-                Section {
-                    Toggle(isOn: Binding(
-                        get: { compatibilityAutoPresets },
-                        set: { newValue in
-                            compatibilityAutoPresets = newValue
-                            ARMSX2Bridge.setCompatibilityAutoGamePresetsEnabled(newValue)
-                            refreshCompatibilityState()
-                        }
-                    )) {
-                        Label(settings.localized("Auto Game Presets"), systemImage: "sparkles")
-                    }
-
-                    LabeledContent(settings.localized("Current Mode")) {
-                        Text(settings.localized(currentPreset.title))
-                            .foregroundStyle(.secondary)
-                            .multilineTextAlignment(.trailing)
-                    }
-
-                    if !compatibilityIdentity.isEmpty {
-                        LabeledContent(settings.localized("Current Game")) {
-                            Text(compatibilityIdentity)
-                                .foregroundStyle(.secondary)
-                        }
-                    } else {
-                        Text(settings.localized("Start a game to remember presets per title."))
-                            .foregroundStyle(.secondary)
-                    }
-                } header: {
-                    Text(settings.localized("Status"))
-                } footer: {
-                    Text(settings.localized("Auto Game Presets applies known safe defaults. Manual flags below are remembered for the current game when a game is running."))
-                }
-
-                Section {
-                    Button {
-                        applyCompatibilityPreset(compatibilityPreset(for: "off"))
-                    } label: {
-                        Label(settings.localized("Use Default / Clear Flags"), systemImage: "power")
-                    }
-                    .foregroundStyle(.primary)
-                } header: {
-                    Text(settings.localized("Reset"))
-                } footer: {
-                    Text(settings.localized("Use this when testing is done or a game behaves worse with compatibility flags enabled."))
-                }
-
-                Section {
-                    compatibilityLabToggle(
-                        "COP1EverythingOnly",
-                        title: "COP1 Everything Only",
-                        systemImage: "function"
-                    )
-                    compatibilityLabToggle(
-                        "COP1EverythingPlusLoadStore",
-                        title: "COP1 Everything + EE Load/Store",
-                        systemImage: "arrow.left.arrow.right"
-                    )
-                    compatibilityLabToggle(
-                        "COP1EverythingPlusMMI",
-                        title: "COP1 Everything + EE MMI",
-                        systemImage: "rectangle.3.group"
-                    )
-                    compatibilityLabToggle(
-                        "COP1EverythingPlusCOP2VU",
-                        title: "COP1 Everything + EE COP2/VU Macro",
-                        systemImage: "cube.transparent"
-                    )
-                    compatibilityLabToggle(
-                        "COP1EverythingPlusMultDiv",
-                        title: "COP1 Everything + EE Mult/Div",
-                        systemImage: "multiply"
-                    )
-                    compatibilityLabToggle(
-                        "COP1EverythingPlusShifts",
-                        title: "COP1 Everything + EE Shifts",
-                        systemImage: "arrow.left.and.right"
-                    )
-                    compatibilityLabToggle(
-                        "COP1EverythingPlusMoves",
-                        title: "COP1 Everything + EE Moves/HI-LO",
-                        systemImage: "arrow.triangle.swap"
-                    )
-                    compatibilityLabToggle(
-                        "COP1EverythingPlusIntegerALU",
-                        title: "COP1 Everything + EE Integer ALU",
-                        systemImage: "plus.forwardslash.minus"
-                    )
-                    compatibilityLabToggle(
-                        "COP1EverythingPlusBranches",
-                        title: "COP1 Everything + EE Branches/Jumps",
-                        systemImage: "arrow.triangle.branch"
-                    )
-                } header: {
-                    Text(settings.localized("Manual Compatibility Flags"))
-                } footer: {
-                    Text(settings.localized("Toggle one or more flags when a game needs compatibility help. Changing any flag switches this game to Custom Advanced Flags."))
-                }
-
-                if !compatibilityIdentity.isEmpty {
-                    Section {
-                        Button(role: .destructive) {
-                            let identity = compatibilityIdentity
-                            ARMSX2Bridge.forgetCompatibilityPresetForCurrentGame()
-                            refreshCompatibilityState()
-                            presentSaveStateStatus("\(settings.localized("Compatibility preset reset for")) \(identity)")
-                        } label: {
-                            Label(settings.localized("Forget This Game's Override"), systemImage: "trash")
-                        }
-                    }
-                }
-            }
-            .navigationTitle(settings.localized("Compatibility Lab"))
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button(settings.localized("Done")) {
-                        showCompatibilityLab = false
-                    }
-                }
-            }
-            .onAppear(perform: refreshCompatibilityState)
-        }
-    }
-
-    private func compatibilityLabToggle(_ key: String, title: String, systemImage: String) -> some View {
-        Toggle(isOn: Binding(
-            get: { ARMSX2Bridge.getJITBisectFlag(key, defaultValue: false) },
-            set: {
-                ARMSX2Bridge.setJITBisectFlag(key, value: $0)
-                compatibilityPresetKey = "custom"
-                if !compatibilityIdentity.isEmpty {
-                    presentSaveStateStatus("\(settings.localized("Custom compatibility flags saved for")) \(compatibilityIdentity)")
-                }
-            }
-        )) {
-            Label(settings.localized(title), systemImage: systemImage)
-        }
-    }
+    // MARK: - Compatibility Helpers
 
     private func refreshCompatibilityState() {
         let preset = ARMSX2Bridge.compatibilityPresetForCurrentGame()
@@ -742,31 +707,120 @@ struct GameScreenView: View {
         refreshCompatibilityState()
 
         if rememberForCurrentGame {
-            presentSaveStateStatus("\(settings.localized(preset.title)) \(settings.localized("saved for")) \(compatibilityIdentity)")
+            presentStatusMessage("\(settings.localized(preset.title)) \(settings.localized("saved for")) \(compatibilityIdentity)")
         } else {
-            presentSaveStateStatus("\(settings.localized("Compatibility preset set to")) \(settings.localized(preset.title))")
+            presentStatusMessage("\(settings.localized("Compatibility preset set to")) \(settings.localized(preset.title))")
         }
+    }
+
+    private func compatibilityLabToggle(_ key: String, title: String, systemImage: String) -> some View {
+        Toggle(isOn: Binding(
+            get: { ARMSX2Bridge.getJITBisectFlag(key, defaultValue: false) },
+            set: {
+                ARMSX2Bridge.setJITBisectFlag(key, value: $0)
+                compatibilityPresetKey = "custom"
+                if !compatibilityIdentity.isEmpty {
+                    presentStatusMessage("\(settings.localized("Custom compatibility flags saved for")) \(compatibilityIdentity)")
+                }
+            }
+        )) {
+            Label(settings.localized(title), systemImage: systemImage)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func openPerGameSettingsForCurrentGame() {
+        // Use the VM-safe bridge path to avoid a disc-image scan while the game is running.
+        guard let gameName = currentRuntimeGameName(),
+              let info = ARMSX2Bridge.gameSettingsForCurrentGame() else {
+            runtimePerGameSettingsEntry = nil
+            runtimePerGameSettings = nil
+            withAnimation(.spring(response: 0.32, dampingFraction: 0.88)) {
+                showPerGameSettings = true
+            }
+            presentImportantStatusMessage(settings.localized("Per-game settings need a running game."))
+            return
+        }
+
+        let serial = (info["serial"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        runtimePerGameSettingsEntry = ISOEntry(
+            name: gameName,
+            fileURL: nil,
+            bootPath: nil,
+            coverURL: nil,
+            coverSignature: nil,
+            metadata: serial.isEmpty ? [:] : ["serial": serial],
+            size: 0,
+            isFavorite: false
+        )
+        runtimePerGameSettings = info
+        withAnimation(.spring(response: 0.32, dampingFraction: 0.88)) {
+            showPerGameSettings = true
+        }
+    }
+
+    private func closePerGameSettingsOverlay() {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            showPerGameSettings = false
+        }
+        runtimePerGameSettingsEntry = nil
+        runtimePerGameSettings = nil
+        refreshRuntimeMenuState()
     }
 
     private func resetCurrentROM() {
         appState.resetCurrentVM()
-        presentSaveStateStatus(settings.localized("Restarting ROM..."))
+        presentStatusMessage(settings.localized("Restarting ROM..."))
     }
 
     private func clearCurrentGameCache() {
         guard let gameName = currentRuntimeGameName() else {
-            presentImportantSaveStateStatus(settings.localized("Cache clear needs a running game."))
+            presentImportantStatusMessage(settings.localized("Cache clear needs a running game."))
             return
         }
 
         let message = ARMSX2Bridge.clearCache(forISO: gameName)
-        presentSaveStateStatus(message)
+        presentStatusMessage(message)
     }
 
+    private func changeDisc(to discName: String) {
+        presentStatusMessage("Changing disc...")
+        ARMSX2Bridge.changeDisc(toISO: discName) { success in
+            Task { @MainActor in
+                if success {
+                    presentStatusMessage("\(discName) inserted. Use the game's disc-swap prompt if needed.")
+                } else {
+                    presentImportantStatusMessage("Could not change discs. Open the game's disc-swap prompt first, or restart with the target disc.")
+                }
+            }
+        }
+    }
+
+    private func restartWithDisc(_ discName: String) {
+        presentStatusMessage("Restarting with \(discName)...")
+        appState.shutdownAndBoot(isoName: discName)
+    }
+
+    private func ejectDisc() {
+        presentStatusMessage("Ejecting disc...")
+        ARMSX2Bridge.ejectDisc { success in
+            Task { @MainActor in
+                if success {
+                    presentStatusMessage("Disc ejected")
+                } else {
+                    presentImportantStatusMessage("Could not eject the disc. Try again after the game has finished loading.")
+                }
+            }
+        }
+    }
+
+    // MARK: - Toast & Feedback
+
     @ViewBuilder
-    private var saveStateToast: some View {
-        if let saveStateStatus {
-            Text(saveStateStatus)
+    private var statusToastOverlay: some View {
+        if let statusMessage {
+            Text(statusMessage)
                 .font(.callout.weight(.semibold))
                 .foregroundStyle(.white)
                 .padding(.horizontal, 14)
@@ -777,30 +831,33 @@ struct GameScreenView: View {
         }
     }
 
-    private func presentSaveStateStatus(
+    private func presentStatusMessage(
         _ message: String,
         displayDuration: TimeInterval = Self.briefStatusDisplayDuration
     ) {
-        saveStateStatusGeneration += 1
-        let currentGeneration = saveStateStatusGeneration
+        statusMessageDismissTask?.cancel()
+        statusMessageGeneration += 1
+        let currentGeneration = statusMessageGeneration
         withAnimation(.easeOut(duration: 0.18)) {
-            saveStateStatus = message
+            statusMessage = message
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + displayDuration) {
-            guard saveStateStatusGeneration == currentGeneration else { return }
+        statusMessageDismissTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(displayDuration))
+            guard !Task.isCancelled else { return }
+            guard statusMessageGeneration == currentGeneration else { return }
             withAnimation(.easeIn(duration: 0.18)) {
-                saveStateStatus = nil
+                statusMessage = nil
             }
         }
     }
 
-    private func presentImportantSaveStateStatus(_ message: String) {
-        presentSaveStateStatus(message, displayDuration: Self.importantStatusDisplayDuration)
+    private func presentImportantStatusMessage(_ message: String) {
+        presentStatusMessage(message, displayDuration: Self.importantStatusDisplayDuration)
     }
 
     private func presentPNACHImportResult(_ message: String) {
         if Self.isPNACHImportSuccessMessage(message) {
-            presentSaveStateStatus(message)
+            presentStatusMessage(message)
         } else {
             fileImporter.presentImportResult(message)
         }
@@ -814,41 +871,24 @@ struct GameScreenView: View {
         return !lines.isEmpty && lines.allSatisfy { $0.hasPrefix("PNACH imported") }
     }
 
+    // MARK: - Virtual Pad
+
+    private var effectiveVirtualPadVisible: Bool {
+        userVirtualPadVisible && (!settings.autoHideVirtualPadWhenControllerConnected || !externalControllerConnected)
+    }
+
+    private var virtualPadHiddenByController: Bool {
+        userVirtualPadVisible && settings.autoHideVirtualPadWhenControllerConnected && externalControllerConnected
+    }
+
+    // MARK: - Disc Helpers
+
     private var availableDiscSwapNames: [String] {
         ARMSX2Bridge.availableISOs().filter { !$0.lowercased().hasSuffix(".elf") }
     }
-
-    private func changeDisc(to discName: String) {
-        presentSaveStateStatus("Changing disc...")
-        ARMSX2Bridge.changeDisc(toISO: discName) { success in
-            Task { @MainActor in
-                if success {
-                    presentSaveStateStatus("\(discName) inserted. Use the game's disc-swap prompt if needed.")
-                } else {
-                    presentImportantSaveStateStatus("Could not change discs. Open the game's disc-swap prompt first, or restart with the target disc.")
-                }
-            }
-        }
-    }
-
-    private func restartWithDisc(_ discName: String) {
-        presentSaveStateStatus("Restarting with \(discName)...")
-        appState.shutdownAndBoot(isoName: discName)
-    }
-
-    private func ejectDisc() {
-        presentSaveStateStatus("Ejecting disc...")
-        ARMSX2Bridge.ejectDisc { success in
-            Task { @MainActor in
-                if success {
-                    presentSaveStateStatus("Disc ejected")
-                } else {
-                    presentImportantSaveStateStatus("Could not eject the disc. Try again after the game has finished loading.")
-                }
-            }
-        }
-    }
 }
+
+// MARK: - Save States Panel
 
 private struct SaveStatesPanel: View {
     @Environment(\.dismiss) private var dismiss
@@ -884,7 +924,8 @@ private struct SaveStatesPanel: View {
                                 isBusy: busySlot == slot.slot,
                                 onSave: { save(slot) },
                                 onLoad: { load(slot) },
-                                onOverwrite: { pendingOverwrite = slot }
+                                onOverwrite: { pendingOverwrite = slot },
+                                settings: settings
                             )
                         }
                     }
@@ -975,6 +1016,8 @@ private struct SaveStatesPanel: View {
     }
 }
 
+// MARK: - Speed Control Panel
+
 private struct SpeedControlPanel: View {
     @Bindable var settings: SettingsStore
     @Environment(\.dismiss) private var dismiss
@@ -1063,12 +1106,15 @@ private struct SpeedControlPanel: View {
     }
 }
 
+// MARK: - Save State Slot Row
+
 private struct SaveStateSlotRow: View {
     let info: ARMSX2SaveStateSlotInfo
     let isBusy: Bool
     let onSave: () -> Void
     let onLoad: () -> Void
     let onOverwrite: () -> Void
+    let settings: SettingsStore
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -1077,7 +1123,7 @@ private struct SaveStateSlotRow: View {
                     .frame(width: 96, height: 72)
 
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Slot \(info.slot)")
+                    Text("\(settings.localized("Slot")) \(info.slot)")
                         .font(.headline)
 
                     if info.occupied {
@@ -1091,7 +1137,7 @@ private struct SaveStateSlotRow: View {
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                     } else {
-                        Text("Empty")
+                        Text(settings.localized("Empty"))
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -1104,7 +1150,7 @@ private struct SaveStateSlotRow: View {
                         .frame(width: 88)
                 } else if !info.occupied {
                     Button(action: onSave) {
-                        Label("Save", systemImage: "square.and.arrow.down")
+                        Label(settings.localized("Save"), systemImage: "square.and.arrow.down")
                     }
                     .buttonStyle(.borderedProminent)
                 }
@@ -1113,13 +1159,13 @@ private struct SaveStateSlotRow: View {
             if info.occupied && !isBusy {
                 HStack(spacing: 8) {
                     Button(action: onLoad) {
-                        Label("Load", systemImage: "arrow.down.circle")
+                        Label(settings.localized("Load"), systemImage: "arrow.down.circle")
                     }
                     .buttonStyle(.borderedProminent)
                     .frame(maxWidth: .infinity)
 
                     Button(action: onOverwrite) {
-                        Label("Overwrite", systemImage: "arrow.triangle.2.circlepath")
+                        Label(settings.localized("Overwrite"), systemImage: "arrow.triangle.2.circlepath")
                     }
                     .buttonStyle(.bordered)
                     .frame(maxWidth: .infinity)
@@ -1137,6 +1183,8 @@ private struct SaveStateSlotRow: View {
         return formatter
     }()
 }
+
+// MARK: - Save State Preview
 
 private struct SaveStatePreview: View {
     let data: Data?


### PR DESCRIPTION
## Summary

It focuses on the in-game quick menu, PNACH importing, fullscreen behavior, OSD behavior, Game Mode support, skip-draw settings, and small runtime polish. The broader notch/Dynamic Island safe-area UI cleanup is intentionally left out for a separate follow-up PR because the tested fix still needs more work.

## Changelog

1. Cleans up the in-game quick menu code and makes the runtime UI easier to maintain.
2. Fixes `.pnach` imports when files include bracketed cheat names like `[Cheat Name]`. 
3. Fixes the OSD toggle so turning it off and on again restores the previous Detail/Full mode instead of resetting to Simple.
4. Fixes fullscreen state handling so the fullscreen toggle no longer gets stale or inverted, including after rotation.
5. Enables iOS Game Mode support through the app plist.
6. Refreshes the home indicator state while emulating, so the gesture bar can auto-hide more reliably during gameplay.
7. Fixes skip-draw settings so global and per-game skip-draw changes are applied live.

## Notes

The notch/Dynamic Island safe-area cleanup was tested but is not included here. It needs a better approach and should be handled separately so this PR stays focused and reviewable.
