### PR TITLE
iOS: Improve the iOS virtual controller and pad layout editor

### DIFF
--- a/app/src/main/swift/Models/PadLayoutStore.swift
+++ b/app/src/main/swift/Models/PadLayoutStore.swift
@@ -9,14 +9,58 @@ struct PadGroupPosition {
     var scale: CGFloat
 }
 
+// MARK: - Shared per-button offset constants
+// These must match the exact offset math used in DPadView and ActionButtonsView.
+enum VirtualPadButtonOffset {
+    static let dpadPortraitSize: CGFloat = 100
+    static let dpadLandscapeSize: CGFloat = 110
+    static let actionButtonSize: CGFloat = 42
+
+    static func dpadButtonWidth(isLandscape: Bool) -> CGFloat {
+        (isLandscape ? dpadLandscapeSize : dpadPortraitSize) * 0.42
+    }
+
+    static func dpadOffset(isLandscape: Bool) -> CGFloat {
+        (isLandscape ? dpadLandscapeSize : dpadPortraitSize) * 0.29
+    }
+
+    static let actionOffset: CGFloat = actionButtonSize * 1.1
+
+    static func offset(for buttonID: String, isLandscape: Bool) -> CGSize {
+        let dpadOff = dpadOffset(isLandscape: isLandscape)
+        let actionOff = actionOffset
+        switch buttonID {
+        case "up":       return CGSize(width: 0, height: -dpadOff)
+        case "down":     return CGSize(width: 0, height: dpadOff)
+        case "left":     return CGSize(width: -dpadOff, height: 0)
+        case "right":    return CGSize(width: dpadOff, height: 0)
+        case "triangle": return CGSize(width: 0, height: -actionOff)
+        case "cross":    return CGSize(width: 0, height: actionOff)
+        case "square":   return CGSize(width: -actionOff, height: 0)
+        case "circle":   return CGSize(width: actionOff, height: 0)
+        default:         return .zero
+        }
+    }
+}
+
 @Observable
 final class PadLayoutStore: @unchecked Sendable {
     static let shared = PadLayoutStore()
 
+    static let actionButtonIDs = ["cross", "circle", "square", "triangle"]
+    static let perButtonIDs = ["triangle", "circle", "square", "cross", "up", "down", "left", "right"]
     static let groupIDs = ["dpad", "action", "l1", "l2", "r1", "r2", "lstick", "rstick", "select", "start"]
 
     var portrait: [String: PadGroupPosition] = [:]
     var landscape: [String: PadGroupPosition] = [:]
+
+    // Per-button overrides — only populated when the user moves an individual button.
+    var perButtonPortrait: [String: PadGroupPosition] = [:]
+    var perButtonLandscape: [String: PadGroupPosition] = [:]
+
+    // Group-level control visibility. Keys are group IDs; value `false` means hidden.
+    // Absent key means visible (default). Stored globally, not per-orientation.
+    var controlVisibility: [String: Bool] = [:]
 
     // MARK: - Default positions (derived from current hardcoded layout)
 
@@ -62,6 +106,71 @@ final class PadLayoutStore: @unchecked Sendable {
         return dict[id] ?? defaults[id] ?? PadGroupPosition(x: 0.5, y: 0.5, scale: 1.0)
     }
 
+    // MARK: - Per-button position lookup
+
+    /// Returns the position for an individual button.
+    /// If a per-button override exists, it is returned.
+    /// Otherwise, the default is computed from the legacy group position using
+    /// the same offset math as the current grouped layout.
+    func perButtonPosition(for id: String, landscape: Bool, areaW: CGFloat, areaH: CGFloat) -> PadGroupPosition {
+        let dict = landscape ? perButtonLandscape : perButtonPortrait
+        if let pos = dict[id] {
+            return pos
+        }
+        let groupID = (id == "triangle" || id == "circle" || id == "square" || id == "cross") ? "action" : "dpad"
+        let groupPos = position(for: groupID, landscape: landscape)
+        return defaultPerButtonPosition(for: id, groupPos: groupPos, isLandscape: landscape, areaW: areaW, areaH: areaH)
+    }
+
+    private func defaultPerButtonPosition(for id: String, groupPos: PadGroupPosition, isLandscape: Bool, areaW: CGFloat, areaH: CGFloat) -> PadGroupPosition {
+        let offset = VirtualPadButtonOffset.offset(for: id, isLandscape: isLandscape)
+        let scaledOffsetX = offset.width * groupPos.scale
+        let scaledOffsetY = offset.height * groupPos.scale
+        return PadGroupPosition(
+            x: groupPos.x + scaledOffsetX / areaW,
+            y: groupPos.y + scaledOffsetY / areaH,
+            scale: groupPos.scale
+        )
+    }
+
+    func groupID(for perButtonID: String) -> String {
+        if ["triangle", "circle", "square", "cross"].contains(perButtonID) { return "action" }
+        if ["up", "down", "left", "right"].contains(perButtonID) { return "dpad" }
+        return perButtonID
+    }
+
+    // MARK: - Visibility helpers
+
+    /// Returns whether a control or button is visible.
+    /// If an explicit per-button key exists, it wins.
+    /// Otherwise, fall back to the group visibility (default: visible).
+    func isControlVisible(_ id: String) -> Bool {
+        if let explicit = controlVisibility[id] {
+            return explicit
+        }
+        let group = groupID(for: id)
+        return controlVisibility[group] ?? true
+    }
+
+    func setControlVisible(_ id: String, visible: Bool) {
+        if visible {
+            let group = groupID(for: id)
+            if id == group {
+                controlVisibility.removeValue(forKey: id)
+            } else if let groupVisible = controlVisibility[group], !groupVisible {
+                controlVisibility[id] = true
+            } else {
+                controlVisibility.removeValue(forKey: id)
+            }
+        } else {
+            controlVisibility[id] = false
+        }
+    }
+
+    func resetControlVisibility() {
+        controlVisibility.removeAll()
+    }
+
     // MARK: - INI persistence
 
     func save() {
@@ -75,6 +184,40 @@ final class PadLayoutStore: @unchecked Sendable {
                 ARMSX2Bridge.setINIFloat("ARMSX2iOS/PadLayout/Landscape", key: "\(id)_x", value: Float(pos.x))
                 ARMSX2Bridge.setINIFloat("ARMSX2iOS/PadLayout/Landscape", key: "\(id)_y", value: Float(pos.y))
                 ARMSX2Bridge.setINIFloat("ARMSX2iOS/PadLayout/Landscape", key: "\(id)_scale", value: Float(pos.scale))
+            }
+        }
+        // Per-button positions: write override if present, sentinel -1 otherwise.
+        for id in Self.perButtonIDs {
+            if let pos = perButtonPortrait[id] {
+                ARMSX2Bridge.setINIFloat("ARMSX2iOS/PadLayout/PerButtonPortrait", key: "\(id)_x", value: Float(pos.x))
+                ARMSX2Bridge.setINIFloat("ARMSX2iOS/PadLayout/PerButtonPortrait", key: "\(id)_y", value: Float(pos.y))
+                ARMSX2Bridge.setINIFloat("ARMSX2iOS/PadLayout/PerButtonPortrait", key: "\(id)_scale", value: Float(pos.scale))
+            } else {
+                ARMSX2Bridge.setINIFloat("ARMSX2iOS/PadLayout/PerButtonPortrait", key: "\(id)_x", value: -1.0)
+                ARMSX2Bridge.setINIFloat("ARMSX2iOS/PadLayout/PerButtonPortrait", key: "\(id)_y", value: -1.0)
+                ARMSX2Bridge.setINIFloat("ARMSX2iOS/PadLayout/PerButtonPortrait", key: "\(id)_scale", value: -1.0)
+            }
+            if let pos = perButtonLandscape[id] {
+                ARMSX2Bridge.setINIFloat("ARMSX2iOS/PadLayout/PerButtonLandscape", key: "\(id)_x", value: Float(pos.x))
+                ARMSX2Bridge.setINIFloat("ARMSX2iOS/PadLayout/PerButtonLandscape", key: "\(id)_y", value: Float(pos.y))
+                ARMSX2Bridge.setINIFloat("ARMSX2iOS/PadLayout/PerButtonLandscape", key: "\(id)_scale", value: Float(pos.scale))
+            } else {
+                ARMSX2Bridge.setINIFloat("ARMSX2iOS/PadLayout/PerButtonLandscape", key: "\(id)_x", value: -1.0)
+                ARMSX2Bridge.setINIFloat("ARMSX2iOS/PadLayout/PerButtonLandscape", key: "\(id)_y", value: -1.0)
+                ARMSX2Bridge.setINIFloat("ARMSX2iOS/PadLayout/PerButtonLandscape", key: "\(id)_scale", value: -1.0)
+            }
+        }
+        // Visibility: `0` = hidden, `1` = visible. Absent means visible (default).
+        for id in Self.groupIDs {
+            let isVisible = isControlVisible(id)
+            ARMSX2Bridge.setINIFloat("ARMSX2iOS/PadLayout/ControlVisibility", key: id, value: isVisible ? 1.0 : 0.0)
+        }
+        // Per-button visibility overrides (only action buttons in this pass).
+        for id in Self.actionButtonIDs {
+            if let explicit = controlVisibility[id] {
+                ARMSX2Bridge.setINIFloat("ARMSX2iOS/PadLayout/ControlVisibility", key: id, value: explicit ? 1.0 : 0.0)
+            } else {
+                ARMSX2Bridge.setINIFloat("ARMSX2iOS/PadLayout/ControlVisibility", key: id, value: -1.0)
             }
         }
     }
