### PR TITLE
Add iOS emulator volume controls

### DIFF
--- a/app/src/main/cpp/ARMSX2Bridge.h
+++ b/app/src/main/cpp/ARMSX2Bridge.h
@@ -102,6 +102,10 @@ typedef void (^ARMSX2RetroAchievementsCompletion)(BOOL success, NSString * _Nonn
 + (BOOL)isPerformanceOverlayVisible;
 + (void)applyOsdPreset:(int)preset;  // 0=off, 1=simple, 2=detail, 3=full
 
+// Audio
++ (int)emulatorVolumePercent;
++ (void)setEmulatorVolumePercent:(int)value;
+
 // ISO management
 + (nullable NSString *)currentISOPath;
 + (nullable NSString *)currentGameISOName;
@@ -137,13 +141,15 @@ typedef void (^ARMSX2RetroAchievementsCompletion)(BOOL success, NSString * _Nonn
             skipDrawStart:(int)skipDrawStart
        skipDrawEndOverride:(BOOL)skipDrawEndOverride
               skipDrawEnd:(int)skipDrawEnd
+         volumeOverride:(BOOL)volumeOverride
+           volumePercent:(int)volumePercent
                     eeCoreType:(int)eeCoreType
                           mtvu:(BOOL)mtvu
                   enableCheats:(BOOL)enableCheats
                  enablePatches:(BOOL)enablePatches
               enableGameFixes:(BOOL)enableGameFixes
     enableGameDBHardwareFixes:(BOOL)enableGameDBHardwareFixes
-    NS_SWIFT_NAME(setGameSettings(forISO:enabled:upscaleMultiplier:aspectRatio:textureFiltering:hardwareMipmapping:blendingAccuracy:interlaceMode:trilinearFiltering:halfPixelOffset:roundSprite:alignSpriteOverride:alignSprite:mergeSpriteOverride:mergeSprite:wildArmsOffsetOverride:wildArmsOffset:textureOffsetXOverride:textureOffsetX:textureOffsetYOverride:textureOffsetY:skipDrawStartOverride:skipDrawStart:skipDrawEndOverride:skipDrawEnd:eeCoreType:mtvu:enableCheats:enablePatches:enableGameFixes:enableGameDBHardwareFixes:));
+    NS_SWIFT_NAME(setGameSettings(forISO:enabled:upscaleMultiplier:aspectRatio:textureFiltering:hardwareMipmapping:blendingAccuracy:interlaceMode:trilinearFiltering:halfPixelOffset:roundSprite:alignSpriteOverride:alignSprite:mergeSpriteOverride:mergeSprite:wildArmsOffsetOverride:wildArmsOffset:textureOffsetXOverride:textureOffsetX:textureOffsetYOverride:textureOffsetY:skipDrawStartOverride:skipDrawStart:skipDrawEndOverride:skipDrawEnd:volumeOverride:volumePercent:eeCoreType:mtvu:enableCheats:enablePatches:enableGameFixes:enableGameDBHardwareFixes:));
 + (void)setGameSettingsForCurrentGameWithEnabled:(BOOL)enabled
                                upscaleMultiplier:(float)upscaleMultiplier
                                      aspectRatio:(nonnull NSString *)aspectRatio
@@ -168,13 +174,15 @@ typedef void (^ARMSX2RetroAchievementsCompletion)(BOOL success, NSString * _Nonn
                                    skipDrawStart:(int)skipDrawStart
                               skipDrawEndOverride:(BOOL)skipDrawEndOverride
                                      skipDrawEnd:(int)skipDrawEnd
+                                   volumeOverride:(BOOL)volumeOverride
+                                     volumePercent:(int)volumePercent
                                       eeCoreType:(int)eeCoreType
                                             mtvu:(BOOL)mtvu
                                     enableCheats:(BOOL)enableCheats
                                    enablePatches:(BOOL)enablePatches
                                  enableGameFixes:(BOOL)enableGameFixes
                       enableGameDBHardwareFixes:(BOOL)enableGameDBHardwareFixes
-    NS_SWIFT_NAME(setGameSettingsForCurrentGame(enabled:upscaleMultiplier:aspectRatio:textureFiltering:hardwareMipmapping:blendingAccuracy:interlaceMode:trilinearFiltering:halfPixelOffset:roundSprite:alignSpriteOverride:alignSprite:mergeSpriteOverride:mergeSprite:wildArmsOffsetOverride:wildArmsOffset:textureOffsetXOverride:textureOffsetX:textureOffsetYOverride:textureOffsetY:skipDrawStartOverride:skipDrawStart:skipDrawEndOverride:skipDrawEnd:eeCoreType:mtvu:enableCheats:enablePatches:enableGameFixes:enableGameDBHardwareFixes:));
+    NS_SWIFT_NAME(setGameSettingsForCurrentGame(enabled:upscaleMultiplier:aspectRatio:textureFiltering:hardwareMipmapping:blendingAccuracy:interlaceMode:trilinearFiltering:halfPixelOffset:roundSprite:alignSpriteOverride:alignSprite:mergeSpriteOverride:mergeSprite:wildArmsOffsetOverride:wildArmsOffset:textureOffsetXOverride:textureOffsetX:textureOffsetYOverride:textureOffsetY:skipDrawStartOverride:skipDrawStart:skipDrawEndOverride:skipDrawEnd:volumeOverride:volumePercent:eeCoreType:mtvu:enableCheats:enablePatches:enableGameFixes:enableGameDBHardwareFixes:));
 + (nonnull NSString *)clearCacheForISO:(nonnull NSString *)isoName NS_SWIFT_NAME(clearCache(forISO:));
 + (nonnull NSString *)deleteGameDataForISO:(nonnull NSString *)isoName NS_SWIFT_NAME(deleteGameData(forISO:));
 + (BOOL)deleteISO:(nonnull NSString *)isoName deleteGameData:(BOOL)deleteGameData NS_SWIFT_NAME(deleteISO(_:deleteGameData:));

--- a/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/app/src/main/cpp/ARMSX2Bridge.mm
@@ -21,6 +21,7 @@ extern "C" bool ARMSX2_IsSDLFullscreen();
 #include "SIO/Sio.h"
 #include "Counters.h"
 #include "GS/GSState.h"
+#include "SPU2/spu2.h"
 #include "GameList.h"
 #include "ps2/BiosTools.h"
 #include "pcsx2/Host.h"
@@ -71,6 +72,7 @@ static NSString* const ARMSX2CompatibilityProfileBranches = @"branches";
 static NSString* const ARMSX2CompatibilityProfileCustom = @"custom";
 static constexpr int ARMSX2UseGlobalIntSentinel = -1;
 static constexpr int ARMSX2TriFilterUseGlobalSentinel = std::numeric_limits<int>::min();
+static constexpr int ARMSX2DefaultAudioVolumePercent = 100;
 
 static int ARMSX2ClampInt(int value, int minValue, int maxValue)
 {
@@ -1427,6 +1429,10 @@ static NSMutableDictionary<NSString*, id>* ARMSX2BuildGlobalGameSettingsResult()
     const bool globalEnableGameDBHardwareFixes = g_p44_settings_interface ? !g_p44_settings_interface->GetBoolValue("EmuCore/GS", "UserHacks", false) : true;
     const int globalEECoreType = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/CPU", "CoreType", 2) : 2;
     const bool globalMTVU = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore/Speedhacks", "vuThread", true) : true;
+    const int globalVolumePercent = ARMSX2ClampInt(
+        g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("SPU2/Output", "StandardVolume", ARMSX2DefaultAudioVolumePercent) : ARMSX2DefaultAudioVolumePercent,
+        0,
+        ARMSX2DefaultAudioVolumePercent);
     return [@{
         @"enabled": @NO,
         @"path": @"",
@@ -1464,6 +1470,9 @@ static NSMutableDictionary<NSString*, id>* ARMSX2BuildGlobalGameSettingsResult()
         @"enableGameDBHardwareFixes": @(globalEnableGameDBHardwareFixes),
         @"eeCoreType": @(globalEECoreType),
         @"mtvu": @(globalMTVU),
+        @"globalVolumePercent": @(globalVolumePercent),
+        @"volumePercent": @(globalVolumePercent),
+        @"hasVolumeOverride": @NO,
     } mutableCopy];
 }
 
@@ -1519,9 +1528,20 @@ static void ARMSX2ApplyPerGameSettingsOverrides(NSMutableDictionary<NSString*, i
         si.ContainsValue("EmuCore/GS", "UserHacks") ||
         si.ContainsValue("EmuCore/CPU", "CoreType") ||
         si.ContainsValue("EmuCore/CPU", "UseArm64Dynarec") ||
-        si.ContainsValue("EmuCore/Speedhacks", "vuThread");
+        si.ContainsValue("EmuCore/Speedhacks", "vuThread") ||
+        si.ContainsValue("SPU2/Output", "StandardVolume") ||
+        si.ContainsValue("SPU2/Output", "FastForwardVolume");
 
     result[@"enabled"] = @(hasKnownOverride);
+    const bool hasStandardVolumeOverride = si.ContainsValue("SPU2/Output", "StandardVolume");
+    const bool hasFastForwardVolumeOverride = si.ContainsValue("SPU2/Output", "FastForwardVolume");
+    const bool hasVolumeOverride = hasStandardVolumeOverride || hasFastForwardVolumeOverride;
+    const int inheritedVolumePercent = [result[@"volumePercent"] intValue];
+    const int volumePercent = hasStandardVolumeOverride ?
+        si.GetIntValue("SPU2/Output", "StandardVolume", inheritedVolumePercent) :
+        (hasFastForwardVolumeOverride ? si.GetIntValue("SPU2/Output", "FastForwardVolume", inheritedVolumePercent) : inheritedVolumePercent);
+    result[@"hasVolumeOverride"] = @(hasVolumeOverride);
+    result[@"volumePercent"] = @(ARMSX2ClampInt(volumePercent, 0, ARMSX2DefaultAudioVolumePercent));
     NSString* currentAspect = [result[@"aspectRatio"] isKindOfClass:NSString.class] ? result[@"aspectRatio"] : @"Auto 4:3/3:2";
     result[@"upscaleMultiplier"] = @(si.GetFloatValue("EmuCore/GS", "upscale_multiplier", [result[@"upscaleMultiplier"] floatValue]));
     result[@"aspectRatio"] = ARMSX2NSStringFromStdString(si.GetStringValue("EmuCore/GS", "AspectRatio", currentAspect.UTF8String));
@@ -1583,6 +1603,8 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
                                                 int skipDrawStart,
                                                 BOOL skipDrawEndOverride,
                                                 int skipDrawEnd,
+                                                BOOL volumeOverride,
+                                                int volumePercent,
                                                 int eeCoreType,
                                                 BOOL mtvu,
                                                 BOOL enableCheats,
@@ -1658,6 +1680,15 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
         else
             si.DeleteValue("EmuCore/GS", "UserHacks_SkipDraw_End");
 
+        if (volumeOverride) {
+            const int clampedVolumePercent = ARMSX2ClampInt(volumePercent, 0, ARMSX2DefaultAudioVolumePercent);
+            si.SetIntValue("SPU2/Output", "StandardVolume", clampedVolumePercent);
+            si.SetIntValue("SPU2/Output", "FastForwardVolume", clampedVolumePercent);
+        } else {
+            si.DeleteValue("SPU2/Output", "StandardVolume");
+            si.DeleteValue("SPU2/Output", "FastForwardVolume");
+        }
+
         si.SetBoolValue("EmuCore", "EnableCheats", enableCheats);
         si.SetBoolValue("EmuCore", "EnablePatches", enablePatches);
         si.SetBoolValue("EmuCore", "EnableGameFixes", enableGameFixes);
@@ -1702,6 +1733,8 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
         si.DeleteValue("ARMSX2iOS/PerGame", "ManualMTVU");
         si.DeleteValue("ARMSX2iOS/PerGame", "ManualMTVUVersion");
         si.DeleteValue("EmuCore/Speedhacks", "vuThread");
+        si.DeleteValue("SPU2/Output", "StandardVolume");
+        si.DeleteValue("SPU2/Output", "FastForwardVolume");
         si.RemoveEmptySections();
     }
 
@@ -2231,6 +2264,8 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
             skipDrawStart:(int)skipDrawStart
        skipDrawEndOverride:(BOOL)skipDrawEndOverride
               skipDrawEnd:(int)skipDrawEnd
+         volumeOverride:(BOOL)volumeOverride
+           volumePercent:(int)volumePercent
                     eeCoreType:(int)eeCoreType
                           mtvu:(BOOL)mtvu
                   enableCheats:(BOOL)enableCheats
@@ -2250,7 +2285,8 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
                                         alignSprite, mergeSpriteOverride, mergeSprite, wildArmsOffsetOverride,
                                         wildArmsOffset, textureOffsetXOverride, textureOffsetX,
                                         textureOffsetYOverride, textureOffsetY, skipDrawStartOverride,
-                                        skipDrawStart, skipDrawEndOverride, skipDrawEnd, eeCoreType, mtvu,
+                                        skipDrawStart, skipDrawEndOverride, skipDrawEnd,
+                                        volumeOverride, volumePercent, eeCoreType, mtvu,
                                         enableCheats, enablePatches, enableGameFixes, enableGameDBHardwareFixes);
 }
 
@@ -2278,6 +2314,8 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
                                    skipDrawStart:(int)skipDrawStart
                               skipDrawEndOverride:(BOOL)skipDrawEndOverride
                                      skipDrawEnd:(int)skipDrawEnd
+                                   volumeOverride:(BOOL)volumeOverride
+                                     volumePercent:(int)volumePercent
                                       eeCoreType:(int)eeCoreType
                                             mtvu:(BOOL)mtvu
                                     enableCheats:(BOOL)enableCheats
@@ -2303,7 +2341,8 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
                                         alignSprite, mergeSpriteOverride, mergeSprite, wildArmsOffsetOverride,
                                         wildArmsOffset, textureOffsetXOverride, textureOffsetX,
                                         textureOffsetYOverride, textureOffsetY, skipDrawStartOverride,
-                                        skipDrawStart, skipDrawEndOverride, skipDrawEnd, eeCoreType, mtvu,
+                                        skipDrawStart, skipDrawEndOverride, skipDrawEnd,
+                                        volumeOverride, volumePercent, eeCoreType, mtvu,
                                         enableCheats, enablePatches, enableGameFixes, enableGameDBHardwareFixes);
 
     if (VMManager::HasValidVM()) {
@@ -2550,6 +2589,47 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
     EmuConfig.GS.OsdShowIndicators = GSConfig.OsdShowIndicators;
     EmuConfig.GS.OsdShowSettings = GSConfig.OsdShowSettings;
     EmuConfig.GS.OsdShowInputs = GSConfig.OsdShowInputs;
+}
+
++ (int)emulatorVolumePercent {
+    const int value = g_p44_settings_interface ?
+        g_p44_settings_interface->GetIntValue("SPU2/Output", "StandardVolume", ARMSX2DefaultAudioVolumePercent) :
+        ARMSX2DefaultAudioVolumePercent;
+    return ARMSX2ClampInt(value, 0, ARMSX2DefaultAudioVolumePercent);
+}
+
++ (void)setEmulatorVolumePercent:(int)value {
+    if (!g_p44_settings_interface)
+        return;
+
+    const int clampedValue = ARMSX2ClampInt(value, 0, ARMSX2DefaultAudioVolumePercent);
+    g_p44_settings_interface->SetIntValue("SPU2/Output", "StandardVolume", clampedValue);
+    g_p44_settings_interface->SetIntValue("SPU2/Output", "FastForwardVolume", clampedValue);
+    g_p44_settings_interface->Save();
+
+    if (!VMManager::HasValidVM())
+        return;
+
+    Host::RunOnCPUThread([clampedValue]() {
+        if (!VMManager::HasValidVM())
+            return;
+
+        const std::string serial = VMManager::GetDiscSerial();
+        const u32 crc = VMManager::GetDiscCRC();
+        if (crc != 0) {
+            INISettingsInterface si(VMManager::GetGameSettingsPath(serial, crc));
+            if (si.Load() &&
+                (si.ContainsValue("SPU2/Output", "StandardVolume") ||
+                 si.ContainsValue("SPU2/Output", "FastForwardVolume"))) {
+                return;
+            }
+        }
+
+        const Pcsx2Config oldConfig(EmuConfig);
+        EmuConfig.SPU2.StandardVolume = clampedValue;
+        EmuConfig.SPU2.FastForwardVolume = clampedValue;
+        SPU2::CheckForConfigChanges(oldConfig);
+    }, false);
 }
 
 // ============================================================