@@ -96,19 +239,112 @@ final class PadLayoutStore: @unchecked Sendable {
                 landscape[id] = PadGroupPosition(x: CGFloat(lx), y: CGFloat(ly), scale: CGFloat(ls))
             }
         }
+        for id in Self.perButtonIDs {
+            // Portrait
+            let px = ARMSX2Bridge.getINIFloat(
+                "ARMSX2iOS/PadLayout/PerButtonPortrait",
+                key: "\(id)_x",
+                defaultValue: -1
+            )
+            let py = ARMSX2Bridge.getINIFloat(
+                "ARMSX2iOS/PadLayout/PerButtonPortrait",
+                key: "\(id)_y",
+                defaultValue: -1
+            )
+            let ps = ARMSX2Bridge.getINIFloat(
+                "ARMSX2iOS/PadLayout/PerButtonPortrait",
+                key: "\(id)_scale",
+                defaultValue: -1
+            )
+            if px >= 0 && py >= 0 && ps > 0 {
+                perButtonPortrait[id] = PadGroupPosition(
+                    x: CGFloat(px),
+                    y: CGFloat(py),
+                    scale: CGFloat(ps)
+                )
+            }
+            // Landscape
+            let lx = ARMSX2Bridge.getINIFloat(
+                "ARMSX2iOS/PadLayout/PerButtonLandscape",
+                key: "\(id)_x",
+                defaultValue: -1
+            )
+            let ly = ARMSX2Bridge.getINIFloat(
+                "ARMSX2iOS/PadLayout/PerButtonLandscape",
+                key: "\(id)_y",
+                defaultValue: -1
+            )
+            let ls = ARMSX2Bridge.getINIFloat(
+                "ARMSX2iOS/PadLayout/PerButtonLandscape",
+                key: "\(id)_scale",
+                defaultValue: -1
+            )
+            if lx >= 0 && ly >= 0 && ls > 0 {
+                perButtonLandscape[id] = PadGroupPosition(
+                    x: CGFloat(lx),
+                    y: CGFloat(ly),
+                    scale: CGFloat(ls)
+                )
+            }
+        }
+        // Visibility: `0` = hidden, `1` = visible, absent = visible (default).
+        for id in Self.groupIDs {
+            let value = ARMSX2Bridge.getINIFloat("ARMSX2iOS/PadLayout/ControlVisibility", key: id, defaultValue: -1)
+            if value >= 0 {
+                controlVisibility[id] = (value > 0.5)
+            }
+        }
+        // Per-button visibility overrides.
+        for id in Self.actionButtonIDs {
+            let value = ARMSX2Bridge.getINIFloat("ARMSX2iOS/PadLayout/ControlVisibility", key: id, defaultValue: -1)
+            if value >= 0 {
+                controlVisibility[id] = (value > 0.5)
+            }
+        }
     }
 
     func resetPortrait() {
         portrait = Self.defaultPortrait
-        save()
     }
 
     func resetLandscape() {
         landscape = Self.defaultLandscape
-        save()
     }
 
     func reset(isLandscape: Bool) {
         if isLandscape { resetLandscape() } else { resetPortrait() }
+    }
+
+    func resetPerButtonActionButtons(isLandscape: Bool) {
+        if isLandscape {
+            for id in ["triangle", "circle", "square", "cross"] {
+                perButtonLandscape.removeValue(forKey: id)
+            }
+        } else {
+            for id in ["triangle", "circle", "square", "cross"] {
+                perButtonPortrait.removeValue(forKey: id)
+            }
+        }
+    }
+
+    func resetPerButtonDPad(isLandscape: Bool) {
+        if isLandscape {
+            for id in ["up", "down", "left", "right"] {
+                perButtonLandscape.removeValue(forKey: id)
+            }
+        } else {
+            for id in ["up", "down", "left", "right"] {
+                perButtonPortrait.removeValue(forKey: id)
+            }
+        }
+    }
+
+    func resetAll() {
+        portrait = Self.defaultPortrait
+        landscape = Self.defaultLandscape
+        perButtonPortrait.removeAll()
+        perButtonLandscape.removeAll()
+        // Note: controlVisibility is intentionally NOT reset here.
+        // Use resetControlVisibility() for that.
     }
 }

--- a/app/src/main/swift/Views/GameScreenView.swift
+++ b/app/src/main/swift/Views/GameScreenView.swift
@@ -135,12 +135,13 @@ struct GameScreenView: View {
             compatibilityLabPanel
                 .presentationDetents([.medium, .large])
         }
-        .fullScreenCover(isPresented: $showPadLayoutEditor, onDismiss: {
-            NSLog("@@PAD_LAYOUT@@ dismiss")
-            showPadLayoutEditor = false
-            updateRuntimeOverlayPause()
-        }) {
-            PadLayoutEditView()
+        .overlay {
+            if showPadLayoutEditor {
+                PadLayoutEditView(onDismiss: {
+                    showPadLayoutEditor = false
+                    updateRuntimeOverlayPause()
+                })
+            }
         }
         .sheet(isPresented: $showPNACHImporter) {
             ImportDocumentPicker(
@@ -940,7 +941,7 @@ struct GameScreenView: View {
     // MARK: - Virtual Pad
 
     private var effectiveVirtualPadVisible: Bool {
-        userVirtualPadVisible && (!settings.autoHideVirtualPadWhenControllerConnected || !externalControllerConnected)
+        userVirtualPadVisible && (!settings.autoHideVirtualPadWhenControllerConnected || !externalControllerConnected) && !showPadLayoutEditor
     }
 
     private var virtualPadHiddenByController: Bool {

--- a/app/src/main/swift/Views/GameScreenView.swift
+++ b/app/src/main/swift/Views/GameScreenView.swift
@@ -86,22 +86,32 @@ struct GameScreenView: View {
                     }
                     .ignoresSafeArea()
                 } else {
-                    // Portrait: split layout. Full-phone skins are skipped until viewport metadata is parsed.
-                    ZStack {
-                        VStack(spacing: 0) {
-                            MetalGameView()
-                                .frame(height: geo.size.height / 2)
-                            if effectiveVirtualPadVisible {
+                    // Portrait: top game viewport, bottom controller deck.
+                    // Game respects the top safe area so OSD stays below the Dynamic Island.
+                    // Controller ignores the bottom safe area so buttons remain usable near the home indicator.
+                    VStack(spacing: 0) {
+                        let gameHeight = min(geo.size.width * 3 / 4, geo.size.height * 0.55)
+                        MetalGameView()
+                            .frame(height: gameHeight)
+                            .clipped()
+
+                        if effectiveVirtualPadVisible {
+                            ZStack {
+                                Color.black
                                 VirtualControllerView()
-                                    .frame(height: geo.size.height / 2)
-                            } else {
-                                Spacer()
+                                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                             }
-                        }
-                        .overlay(alignment: .topTrailing) {
-                            menuButtonOverlay(isLandscape: false)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
                         }
                     }
+                    .overlay(alignment: .topTrailing) {
+                        if !menuButtonHidden {
+                            menuButton()
+                                .padding(.top, 4)
+                                .padding(.trailing, 4)
+                        }
+                    }
+                    .ignoresSafeArea(.container, edges: .bottom)
                 }
             }
             .preference(key: GameScreenSizePreferenceKey.self, value: geo.size)

--- a/app/src/main/swift/Views/Settings/PadLayoutEditView.swift
+++ b/app/src/main/swift/Views/Settings/PadLayoutEditView.swift
@@ -3,173 +3,202 @@
 
 import SwiftUI
 
+private struct PadLayoutSnapshot {
+    let portrait: [String: PadGroupPosition]
+    let landscape: [String: PadGroupPosition]
+    let perButtonPortrait: [String: PadGroupPosition]
+    let perButtonLandscape: [String: PadGroupPosition]
+    let controlVisibility: [String: Bool]
+    let skin: VirtualPadSkin
+}
+
 struct PadLayoutEditView: View {
+    let onDismiss: () -> Void
     @State private var settings = SettingsStore.shared
     @State private var layout = PadLayoutStore.shared
     @State private var editLandscape = false
-    @Environment(\.dismiss) private var dismiss
+    @State private var undoStack: [PadLayoutSnapshot] = []
+    @State private var originalSnapshot: PadLayoutSnapshot? = nil
+    @State private var didInitializeOrientation = false
 
     var body: some View {
-        Group {
-            if editLandscape {
-                GeometryReader { geo in
-                    ZStack {
-                        Color(white: 0.08)
+        GeometryReader { geo in
+            let isActuallyLandscape = geo.size.width > geo.size.height
+            let isMismatch = isActuallyLandscape != editLandscape
+            ZStack(alignment: .top) {
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onTapGesture {}
+                    .gesture(DragGesture(minimumDistance: 0))
 
-                        // Safe zone guide: shows where buttons won't be clipped by notch/home indicator
-                        // Uses a fixed 5% margin on each side as a universal safe guide
-                        let margin: CGFloat = 0.05
-                        let guideRect = CGRect(
-                            x: geo.size.width * margin,
-                            y: geo.size.height * margin,
-                            width: geo.size.width * (1 - margin * 2),
-                            height: geo.size.height * (1 - margin * 2)
-                        )
-                        Rectangle()
-                            .stroke(style: StrokeStyle(lineWidth: 1, dash: [6, 4]))
-                            .foregroundStyle(.yellow.opacity(0.3))
-                            .frame(width: guideRect.width, height: guideRect.height)
-                            .position(x: guideRect.midX, y: guideRect.midY)
-
-                        customSkinPreview(isLandscape: true, width: geo.size.width, height: geo.size.height)
-
-                        Text("Safe Zone")
-                            .font(.caption2)
-                            .foregroundStyle(.yellow.opacity(0.25))
-                            .position(x: guideRect.midX, y: guideRect.minY + 12)
-
-                        editorContent(areaW: geo.size.width, areaH: geo.size.height)
-
-                        VStack {
-                            floatingToolbar
-                            Spacer()
-                            Button("Reset to Default") {
-                                layout.reset(isLandscape: true)
-                            }
-                            .font(.caption)
-                            .foregroundStyle(.red.opacity(0.7))
-                            .padding(.bottom, 6)
-                        }
-                    }
-                    .ignoresSafeArea()
+                if isActuallyLandscape {
+                    landscapeEditorCanvas(isEditable: !isMismatch)
+                } else {
+                    portraitEditorCanvas(width: geo.size.width, height: geo.size.height, isEditable: !isMismatch)
                 }
-            } else {
-                GeometryReader { geo in
-                    ZStack {
-                        VStack(spacing: 0) {
-                            ZStack {
-                                Color.black
-                                Text("Game Screen")
-                                    .foregroundStyle(.white.opacity(0.3))
-                                    .font(.caption)
-                            }
-                            .frame(height: geo.size.height / 2)
 
-                            ZStack {
-                                Color(white: 0.10)
-                                customSkinPreview(isLandscape: false, width: geo.size.width, height: geo.size.height / 2)
+                VStack(spacing: 0) {
+                    editorToolbar()
+                        .padding(.top, max(geo.safeAreaInsets.top, 8))
+                        .padding(.horizontal, max(max(geo.safeAreaInsets.leading, geo.safeAreaInsets.trailing), 8))
 
-                                // Safe zone guide for portrait pad area
-                                let padH = geo.size.height / 2
-                                let pm: CGFloat = 0.04
-                                Rectangle()
-                                    .stroke(style: StrokeStyle(lineWidth: 1, dash: [6, 4]))
-                                    .foregroundStyle(.yellow.opacity(0.3))
-                                    .padding(.horizontal, geo.size.width * pm)
-                                    .padding(.vertical, padH * pm)
-
-                                Text("Safe Zone")
-                                    .font(.caption2)
-                                    .foregroundStyle(.yellow.opacity(0.25))
-                                    .position(x: geo.size.width / 2, y: 14)
-
-                                editorPortraitContent(areaW: geo.size.width, areaH: padH)
-                            }
-                            .frame(height: geo.size.height / 2)
-                        }
-
-                        VStack {
-                            HStack {
-                                Button("Cancel") { dismiss() }
-                                    .padding(8)
-                                    .background(.black.opacity(0.5), in: Capsule())
-                                Spacer()
-                                Picker("", selection: $editLandscape) {
-                                    Text("Portrait").tag(false)
-                                    Text("Landscape").tag(true)
-                                }
-                                .pickerStyle(.segmented)
-                                .frame(width: 168)
-                                .background(.black.opacity(0.3), in: RoundedRectangle(cornerRadius: 8))
-                                Spacer()
-                                skinPickerMenu
-                                Spacer()
-                                Button("Save") {
-                                    NSLog("@@PAD_LAYOUT@@ save portrait=%d landscape=%d", layout.portrait.count, layout.landscape.count)
-                                    layout.save()
-                                    dismiss()
-                                }
-                                .fontWeight(.semibold)
-                                .padding(8)
-                                .background(.black.opacity(0.5), in: Capsule())
-                            }
-                            .padding(.horizontal)
-                            .padding(.top, 4)
-                            Spacer()
-                            Button("Reset to Default") {
-                                layout.reset(isLandscape: false)
-                            }
-                            .font(.caption)
-                            .foregroundStyle(.red.opacity(0.7))
-                            .padding(.bottom, 6)
-                        }
+                    if isMismatch {
+                        orientationMismatchView()
+                    } else {
+                        Spacer(minLength: 0)
                     }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                .zIndex(2)
+            }
+            .frame(width: geo.size.width, height: geo.size.height, alignment: .top)
+            .onAppear {
+                if originalSnapshot == nil {
+                    originalSnapshot = captureSnapshot()
+                }
+                if !didInitializeOrientation {
+                    editLandscape = isActuallyLandscape
+                    didInitializeOrientation = true
                 }
             }
         }
-        .background(Color(white: 0.08))
         .navigationBarHidden(true)
         .statusBarHidden()
         .persistentSystemOverlays(.hidden)
         .onDisappear {
-            NSLog("@@PAD_LAYOUT@@ disappear")
+            rollbackUnsavedChanges()
             NotificationCenter.default.post(name: Notification.Name("ARMSX2iOSPadLayoutEditorDismissed"), object: nil)
         }
     }
 
-    private var floatingToolbar: some View {
-        HStack {
-            Button("Cancel") { dismiss() }
-                .padding(8)
-                .background(.black.opacity(0.5), in: Capsule())
-            Spacer()
-            Picker("", selection: $editLandscape) {
-                Text("Portrait").tag(false)
-                Text("Landscape").tag(true)
+    // MARK: - Landscape editor canvas (always shown when device is landscape)
+    private func landscapeEditorCanvas(isEditable: Bool) -> some View {
+        GeometryReader { geo in
+            let width = geo.size.width
+            let height = geo.size.height
+            ZStack {
+                Color.clear
+                    .allowsHitTesting(false)
+
+                if isEditable {
+                    customSkinPreview(isLandscape: true, width: width, height: height)
+                    editorControls(areaW: width, areaH: height, isLandscape: true)
+                }
             }
-            .pickerStyle(.segmented)
-            .frame(width: 168)
-            .background(.black.opacity(0.3), in: RoundedRectangle(cornerRadius: 8))
-            Spacer()
-            skinPickerMenu
-            Spacer()
-            Button("Save") {
-                NSLog("@@PAD_LAYOUT@@ save portrait=%d landscape=%d", layout.portrait.count, layout.landscape.count)
-                layout.save()
-                dismiss()
-            }
-            .fontWeight(.semibold)
-            .padding(8)
-            .background(.black.opacity(0.5), in: Capsule())
+            .contentShape(Rectangle())
         }
-        .padding(.horizontal)
-        .padding(.top, 4)
+        .ignoresSafeArea()
     }
 
-    private var skinPickerMenu: some View {
+    // MARK: - Portrait editor canvas (always shown when device is portrait)
+    private func portraitEditorCanvas(width: CGFloat, height: CGFloat, isEditable: Bool) -> some View {
+        let gameHeight = min(width * 3 / 4, height * 0.55)
+        let padHeight = height - gameHeight
+        return VStack(spacing: 0) {
+            // Top: reveal paused gameplay underneath
+            Color.clear
+                .allowsHitTesting(false)
+                .frame(height: gameHeight)
+
+            // Bottom: controller deck editing area (dark enough for controls)
+            ZStack {
+                Color.black.opacity(0.85)
+                if isEditable {
+                    customSkinPreview(isLandscape: false, width: width, height: padHeight)
+                    editorControls(areaW: width, areaH: padHeight, isLandscape: false)
+                }
+            }
+            .frame(height: padHeight)
+            .clipped()
+        }
+    }
+
+    private func editorToolbar() -> some View {
+        HStack(spacing: 6) {
+            Button {
+                rollbackUnsavedChanges()
+                onDismiss()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title3)
+                    .foregroundStyle(.white)
+                    .frame(width: 28, height: 28)
+            }
+
+            Button {
+                guard let snapshot = undoStack.popLast() else { return }
+                restore(snapshot: snapshot)
+            } label: {
+                Image(systemName: "arrow.uturn.backward.circle")
+                    .font(.title3)
+                    .foregroundStyle(undoStack.isEmpty ? .white.opacity(0.3) : .white)
+                    .frame(width: 28, height: 28)
+            }
+            .disabled(undoStack.isEmpty)
+
+            Picker("", selection: $editLandscape) {
+                Text("Port.").tag(false)
+                Text("Land.").tag(true)
+            }
+            .pickerStyle(.segmented)
+            .frame(width: 112)
+            .background(.black.opacity(0.3), in: RoundedRectangle(cornerRadius: 8))
+
+            skinPickerMenuButton()
+            optionsMenuButton()
+
+            Button {
+                layout.save()
+                undoStack.removeAll()
+                originalSnapshot = nil
+                onDismiss()
+            } label: {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.title3)
+                    .foregroundStyle(.green)
+                    .frame(width: 28, height: 28)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(.black.opacity(0.55), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private func orientationMismatchView() -> some View {
+        let message = editLandscape
+            ? "Rotate device to landscape to edit landscape layout"
+            : "Rotate device to portrait to edit portrait layout"
+        let explanation = editLandscape
+            ? "Accurate editing requires rotating the device or switching to portrait layout."
+            : "Accurate editing requires rotating the device or switching to landscape layout."
+        return VStack(spacing: 12) {
+            Image(systemName: "rotate.right")
+                .font(.system(size: 48, weight: .light))
+                .foregroundStyle(.white.opacity(0.6))
+            Text(message)
+                .font(.headline.weight(.semibold))
+                .foregroundStyle(.white)
+                .multilineTextAlignment(.center)
+                .lineLimit(3)
+            Text(explanation)
+                .font(.subheadline)
+                .foregroundStyle(.white.opacity(0.7))
+                .multilineTextAlignment(.center)
+                .lineLimit(3)
+        }
+        .padding(.horizontal, 32)
+        .padding(.vertical, 24)
+        .background(.black.opacity(0.6), in: RoundedRectangle(cornerRadius: 16))
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .allowsHitTesting(false)
+    }
+
+    private func skinPickerMenuButton() -> some View {
         Menu {
             ForEach(VirtualPadSkin.allCases) { skin in
                 Button {
+                    guard settings.virtualPadSkin != skin else { return }
+                    pushSnapshot()
                     settings.virtualPadSkin = skin
                 } label: {
                     Label(settings.localized(skin.label), systemImage: settings.virtualPadSkin == skin ? "checkmark" : "circle")
@@ -177,10 +206,58 @@ struct PadLayoutEditView: View {
             }
         } label: {
             Image(systemName: "paintpalette.fill")
-                .font(.callout)
+                .font(.title3)
                 .foregroundStyle(.white)
-                .frame(width: 34, height: 34)
-                .background(.black.opacity(0.5), in: Circle())
+                .frame(width: 28, height: 28)
+        }
+    }
+
+    private func optionsMenuButton() -> some View {
+        Menu {
+            Section("Visibility") {
+                ForEach(PadLayoutStore.groupIDs.filter { $0 != "action" }, id: \.self) { (id: String) in
+                    visibilityMenuItem(id: id)
+                }
+                visibilityMenuItem(id: "cross", label: "X")
+                visibilityMenuItem(id: "circle", label: "O")
+                visibilityMenuItem(id: "triangle", label: "Triangle")
+                visibilityMenuItem(id: "square", label: "Square")
+            }
+
+            Section("Reset") {
+                Button("Reset Action", role: .destructive) {
+                    pushSnapshot()
+                    layout.resetPerButtonActionButtons(isLandscape: editLandscape)
+                }
+                Button("Reset D-Pad", role: .destructive) {
+                    pushSnapshot()
+                    layout.resetPerButtonDPad(isLandscape: editLandscape)
+                }
+                Button("Reset All", role: .destructive) {
+                    pushSnapshot()
+                    layout.resetAll()
+                }
+                Button("Reset Visibility", role: .destructive) {
+                    pushSnapshot()
+                    layout.resetControlVisibility()
+                }
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .font(.title3)
+                .foregroundStyle(.white)
+                .frame(width: 28, height: 28)
+        }
+    }
+
+    private func visibilityMenuItem(id: String, label: String? = nil) -> some View {
+        let visible = layout.isControlVisible(id)
+        return Button {
+            pushSnapshot()
+            layout.setControlVisible(id, visible: !visible)
+        } label: {
+            let name = label ?? id.uppercased()
+            Label(name, systemImage: visible ? "eye" : "eye.slash")
         }
     }
 
@@ -200,21 +277,52 @@ struct PadLayoutEditView: View {
     }
 
     @ViewBuilder
-    private func editorContent(areaW: CGFloat, areaH: CGFloat) -> some View {
+    private func editorControls(areaW: CGFloat, areaH: CGFloat, isLandscape: Bool) -> some View {
+        let stickScale = min(max(CGFloat(settings.analogStickScale), 0.8), 1.6)
         ZStack {
-            ForEach(PadLayoutStore.groupIDs, id: \.self) { id in
-                DraggableGroup(id: id, areaW: areaW, areaH: areaH, isLandscape: editLandscape)
+            ForEach(PadLayoutStore.perButtonIDs, id: \.self) { (id: String) in
+                DraggableButton(id: id, areaW: areaW, areaH: areaH, isLandscape: isLandscape, onBeginEdit: pushSnapshot)
+            }
+            ForEach(PadLayoutStore.groupIDs.filter { $0 != "action" && $0 != "dpad" }, id: \.self) { (id: String) in
+                DraggableGroup(id: id, areaW: areaW, areaH: areaH, isLandscape: isLandscape, analogStickScale: stickScale, onBeginEdit: pushSnapshot)
             }
         }
+        .environment(\.padSkin, settings.virtualPadSkin)
+        .environment(\.padOpacity, 1.0)
+        .environment(\.padUsesFullSkin, false)
     }
 
-    @ViewBuilder
-    private func editorPortraitContent(areaW: CGFloat, areaH: CGFloat) -> some View {
-        ZStack {
-            ForEach(PadLayoutStore.groupIDs, id: \.self) { id in
-                DraggableGroup(id: id, areaW: areaW, areaH: areaH, isLandscape: false)
-            }
-        }
+    // MARK: - Snapshot / Undo
+
+    private func captureSnapshot() -> PadLayoutSnapshot {
+        PadLayoutSnapshot(
+            portrait: layout.portrait,
+            landscape: layout.landscape,
+            perButtonPortrait: layout.perButtonPortrait,
+            perButtonLandscape: layout.perButtonLandscape,
+            controlVisibility: layout.controlVisibility,
+            skin: settings.virtualPadSkin
+        )
+    }
+
+    private func restore(snapshot: PadLayoutSnapshot) {
+        layout.portrait = snapshot.portrait
+        layout.landscape = snapshot.landscape
+        layout.perButtonPortrait = snapshot.perButtonPortrait
+        layout.perButtonLandscape = snapshot.perButtonLandscape
+        layout.controlVisibility = snapshot.controlVisibility
+        settings.virtualPadSkin = snapshot.skin
+    }
+
+    private func pushSnapshot() {
+        undoStack.append(captureSnapshot())
+    }
+
+    private func rollbackUnsavedChanges() {
+        guard let snapshot = originalSnapshot else { return }
+        restore(snapshot: snapshot)
+        undoStack.removeAll()
+        originalSnapshot = nil
     }
 }
 
@@ -224,10 +332,13 @@ private struct DraggableGroup: View {
     let areaW: CGFloat
     let areaH: CGFloat
     let isLandscape: Bool
+    let analogStickScale: CGFloat
+    let onBeginEdit: () -> Void
 
     @State private var layout = PadLayoutStore.shared
     @State private var dragOffset: CGSize = .zero
     @State private var currentScale: CGFloat = 1.0
+    @State private var hasPushedSnapshot = false
 
     private var pos: PadGroupPosition {
         layout.position(for: id, landscape: isLandscape)
@@ -241,6 +352,7 @@ private struct DraggableGroup: View {
     }
 
     var body: some View {
+        let isVisible = layout.isControlVisible(id)
         ZStack {
             RoundedRectangle(cornerRadius: 8)
                 .fill(.white.opacity(0.05))
@@ -260,11 +372,18 @@ private struct DraggableGroup: View {
                 .offset(y: -(scaledSize.height / 2 + 12))
         }
         .position(x: currentX, y: currentY)
-        .opacity(0.8)
+        .opacity(isVisible ? 0.8 : 0.25)
         .gesture(
             DragGesture()
-                .onChanged { v in dragOffset = v.translation }
+                .onChanged { v in
+                    if !hasPushedSnapshot {
+                        onBeginEdit()
+                        hasPushedSnapshot = true
+                    }
+                    dragOffset = v.translation
+                }
                 .onEnded { v in
+                    hasPushedSnapshot = false
                     let newX = (pos.x * areaW + v.translation.width) / areaW
                     let newY = (pos.y * areaH + v.translation.height) / areaH
                     updatePosition(x: newX.clamped(0, 1), y: newY.clamped(0, 1))
@@ -273,8 +392,15 @@ private struct DraggableGroup: View {
         )
         .simultaneousGesture(
             MagnifyGesture()
-                .onChanged { v in currentScale = v.magnification }
+                .onChanged { v in
+                    if !hasPushedSnapshot {
+                        onBeginEdit()
+                        hasPushedSnapshot = true
+                    }
+                    currentScale = v.magnification
+                }
                 .onEnded { v in
+                    hasPushedSnapshot = false
                     let newScale = (pos.scale * v.magnification).clamped(0.5, 2.0)
                     updateScale(newScale)
                     currentScale = 1.0
@@ -291,7 +417,6 @@ private struct DraggableGroup: View {
         } else {
             layout.portrait[id] = p
         }
-        NSLog("@@PAD_LAYOUT@@ move id=%@ landscape=%d x=%.4f y=%.4f", id, isLandscape ? 1 : 0, Double(x), Double(y))
     }
 
     private func updateScale(_ scale: CGFloat) {
@@ -302,21 +427,33 @@ private struct DraggableGroup: View {
         } else {
             layout.portrait[id] = p
         }
-        NSLog("@@PAD_LAYOUT@@ scale id=%@ landscape=%d scale=%.4f", id, isLandscape ? 1 : 0, Double(scale))
     }
 
     private var groupSize: CGSize {
         switch id {
-        case "dpad":   return CGSize(width: 120, height: 120)
-        case "action": return CGSize(width: 120, height: 120)
-        case "l1":     return CGSize(width: 110, height: 36)
-        case "l2":     return CGSize(width: 120, height: 48)
-        case "r1":     return CGSize(width: 110, height: 36)
-        case "r2":     return CGSize(width: 120, height: 48)
-        case "lstick", "rstick": return CGSize(width: 80, height: 90)
-        case "select": return CGSize(width: 50, height: 28)
-        case "start":  return CGSize(width: 56, height: 28)
-        default:       return CGSize(width: 60, height: 40)
+        case "dpad":
+            let s = isLandscape ? VirtualPadButtonOffset.dpadLandscapeSize : VirtualPadButtonOffset.dpadPortraitSize
+            return CGSize(width: s, height: s)
+        case "action":
+            let s = VirtualPadButtonOffset.actionButtonSize * 3.2
+            return CGSize(width: s, height: s)
+        case "l1":
+            return CGSize(width: 120, height: 32)
+        case "l2":
+            return CGSize(width: 130, height: 44)
+        case "r1":
+            return CGSize(width: 120, height: 32)
+        case "r2":
+            return CGSize(width: 130, height: 44)
+        case "lstick", "rstick":
+            let s = 68 * min(max(analogStickScale, 0.8), 1.6)
+            return CGSize(width: s, height: s)
+        case "select":
+            return CGSize(width: 40, height: 22)
+        case "start":
+            return CGSize(width: 48, height: 22)
+        default:
+            return CGSize(width: 60, height: 40)
         }
     }
 
@@ -324,25 +461,180 @@ private struct DraggableGroup: View {
     private var groupContent: some View {
         switch id {
         case "dpad":
-            DPadView(size: 100)
+            DPadView(size: isLandscape ? VirtualPadButtonOffset.dpadLandscapeSize : VirtualPadButtonOffset.dpadPortraitSize)
         case "action":
-            ActionButtonsView(size: 42)
+            ActionButtonsView(size: VirtualPadButtonOffset.actionButtonSize)
         case "l1":
-            PadBtn(label: "L1", w: 100, h: 30, btn: .L1)
+            PadBtn(label: "L1", w: 120, h: 32, btn: .L1)
         case "l2":
-            PadBtn(label: "L2", w: 110, h: 40, btn: .L2)
+            PadBtn(label: "L2", w: 130, h: 44, btn: .L2)
         case "r1":
-            PadBtn(label: "R1", w: 100, h: 30, btn: .R1)
+            PadBtn(label: "R1", w: 120, h: 32, btn: .R1)
         case "r2":
-            PadBtn(label: "R2", w: 110, h: 40, btn: .R2)
+            PadBtn(label: "R2", w: 130, h: 44, btn: .R2)
         case "lstick":
-            StickView(isLeft: true, sizeScale: 1.0)
+            StickView(isLeft: true, sizeScale: analogStickScale)
         case "rstick":
-            StickView(isLeft: false, sizeScale: 1.0)
+            StickView(isLeft: false, sizeScale: analogStickScale)
         case "select":
-            PadBtn(label: "SEL", w: 42, h: 22, btn: .select)
+            PadBtn(label: "SEL", w: 40, h: 22, btn: .select)
         case "start":
             PadBtn(label: "START", w: 48, h: 22, btn: .start)
+        default:
+            EmptyView()
+        }
+    }
+}
+
+// MARK: - Draggable individual button widget
+private struct DraggableButton: View {
+    let id: String
+    let areaW: CGFloat
+    let areaH: CGFloat
+    let isLandscape: Bool
+    let onBeginEdit: () -> Void
+
+    @State private var layout = PadLayoutStore.shared
+    @State private var dragOffset: CGSize = .zero
+    @State private var currentScale: CGFloat = 1.0
+    @State private var hasPushedSnapshot = false
+
+    private var pos: PadGroupPosition {
+        layout.perButtonPosition(for: id, landscape: isLandscape, areaW: areaW, areaH: areaH)
+    }
+
+    private var currentX: CGFloat { pos.x * areaW + dragOffset.width }
+    private var currentY: CGFloat { pos.y * areaH + dragOffset.height }
+
+    private var baseButtonSize: CGSize {
+        switch id {
+        case "up", "down", "left", "right":
+            let w = VirtualPadButtonOffset.dpadButtonWidth(isLandscape: isLandscape)
+            return CGSize(width: w, height: w)
+        case "triangle", "circle", "square", "cross":
+            let sz = VirtualPadButtonOffset.actionButtonSize
+            return CGSize(width: sz, height: sz)
+        default:
+            return CGSize(width: 40, height: 40)
+        }
+    }
+
+    private var scaledSize: CGSize {
+        let s = pos.scale * currentScale
+        return CGSize(width: baseButtonSize.width * s, height: baseButtonSize.height * s)
+    }
+
+    var body: some View {
+        let isVisible = layout.isControlVisible(id)
+        ZStack {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(.white.opacity(0.05))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(.blue.opacity(0.4), lineWidth: 1.5)
+                )
+                .frame(width: scaledSize.width + 12, height: scaledSize.height + 12)
+
+            buttonContent
+                .scaleEffect(pos.scale * currentScale)
+                .allowsHitTesting(false)
+
+            Text(buttonLabel.uppercased())
+                .font(.system(size: 8, weight: .bold))
+                .foregroundStyle(.blue.opacity(0.7))
+                .offset(y: -(scaledSize.height / 2 + 10))
+        }
+        .position(x: currentX, y: currentY)
+        .opacity(isVisible ? 0.8 : 0.25)
+        .gesture(
+            DragGesture()
+                .onChanged { v in
+                    if !hasPushedSnapshot {
+                        onBeginEdit()
+                        hasPushedSnapshot = true
+                    }
+                    dragOffset = v.translation
+                }
+                .onEnded { v in
+                    hasPushedSnapshot = false
+                    let newX = (pos.x * areaW + v.translation.width) / areaW
+                    let newY = (pos.y * areaH + v.translation.height) / areaH
+                    updatePosition(x: newX.clamped(0, 1), y: newY.clamped(0, 1))
+                    dragOffset = .zero
+                }
+        )
+        .simultaneousGesture(
+            MagnifyGesture()
+                .onChanged { v in
+                    if !hasPushedSnapshot {
+                        onBeginEdit()
+                        hasPushedSnapshot = true
+                    }
+                    currentScale = v.magnification
+                }
+                .onEnded { v in
+                    hasPushedSnapshot = false
+                    let newScale = (pos.scale * v.magnification).clamped(0.5, 2.0)
+                    updateScale(newScale)
+                    currentScale = 1.0
+                }
+        )
+    }
+
+    private var buttonLabel: String {
+        switch id {
+        case "up": return "UP"
+        case "down": return "DN"
+        case "left": return "LT"
+        case "right": return "RT"
+        case "triangle": return "TRI"
+        case "circle": return "CIR"
+        case "square": return "SQU"
+        case "cross": return "CRO"
+        default: return id
+        }
+    }
+
+    private func updatePosition(x: CGFloat, y: CGFloat) {
+        var p = pos
+        p.x = x
+        p.y = y
+        if isLandscape {
+            layout.perButtonLandscape[id] = p
+        } else {
+            layout.perButtonPortrait[id] = p
+        }
+    }
+
+    private func updateScale(_ scale: CGFloat) {
+        var p = pos
+        p.scale = scale
+        if isLandscape {
+            layout.perButtonLandscape[id] = p
+        } else {
+            layout.perButtonPortrait[id] = p
+        }
+    }
+
+    @ViewBuilder
+    private var buttonContent: some View {
+        switch id {
+        case "up":
+            PadBtn(label: "▲", w: VirtualPadButtonOffset.dpadButtonWidth(isLandscape: isLandscape), h: VirtualPadButtonOffset.dpadButtonWidth(isLandscape: isLandscape), btn: .up)
+        case "down":
+            PadBtn(label: "▼", w: VirtualPadButtonOffset.dpadButtonWidth(isLandscape: isLandscape), h: VirtualPadButtonOffset.dpadButtonWidth(isLandscape: isLandscape), btn: .down)
+        case "left":
+            PadBtn(label: "◀", w: VirtualPadButtonOffset.dpadButtonWidth(isLandscape: isLandscape), h: VirtualPadButtonOffset.dpadButtonWidth(isLandscape: isLandscape), btn: .left)
+        case "right":
+            PadBtn(label: "▶", w: VirtualPadButtonOffset.dpadButtonWidth(isLandscape: isLandscape), h: VirtualPadButtonOffset.dpadButtonWidth(isLandscape: isLandscape), btn: .right)
+        case "triangle":
+            PSBtn(sym: "△", clr: .green, sz: VirtualPadButtonOffset.actionButtonSize, btn: .triangle)
+        case "cross":
+            PSBtn(sym: "✕", clr: .blue, sz: VirtualPadButtonOffset.actionButtonSize, btn: .cross)
+        case "square":
+            PSBtn(sym: "□", clr: .pink, sz: VirtualPadButtonOffset.actionButtonSize, btn: .square)
+        case "circle":
+            PSBtn(sym: "○", clr: .red, sz: VirtualPadButtonOffset.actionButtonSize, btn: .circle)
         default:
             EmptyView()
         }

--- a/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift
+++ b/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift
@@ -120,7 +120,7 @@ struct VirtualPadSettingsView: View {
             Text(skinImportMessage)
         }
         .fullScreenCover(isPresented: $showLayoutEditor) {
-            PadLayoutEditView()
+            PadLayoutEditView(onDismiss: { showLayoutEditor = false })
         }
     }
 

--- a/app/src/main/swift/Views/VirtualControllerView.swift
+++ b/app/src/main/swift/Views/VirtualControllerView.swift
@@ -578,6 +578,10 @@ struct VirtualControllerView: View {
         layout.position(for: id, landscape: landscape)
     }
 
+    private func perButtonPos(_ id: String, landscape: Bool, w: CGFloat, h: CGFloat) -> PadGroupPosition {
+        layout.perButtonPosition(for: id, landscape: landscape, areaW: w, areaH: h)
+    }
+
     // MARK: - Landscape: overlay on game screen
     @ViewBuilder
     func landscapeLayout(w: CGFloat, h: CGFloat) -> some View {
@@ -594,36 +598,86 @@ struct VirtualControllerView: View {
                     .allowsHitTesting(false)
             }
 
-            DPadView(size: 110)
-                .scaleEffect(pos("dpad", landscape: true).scale)
-                .position(x: pos("dpad", landscape: true).x * w, y: pos("dpad", landscape: true).y * h)
-            ActionButtonsView(size: 42)
-                .scaleEffect(pos("action", landscape: true).scale)
-                .position(x: pos("action", landscape: true).x * w, y: pos("action", landscape: true).y * h)
-            PadBtn(label: "L2", w: 130, h: 44, btn: .L2)
-                .scaleEffect(pos("l2", landscape: true).scale)
-                .position(x: pos("l2", landscape: true).x * w, y: pos("l2", landscape: true).y * h)
-            PadBtn(label: "L1", w: 120, h: 32, btn: .L1)
-                .scaleEffect(pos("l1", landscape: true).scale)
-                .position(x: pos("l1", landscape: true).x * w, y: pos("l1", landscape: true).y * h)
-            PadBtn(label: "R2", w: 130, h: 44, btn: .R2)
-                .scaleEffect(pos("r2", landscape: true).scale)
-                .position(x: pos("r2", landscape: true).x * w, y: pos("r2", landscape: true).y * h)
-            PadBtn(label: "R1", w: 120, h: 32, btn: .R1)
-                .scaleEffect(pos("r1", landscape: true).scale)
-                .position(x: pos("r1", landscape: true).x * w, y: pos("r1", landscape: true).y * h)
-            PadBtn(label: "SEL", w: 40, h: 22, btn: .select)
-                .scaleEffect(pos("select", landscape: true).scale)
-                .position(x: pos("select", landscape: true).x * w, y: pos("select", landscape: true).y * h)
-            PadBtn(label: "START", w: 48, h: 22, btn: .start)
-                .scaleEffect(pos("start", landscape: true).scale)
-                .position(x: pos("start", landscape: true).x * w, y: pos("start", landscape: true).y * h)
-            StickView(isLeft: true, sizeScale: analogStickScale)
-                .scaleEffect(pos("lstick", landscape: true).scale)
-                .position(x: pos("lstick", landscape: true).x * w, y: pos("lstick", landscape: true).y * h)
-            StickView(isLeft: false, sizeScale: analogStickScale)
-                .scaleEffect(pos("rstick", landscape: true).scale)
-                .position(x: pos("rstick", landscape: true).x * w, y: pos("rstick", landscape: true).y * h)
+            // D-pad buttons (individual placement)
+            if layout.isControlVisible("dpad") {
+                let dpadW = VirtualPadButtonOffset.dpadButtonWidth(isLandscape: true)
+                PadBtn(label: "▲", w: dpadW, h: dpadW, btn: .up)
+                    .scaleEffect(perButtonPos("up", landscape: true, w: w, h: h).scale)
+                    .position(x: perButtonPos("up", landscape: true, w: w, h: h).x * w, y: perButtonPos("up", landscape: true, w: w, h: h).y * h)
+                PadBtn(label: "▼", w: dpadW, h: dpadW, btn: .down)
+                    .scaleEffect(perButtonPos("down", landscape: true, w: w, h: h).scale)
+                    .position(x: perButtonPos("down", landscape: true, w: w, h: h).x * w, y: perButtonPos("down", landscape: true, w: w, h: h).y * h)
+                PadBtn(label: "◀", w: dpadW, h: dpadW, btn: .left)
+                    .scaleEffect(perButtonPos("left", landscape: true, w: w, h: h).scale)
+                    .position(x: perButtonPos("left", landscape: true, w: w, h: h).x * w, y: perButtonPos("left", landscape: true, w: w, h: h).y * h)
+                PadBtn(label: "▶", w: dpadW, h: dpadW, btn: .right)
+                    .scaleEffect(perButtonPos("right", landscape: true, w: w, h: h).scale)
+                    .position(x: perButtonPos("right", landscape: true, w: w, h: h).x * w, y: perButtonPos("right", landscape: true, w: w, h: h).y * h)
+            }
+
+            // Action buttons (individual placement)
+            let actionSz = VirtualPadButtonOffset.actionButtonSize
+            if layout.isControlVisible("triangle") {
+                PSBtn(sym: "△", clr: .green, sz: actionSz, btn: .triangle)
+                    .scaleEffect(perButtonPos("triangle", landscape: true, w: w, h: h).scale)
+                    .position(x: perButtonPos("triangle", landscape: true, w: w, h: h).x * w, y: perButtonPos("triangle", landscape: true, w: w, h: h).y * h)
+            }
+            if layout.isControlVisible("cross") {
+                PSBtn(sym: "✕", clr: .blue, sz: actionSz, btn: .cross)
+                    .scaleEffect(perButtonPos("cross", landscape: true, w: w, h: h).scale)
+                    .position(x: perButtonPos("cross", landscape: true, w: w, h: h).x * w, y: perButtonPos("cross", landscape: true, w: w, h: h).y * h)
+            }
+            if layout.isControlVisible("square") {
+                PSBtn(sym: "□", clr: .pink, sz: actionSz, btn: .square)
+                    .scaleEffect(perButtonPos("square", landscape: true, w: w, h: h).scale)
+                    .position(x: perButtonPos("square", landscape: true, w: w, h: h).x * w, y: perButtonPos("square", landscape: true, w: w, h: h).y * h)
+            }
+            if layout.isControlVisible("circle") {
+                PSBtn(sym: "○", clr: .red, sz: actionSz, btn: .circle)
+                    .scaleEffect(perButtonPos("circle", landscape: true, w: w, h: h).scale)
+                    .position(x: perButtonPos("circle", landscape: true, w: w, h: h).x * w, y: perButtonPos("circle", landscape: true, w: w, h: h).y * h)
+            }
+
+            if layout.isControlVisible("l2") {
+                PadBtn(label: "L2", w: 130, h: 44, btn: .L2)
+                    .scaleEffect(pos("l2", landscape: true).scale)
+                    .position(x: pos("l2", landscape: true).x * w, y: pos("l2", landscape: true).y * h)
+            }
+            if layout.isControlVisible("l1") {
+                PadBtn(label: "L1", w: 120, h: 32, btn: .L1)
+                    .scaleEffect(pos("l1", landscape: true).scale)
+                    .position(x: pos("l1", landscape: true).x * w, y: pos("l1", landscape: true).y * h)
+            }
+            if layout.isControlVisible("r2") {
+                PadBtn(label: "R2", w: 130, h: 44, btn: .R2)
+                    .scaleEffect(pos("r2", landscape: true).scale)
+                    .position(x: pos("r2", landscape: true).x * w, y: pos("r2", landscape: true).y * h)
+            }
+            if layout.isControlVisible("r1") {
+                PadBtn(label: "R1", w: 120, h: 32, btn: .R1)
+                    .scaleEffect(pos("r1", landscape: true).scale)
+                    .position(x: pos("r1", landscape: true).x * w, y: pos("r1", landscape: true).y * h)
+            }
+            if layout.isControlVisible("select") {
+                PadBtn(label: "SEL", w: 40, h: 22, btn: .select)
+                    .scaleEffect(pos("select", landscape: true).scale)
+                    .position(x: pos("select", landscape: true).x * w, y: pos("select", landscape: true).y * h)
+            }
+            if layout.isControlVisible("start") {
+                PadBtn(label: "START", w: 48, h: 22, btn: .start)
+                    .scaleEffect(pos("start", landscape: true).scale)
+                    .position(x: pos("start", landscape: true).x * w, y: pos("start", landscape: true).y * h)
+            }
+            if layout.isControlVisible("lstick") {
+                StickView(isLeft: true, sizeScale: analogStickScale)
+                    .scaleEffect(pos("lstick", landscape: true).scale)
+                    .position(x: pos("lstick", landscape: true).x * w, y: pos("lstick", landscape: true).y * h)
+            }
+            if layout.isControlVisible("rstick") {
+                StickView(isLeft: false, sizeScale: analogStickScale)
+                    .scaleEffect(pos("rstick", landscape: true).scale)
+                    .position(x: pos("rstick", landscape: true).x * w, y: pos("rstick", landscape: true).y * h)
+            }
         }
     }
 
@@ -641,44 +695,93 @@ struct VirtualControllerView: View {
                     .frame(width: w, height: h)
                     .clipped()
                     .allowsHitTesting(false)
-            } else {
-                Color(white: 0.10).opacity(Double(settings.padOpacity))  // A002: apply opacity to background too
             }
 
             GeometryReader { cGeo in
                 let cW = cGeo.size.width
                 let cH = cGeo.size.height
 
-                PadBtn(label: "L2", w: 110, h: 40, btn: .L2)
-                    .scaleEffect(pos("l2", landscape: false).scale)
-                    .position(x: pos("l2", landscape: false).x * cW, y: pos("l2", landscape: false).y * cH)
-                PadBtn(label: "L1", w: 100, h: 30, btn: .L1)
-                    .scaleEffect(pos("l1", landscape: false).scale)
-                    .position(x: pos("l1", landscape: false).x * cW, y: pos("l1", landscape: false).y * cH)
-                PadBtn(label: "R2", w: 110, h: 40, btn: .R2)
-                    .scaleEffect(pos("r2", landscape: false).scale)
-                    .position(x: pos("r2", landscape: false).x * cW, y: pos("r2", landscape: false).y * cH)
-                PadBtn(label: "R1", w: 100, h: 30, btn: .R1)
-                    .scaleEffect(pos("r1", landscape: false).scale)
-                    .position(x: pos("r1", landscape: false).x * cW, y: pos("r1", landscape: false).y * cH)
-                PadBtn(label: "SEL", w: 42, h: 22, btn: .select)
-                    .scaleEffect(pos("select", landscape: false).scale)
-                    .position(x: pos("select", landscape: false).x * cW, y: pos("select", landscape: false).y * cH)
-                PadBtn(label: "START", w: 48, h: 22, btn: .start)
-                    .scaleEffect(pos("start", landscape: false).scale)
-                    .position(x: pos("start", landscape: false).x * cW, y: pos("start", landscape: false).y * cH)
-                DPadView(size: 100)
-                    .scaleEffect(pos("dpad", landscape: false).scale)
-                    .position(x: pos("dpad", landscape: false).x * cW, y: pos("dpad", landscape: false).y * cH)
-                ActionButtonsView(size: 42)
-                    .scaleEffect(pos("action", landscape: false).scale)
-                    .position(x: pos("action", landscape: false).x * cW, y: pos("action", landscape: false).y * cH)
-                StickView(isLeft: true, sizeScale: analogStickScale)
-                    .scaleEffect(pos("lstick", landscape: false).scale)
-                    .position(x: pos("lstick", landscape: false).x * cW, y: pos("lstick", landscape: false).y * cH)
-                StickView(isLeft: false, sizeScale: analogStickScale)
-                    .scaleEffect(pos("rstick", landscape: false).scale)
-                    .position(x: pos("rstick", landscape: false).x * cW, y: pos("rstick", landscape: false).y * cH)
+                if layout.isControlVisible("l2") {
+                    PadBtn(label: "L2", w: 110, h: 40, btn: .L2)
+                        .scaleEffect(pos("l2", landscape: false).scale)
+                        .position(x: pos("l2", landscape: false).x * cW, y: pos("l2", landscape: false).y * cH)
+                }
+                if layout.isControlVisible("l1") {
+                    PadBtn(label: "L1", w: 100, h: 30, btn: .L1)
+                        .scaleEffect(pos("l1", landscape: false).scale)
+                        .position(x: pos("l1", landscape: false).x * cW, y: pos("l1", landscape: false).y * cH)
+                }
+                if layout.isControlVisible("r2") {
+                    PadBtn(label: "R2", w: 110, h: 40, btn: .R2)
+                        .scaleEffect(pos("r2", landscape: false).scale)
+                        .position(x: pos("r2", landscape: false).x * cW, y: pos("r2", landscape: false).y * cH)
+                }
+                if layout.isControlVisible("r1") {
+                    PadBtn(label: "R1", w: 100, h: 30, btn: .R1)
+                        .scaleEffect(pos("r1", landscape: false).scale)
+                        .position(x: pos("r1", landscape: false).x * cW, y: pos("r1", landscape: false).y * cH)
+                }
+                if layout.isControlVisible("select") {
+                    PadBtn(label: "SEL", w: 42, h: 22, btn: .select)
+                        .scaleEffect(pos("select", landscape: false).scale)
+                        .position(x: pos("select", landscape: false).x * cW, y: pos("select", landscape: false).y * cH)
+                }
+                if layout.isControlVisible("start") {
+                    PadBtn(label: "START", w: 48, h: 22, btn: .start)
+                        .scaleEffect(pos("start", landscape: false).scale)
+                        .position(x: pos("start", landscape: false).x * cW, y: pos("start", landscape: false).y * cH)
+                }
+
+                // D-pad buttons (individual placement)
+                if layout.isControlVisible("dpad") {
+                    let dpadW = VirtualPadButtonOffset.dpadButtonWidth(isLandscape: false)
+                    PadBtn(label: "▲", w: dpadW, h: dpadW, btn: .up)
+                        .scaleEffect(perButtonPos("up", landscape: false, w: cW, h: cH).scale)
+                        .position(x: perButtonPos("up", landscape: false, w: cW, h: cH).x * cW, y: perButtonPos("up", landscape: false, w: cW, h: cH).y * cH)
+                    PadBtn(label: "▼", w: dpadW, h: dpadW, btn: .down)
+                        .scaleEffect(perButtonPos("down", landscape: false, w: cW, h: cH).scale)
+                        .position(x: perButtonPos("down", landscape: false, w: cW, h: cH).x * cW, y: perButtonPos("down", landscape: false, w: cW, h: cH).y * cH)
+                    PadBtn(label: "◀", w: dpadW, h: dpadW, btn: .left)
+                        .scaleEffect(perButtonPos("left", landscape: false, w: cW, h: cH).scale)
+                        .position(x: perButtonPos("left", landscape: false, w: cW, h: cH).x * cW, y: perButtonPos("left", landscape: false, w: cW, h: cH).y * cH)
+                    PadBtn(label: "▶", w: dpadW, h: dpadW, btn: .right)
+                        .scaleEffect(perButtonPos("right", landscape: false, w: cW, h: cH).scale)
+                        .position(x: perButtonPos("right", landscape: false, w: cW, h: cH).x * cW, y: perButtonPos("right", landscape: false, w: cW, h: cH).y * cH)
+                }
+
+                // Action buttons (individual placement)
+                let actionSz = VirtualPadButtonOffset.actionButtonSize
+                if layout.isControlVisible("triangle") {
+                    PSBtn(sym: "△", clr: .green, sz: actionSz, btn: .triangle)
+                        .scaleEffect(perButtonPos("triangle", landscape: false, w: cW, h: cH).scale)
+                        .position(x: perButtonPos("triangle", landscape: false, w: cW, h: cH).x * cW, y: perButtonPos("triangle", landscape: false, w: cW, h: cH).y * cH)
+                }
+                if layout.isControlVisible("cross") {
+                    PSBtn(sym: "✕", clr: .blue, sz: actionSz, btn: .cross)
+                        .scaleEffect(perButtonPos("cross", landscape: false, w: cW, h: cH).scale)
+                        .position(x: perButtonPos("cross", landscape: false, w: cW, h: cH).x * cW, y: perButtonPos("cross", landscape: false, w: cW, h: cH).y * cH)
+                }
+                if layout.isControlVisible("square") {
+                    PSBtn(sym: "□", clr: .pink, sz: actionSz, btn: .square)
+                        .scaleEffect(perButtonPos("square", landscape: false, w: cW, h: cH).scale)
+                        .position(x: perButtonPos("square", landscape: false, w: cW, h: cH).x * cW, y: perButtonPos("square", landscape: false, w: cW, h: cH).y * cH)
+                }
+                if layout.isControlVisible("circle") {
+                    PSBtn(sym: "○", clr: .red, sz: actionSz, btn: .circle)
+                        .scaleEffect(perButtonPos("circle", landscape: false, w: cW, h: cH).scale)
+                        .position(x: perButtonPos("circle", landscape: false, w: cW, h: cH).x * cW, y: perButtonPos("circle", landscape: false, w: cW, h: cH).y * cH)
+                }
+
+                if layout.isControlVisible("lstick") {
+                    StickView(isLeft: true, sizeScale: analogStickScale)
+                        .scaleEffect(pos("lstick", landscape: false).scale)
+                        .position(x: pos("lstick", landscape: false).x * cW, y: pos("lstick", landscape: false).y * cH)
+                }
+                if layout.isControlVisible("rstick") {
+                    StickView(isLeft: false, sizeScale: analogStickScale)
+                        .scaleEffect(pos("rstick", landscape: false).scale)
+                        .position(x: pos("rstick", landscape: false).x * cW, y: pos("rstick", landscape: false).y * cH)
+                }
             }
         }
     }
@@ -826,23 +929,33 @@ struct PSBtn: View {
     @Environment(\.padSkin) private var padSkin
     @Environment(\.padUsesFullSkin) private var padUsesFullSkin
 
+    private var touchTarget: CGFloat { max(sz, 55) }
+
     var body: some View {
-        Group {
-            if ARMSX2UsesUIKitPadPressSurface() {
+        if ARMSX2UsesUIKitPadPressSurface() {
+            ZStack {
                 UIKitPadPressSurface(onPress: updatePressed) {
                     buttonFace
+                        .frame(width: sz, height: sz)
                 }
-            } else {
-                buttonFace
-                    .contentShape(Circle())
-                    .simultaneousGesture(DragGesture(minimumDistance: 0)
-                        .onChanged { _ in updatePressed(true) }
-                        .onEnded { _ in updatePressed(false) })
+                .frame(width: touchTarget, height: touchTarget)
             }
+            .frame(width: touchTarget, height: touchTarget)
+            .opacity(padUsesFullSkin ? 1.0 : padOpacity)
+            .animation(.easeOut(duration: 0.06), value: on)
+        } else {
+            ZStack {
+                buttonFace
+                    .frame(width: sz, height: sz)
+            }
+            .frame(width: touchTarget, height: touchTarget)
+            .contentShape(Rectangle())
+            .opacity(padUsesFullSkin ? 1.0 : padOpacity)
+            .animation(.easeOut(duration: 0.06), value: on)
+            .simultaneousGesture(DragGesture(minimumDistance: 0)
+                .onChanged { _ in updatePressed(true) }
+                .onEnded { _ in updatePressed(false) })
         }
-        .frame(width: sz, height: sz)
-        .opacity(padUsesFullSkin ? 1.0 : padOpacity)
-        .animation(.easeOut(duration: 0.06), value: on)
     }
 
     private var buttonFace: some View {
@@ -890,23 +1003,34 @@ struct PadBtn: View {
     @Environment(\.padSkin) private var padSkin
     @Environment(\.padUsesFullSkin) private var padUsesFullSkin
 
+    private var touchW: CGFloat { max(w, 55) }
+    private var touchH: CGFloat { max(h, 55) }
+
     var body: some View {
-        Group {
-            if ARMSX2UsesUIKitPadPressSurface() {
+        if ARMSX2UsesUIKitPadPressSurface() {
+            ZStack {
                 UIKitPadPressSurface(onPress: updatePressed) {
                     buttonFace
+                        .frame(width: w, height: h)
                 }
-            } else {
-                buttonFace
-                    .contentShape(Rectangle())
-                    .simultaneousGesture(DragGesture(minimumDistance: 0)
-                        .onChanged { _ in updatePressed(true) }
-                        .onEnded { _ in updatePressed(false) })
+                .frame(width: touchW, height: touchH)
             }
+            .frame(width: touchW, height: touchH)
+            .opacity(padUsesFullSkin ? 1.0 : padOpacity)
+            .animation(.easeOut(duration: 0.06), value: on)
+        } else {
+            ZStack {
+                buttonFace
+                    .frame(width: w, height: h)
+            }
+            .frame(width: touchW, height: touchH)
+            .contentShape(Rectangle())
+            .opacity(padUsesFullSkin ? 1.0 : padOpacity)
+            .animation(.easeOut(duration: 0.06), value: on)
+            .simultaneousGesture(DragGesture(minimumDistance: 0)
+                .onChanged { _ in updatePressed(true) }
+                .onEnded { _ in updatePressed(false) })
         }
-        .frame(width: w, height: h)
-        .opacity(padUsesFullSkin ? 1.0 : padOpacity)
-        .animation(.easeOut(duration: 0.06), value: on)
     }
 
     private var buttonFace: some View {


### PR DESCRIPTION
## Summary

Improves the iOS virtual controller and pad layout editor. The portrait gameplay layout now uses a top game viewport with a bottom controller deck, the virtual pad background stays transparent unless a full custom skin is active, and individual controls can be positioned and hidden independently. The layout editor adds undo, transactional Cancel/Save behavior, skin rollback, orientation-mismatch handling, a compact top toolbar, and safer editor input handling. No workflow, build script, or documentation changes are included.

## Changelog

1. Adds per-button position overrides for the D-pad and action buttons, with fallback positions computed from the existing group layouts.
2. Adds per-control visibility toggles with group-level fallback and persists position/visibility state through INI save/load.
3. Renders portrait and landscape virtual controllers using the new per-button placement and visibility guards.
4. Removes the opaque portrait virtual-controller background when no full custom skin is active.
5. Reworks the portrait gameplay layout so the game viewport sits above the controller deck and the controller deck can extend through the bottom safe area.
6. Keeps gameplay visible while editing the pad layout and hides the gameplay virtual pad to avoid duplicate controls.
7. Adds undo, Cancel rollback, Save commit behavior, and skin-change rollback to the layout editor.
8. Shows an orientation-mismatch message and disables editable controls when the selected layout orientation does not match the device orientation.
9. Adds a compact top toolbar with visibility/reset options and an input shield so editor touches do not pass through to gameplay.