--- a/app/src/main/swift/Models/SettingsStore.swift
+++ b/app/src/main/swift/Models/SettingsStore.swift
@@ -68,6 +68,7 @@ final class SettingsStore: @unchecked Sendable {
     static let minFastForwardScalar: Float = 1.25
     static let maxFastForwardScalar: Float = 10.0
     static let defaultFastForwardScalar: Float = 2.0
+    static let defaultEmulatorVolumePercent = 100
     static let textureOffsetRange = -4096...4096
     static let skipDrawRange = 0...5000
     static let defaultOsdPerformancePosition = 3
@@ -138,6 +139,17 @@ final class SettingsStore: @unchecked Sendable {
             }
             guard !suppressINIWrites else { return }
             ARMSX2Bridge.setINIFloat("Framerate", key: "TurboScalar", value: fastForwardScalar)
+        }
+    }
+    var emulatorVolumePercent: Int {
+        didSet {
+            let normalized = Self.clampedEmulatorVolumePercent(emulatorVolumePercent)
+            guard emulatorVolumePercent == normalized else {
+                emulatorVolumePercent = normalized
+                return
+            }
+            guard !suppressINIWrites else { return }
+            ARMSX2Bridge.setEmulatorVolumePercent(Int32(normalized))
         }
     }
     var ntscFramerate: Float {
@@ -597,6 +609,7 @@ final class SettingsStore: @unchecked Sendable {
         targetFPS = Self.targetFPS(fromNominalScalar: nominalScalar, baseFramerate: loadedNTSCFramerate)
         Self.sanitizeNominalScalarIfNeeded(nominalScalar)
         fastForwardScalar = Self.clampedSpeedScalar(ARMSX2Bridge.getINIFloat("Framerate", key: "TurboScalar", defaultValue: Self.defaultFastForwardScalar))
+        emulatorVolumePercent = Self.clampedEmulatorVolumePercent(Int(ARMSX2Bridge.emulatorVolumePercent()))
         // Boot
         fastCDVD = ARMSX2Bridge.getINIBool("EmuCore/Speedhacks", key: "fastCDVD", defaultValue: false)
         // Advanced Speedhacks
@@ -728,6 +741,7 @@ final class SettingsStore: @unchecked Sendable {
         targetFPS = Self.targetFPS(fromNominalScalar: nominalScalar, baseFramerate: ntscFramerate)
         Self.sanitizeNominalScalarIfNeeded(nominalScalar)
         fastForwardScalar = Self.clampedSpeedScalar(ARMSX2Bridge.getINIFloat("Framerate", key: "TurboScalar", defaultValue: Self.defaultFastForwardScalar))
+        emulatorVolumePercent = Self.clampedEmulatorVolumePercent(Int(ARMSX2Bridge.emulatorVolumePercent()))
         fastCDVD = ARMSX2Bridge.getINIBool("EmuCore/Speedhacks", key: "fastCDVD", defaultValue: false)
         eeCycleRate = Int(ARMSX2Bridge.getINIInt("EmuCore/Speedhacks", key: "EECycleRate", defaultValue: 0))
         vu1Instant = ARMSX2Bridge.getINIBool("EmuCore/Speedhacks", key: "vu1Instant", defaultValue: true)
@@ -849,6 +863,10 @@ final class SettingsStore: @unchecked Sendable {
         guard scalar.isFinite else { return defaultFastForwardScalar }
         let stepped = (scalar * 4.0).rounded() / 4.0
         return min(max(stepped, minFastForwardScalar), maxFastForwardScalar)
+    }
+
+    static func clampedEmulatorVolumePercent(_ value: Int) -> Int {
+        min(max(value, 0), 100)
     }
 
     private static func clampedAnalogStickScale(_ scale: Float) -> Float {
@@ -997,6 +1015,7 @@ final class SettingsStore: @unchecked Sendable {
         fastForwardRuntimeEnabled = false
         frameLimiterDisabledForFastForward = false
         fastForwardScalar = Self.defaultFastForwardScalar
+        emulatorVolumePercent = Self.defaultEmulatorVolumePercent
         ntscFramerate = 59.94
         palFramerate = 50.0
         fastCDVD = false

--- a/app/src/main/swift/Views/GameListView.swift
+++ b/app/src/main/swift/Views/GameListView.swift
@@ -1623,6 +1623,9 @@ struct PerGameSettingsPanel: View {
     @State private var skipDrawStart: Int
     @State private var skipDrawEndOverride: Bool
     @State private var skipDrawEnd: Int
+    @State private var globalVolumePercent: Int
+    @State private var volumeOverride: Bool
+    @State private var volumePercent: Int
     @State private var eeCoreType: Int
     @State private var mtvu: Bool
     @State private var enableCheats: Bool
@@ -1644,6 +1647,11 @@ struct PerGameSettingsPanel: View {
         // this view never re-scans the disc image during init while a game is running.
         let info = preloadedSettings ?? ARMSX2Bridge.gameSettings(forISO: game.bootName)
         _enabled = State(initialValue: Self.boolValue(info["enabled"], defaultValue: false))
+        let inheritedVolume = Self.clampedVolume(Self.intValue(info["globalVolumePercent"], defaultValue: SettingsStore.defaultEmulatorVolumePercent))
+        let loadedVolume = Self.clampedVolume(Self.intValue(info["volumePercent"], defaultValue: inheritedVolume))
+        _globalVolumePercent = State(initialValue: inheritedVolume)
+        _volumeOverride = State(initialValue: Self.boolValue(info["hasVolumeOverride"], defaultValue: false))
+        _volumePercent = State(initialValue: loadedVolume)
         _upscaleMultiplier = State(initialValue: Self.floatValue(info["upscaleMultiplier"], defaultValue: 1.0))
         _aspectRatio = State(initialValue: Self.normalizedAspect(info["aspectRatio"] as? String))
         _textureFiltering = State(initialValue: Self.intValue(info["textureFiltering"], defaultValue: 2))
@@ -1712,6 +1720,23 @@ struct PerGameSettingsPanel: View {
         )
     }
 
+    private var volumeOverrideBinding: Binding<Bool> {
+        Binding(
+            get: { volumeOverride },
+            set: { newValue in
+                volumeOverride = newValue
+                volumePercent = newValue ? Self.clampedVolume(volumePercent) : globalVolumePercent
+            }
+        )
+    }
+
+    private var volumeSliderBinding: Binding<Double> {
+        Binding(
+            get: { Double(volumePercent) },
+            set: { volumePercent = Self.clampedVolume(Int($0.rounded())) }
+        )
+    }
+
     var body: some View {
         NavigationStack {
             Form {
@@ -1739,6 +1764,56 @@ struct PerGameSettingsPanel: View {
                 Section {
                     Toggle(settings.localized("Use Per-Game Overrides"), isOn: $enabled)
                     Text(settings.localized("Overrides are saved for this game only and apply on the next boot/reset of this title."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section(settings.localized("Audio")) {
+                    Toggle(settings.localized("Use Custom Volume"), isOn: volumeOverrideBinding)
+                        .disabled(!enabled)
+
+                    if volumeOverride {
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                Text(settings.localized("Emulator Volume"))
+                                Spacer()
+                                Text(Self.formatPercent(volumePercent))
+                                    .foregroundStyle(.secondary)
+                                    .font(.callout.monospacedDigit())
+                            }
+
+                            Slider(value: volumeSliderBinding, in: 0...100, step: 1)
+                                .disabled(!enabled)
+                                .accessibilityLabel(settings.localized("Per-Game Emulator Volume"))
+                                .accessibilityValue(Self.formatPercent(volumePercent))
+                                .accessibilityHint(settings.localized("Adjusts emulator audio for this game without changing iOS system volume or other apps."))
+
+                            HStack {
+                                Text("0%")
+                                Spacer()
+                                Button(settings.localized("Reset to Global")) {
+                                    volumeOverride = false
+                                    volumePercent = globalVolumePercent
+                                }
+                                .buttonStyle(.borderless)
+                                .disabled(!enabled)
+                                Spacer()
+                                Text("100%")
+                            }
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                        }
+                    } else {
+                        HStack {
+                            Text(settings.localized("Using Global"))
+                            Spacer()
+                            Text(Self.formatPercent(globalVolumePercent))
+                                .foregroundStyle(.secondary)
+                                .font(.callout.monospacedDigit())
+                        }
+                    }
+
+                    Text(settings.localized("Custom volume changes this game's emulator audio only. Turn it off to inherit the global Emulator Volume setting."))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -1997,6 +2072,8 @@ struct PerGameSettingsPanel: View {
                 skipDrawStart: Int32(normalizedSkipDraw.start),
                 skipDrawEndOverride: skipDrawEndOverride,
                 skipDrawEnd: Int32(normalizedSkipDraw.end),
+                volumeOverride: enabled && volumeOverride,
+                volumePercent: Int32(volumePercent),
                 eeCoreType: Int32(eeCoreType),
                 mtvu: mtvu,
                 enableCheats: enableCheats,
@@ -2031,6 +2108,8 @@ struct PerGameSettingsPanel: View {
                 skipDrawStart: Int32(normalizedSkipDraw.start),
                 skipDrawEndOverride: skipDrawEndOverride,
                 skipDrawEnd: Int32(normalizedSkipDraw.end),
+                volumeOverride: enabled && volumeOverride,
+                volumePercent: Int32(volumePercent),
                 eeCoreType: Int32(eeCoreType),
                 mtvu: mtvu,
                 enableCheats: enableCheats,
@@ -2039,7 +2118,10 @@ struct PerGameSettingsPanel: View {
                 enableGameDBHardwareFixes: enableGameDBHardwareFixes
             )
         }
-        statusMessage = enabled ? "\(settings.localized("Saved for")) \(game.metadata["serial"] ?? game.name). \(settings.localized("Reset or relaunch the game to apply."))" : settings.localized("Per-game overrides cleared.")
+        let applyMessage = savesToRunningGame ?
+            settings.localized("Volume changes apply now; some settings need reset or relaunch.") :
+            settings.localized("Reset or relaunch the game to apply.")
+        statusMessage = enabled ? "\(settings.localized("Saved for")) \(game.metadata["serial"] ?? game.name). \(applyMessage)" : settings.localized("Per-game overrides cleared.")
     }
 
     private func normalizeSkipDrawRangeIfNeeded() {
@@ -2102,6 +2184,14 @@ struct PerGameSettingsPanel: View {
 
     private static func clampedSkipDraw(_ value: Int) -> Int {
         min(max(value, SettingsStore.skipDrawRange.lowerBound), SettingsStore.skipDrawRange.upperBound)
+    }
+
+    private static func clampedVolume(_ value: Int) -> Int {
+        SettingsStore.clampedEmulatorVolumePercent(value)
+    }
+
+    private static func formatPercent(_ value: Int) -> String {
+        "\(clampedVolume(value))%"
     }
 
     private static func normalizedSkipDrawEnd(start: Int, end: Int, startOverride: Bool, endOverride: Bool) -> Int {

--- a/app/src/main/swift/Views/Settings/EmulatorSettingsView.swift
+++ b/app/src/main/swift/Views/Settings/EmulatorSettingsView.swift
@@ -115,6 +115,47 @@ struct EmulatorSettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
+            Section(settings.localized("Audio")) {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text(settings.localized("Emulator Volume"))
+                        Spacer()
+                        Text(Self.formatPercent(settings.emulatorVolumePercent))
+                            .foregroundStyle(.secondary)
+                            .font(.callout.monospacedDigit())
+                    }
+
+                    Slider(
+                        value: Binding(
+                            get: { Double(settings.emulatorVolumePercent) },
+                            set: { settings.emulatorVolumePercent = Int($0.rounded()) }
+                        ),
+                        in: 0...100,
+                        step: 1
+                    )
+                    .accessibilityLabel(settings.localized("Emulator Volume"))
+                    .accessibilityValue(Self.formatPercent(settings.emulatorVolumePercent))
+                    .accessibilityHint(settings.localized("Adjusts emulator game audio without changing iOS system volume or other apps."))
+
+                    HStack {
+                        Text("0%")
+                        Spacer()
+                        Button(settings.localized("Reset")) {
+                            settings.emulatorVolumePercent = SettingsStore.defaultEmulatorVolumePercent
+                        }
+                        .buttonStyle(.borderless)
+                        Spacer()
+                        Text("100%")
+                    }
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                }
+
+                Text(settings.localized("Controls emulator and game audio only. iOS system volume and other apps stay separate."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section(settings.localized("Performance")) {
                 Toggle(settings.localized("Frame Limiter"), isOn: $settings.frameLimiterEnabled)
 
@@ -248,5 +289,9 @@ struct EmulatorSettingsView: View {
 
     private static func formatFPS(_ value: Float) -> String {
         String(format: "%.2f FPS", value)
+    }
+
+    private static func formatPercent(_ value: Int) -> String {
+        "\(SettingsStore.clampedEmulatorVolumePercent(value))%"
     }
 }


### PR DESCRIPTION
This PR adds emulator volume controls to the iOS app, making it easier to lower game audio while using Discord, calls, music, or other system audio.

It adds a new **Emulator Volume** slider in the global emulator settings. The slider controls emulator/game audio only, while leaving iOS system volume and other apps unchanged. The selected volume is saved between launches and applies to both normal gameplay and fast-forward audio so volume stays predictable.

This PR also adds per-game volume overrides. Users can choose a custom volume for individual games, or leave a game set to use the global emulator volume. Per-game overrides can be reset back to global at any time without affecting other per-game settings.

## What changed

* Added a global **Emulator Volume** slider under Emulator settings.
* Added support for volume values from **0% to 100%**.
* Saved emulator volume between app launches.
* Applied the same volume value to normal and fast-forward audio.
* Added per-game custom volume support.
* Added a **Use Custom Volume** toggle in per-game settings.
* Added a **Using Global: XX%** state when no custom volume is set.
* Added **Reset to Global** behavior for per-game volume.
* Preserved unrelated per-game settings when disabling custom volume.
* Added a small native bridge path for applying emulator volume settings.
* Added accessibility-friendly labels and visible percentage values for the new controls.

