### PR TITLE
iOS: QuickLoad PS2 games from an extracted-disc folder (ELF + linked disc)

### DIFF
--- a/app/src/main/cpp/ARMSX2Bridge.h
+++ b/app/src/main/cpp/ARMSX2Bridge.h
@@ -183,6 +183,8 @@ typedef void (^ARMSX2RetroAchievementsCompletion)(BOOL success, NSString * _Nonn
                                  enableGameFixes:(BOOL)enableGameFixes
                       enableGameDBHardwareFixes:(BOOL)enableGameDBHardwareFixes
     NS_SWIFT_NAME(setGameSettingsForCurrentGame(enabled:upscaleMultiplier:aspectRatio:textureFiltering:hardwareMipmapping:blendingAccuracy:interlaceMode:trilinearFiltering:halfPixelOffset:roundSprite:alignSpriteOverride:alignSprite:mergeSpriteOverride:mergeSprite:wildArmsOffsetOverride:wildArmsOffset:textureOffsetXOverride:textureOffsetX:textureOffsetYOverride:textureOffsetY:skipDrawStartOverride:skipDrawStart:skipDrawEndOverride:skipDrawEnd:volumeOverride:volumePercent:eeCoreType:mtvu:enableCheats:enablePatches:enableGameFixes:enableGameDBHardwareFixes:));
++ (nullable NSString *)linkedDiscPathForELF:(nonnull NSString *)elfName NS_SWIFT_NAME(linkedDiscPath(forELF:));
++ (void)setLinkedDiscPath:(nullable NSString *)discPath forELF:(nonnull NSString *)elfName NS_SWIFT_NAME(setLinkedDiscPath(_:forELF:));
 + (nonnull NSString *)clearCacheForISO:(nonnull NSString *)isoName NS_SWIFT_NAME(clearCache(forISO:));
 + (nonnull NSString *)deleteGameDataForISO:(nonnull NSString *)isoName NS_SWIFT_NAME(deleteGameData(forISO:));
 + (BOOL)deleteISO:(nonnull NSString *)isoName deleteGameData:(BOOL)deleteGameData NS_SWIFT_NAME(deleteISO(_:deleteGameData:));

--- a/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/app/src/main/cpp/ARMSX2Bridge.mm
@@ -2396,7 +2396,7 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
     si.Load();
     NSString* trimmed = [discPath stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     if (trimmed.length > 0)
-        si.SetStringValue("EmuCore", "DiscPath", (ARMSX2ResolveISOPath(trimmed) ?: trimmed).UTF8String);
+        si.SetStringValue("EmuCore", "DiscPath", trimmed.UTF8String);
     else
         si.DeleteValue("EmuCore", "DiscPath");
     si.Save();

--- a/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/app/src/main/cpp/ARMSX2Bridge.mm
@@ -769,6 +769,28 @@ static BOOL ARMSX2IsSupportedGameImageAtPath(NSString* path)
 	return NO;
 }
 
+static void ARMSX2EnumerateLocalGameImages(NSString* root, void (^block)(NSString* absolutePath, NSString* relativeName))
+{
+	NSFileManager* fm = [NSFileManager defaultManager];
+	BOOL isDir = NO;
+	if (root.length == 0 || block == nil || ![fm fileExistsAtPath:root isDirectory:&isDir] || !isDir)
+		return;
+	NSString* prefix = [root.stringByStandardizingPath stringByAppendingString:@"/"];
+	for (NSURL* url in [fm enumeratorAtURL:[NSURL fileURLWithPath:root isDirectory:YES]
+	               includingPropertiesForKeys:nil
+	                                  options:NSDirectoryEnumerationSkipsHiddenFiles
+	                             errorHandler:nil]) {
+		NSString* path = url.path;
+		if (!ARMSX2IsSupportedGameImageAtPath(path))
+			continue;
+		NSString* full = path.stringByStandardizingPath;
+		NSString* rel = [full hasPrefix:prefix] ? [full substringFromIndex:prefix.length] : full.lastPathComponent;
+		if ([rel containsString:@"/"] && ![rel.pathExtension.lowercaseString isEqualToString:@"elf"])
+			continue;
+		block(path, rel);
+	}
+}
+
 static NSString* ARMSX2ResolveISOPath(NSString* isoName)
 {
 	if (isoName.length == 0)
@@ -2063,8 +2085,11 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
         }
     };
 
-    // Scan Documents/iso/ first, then Documents/ root
-    scanDir([self isoDirectory]);
+    ARMSX2EnumerateLocalGameImages([self isoDirectory], ^(NSString* absolutePath, NSString* relativeName) {
+        if ([seen containsObject:relativeName]) return;
+        [isos addObject:relativeName];
+        [seen addObject:relativeName];
+    });
     NSString *docsPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
     scanDir(docsPath);
 
@@ -2106,7 +2131,9 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
 		}
 	};
 
-	scanLocalDir([self isoDirectory], @"On My iPhone");
+	ARMSX2EnumerateLocalGameImages([self isoDirectory], ^(NSString* absolutePath, NSString* relativeName) {
+		addPathWithName(absolutePath, relativeName, NO, @"On My iPhone", YES);
+	});
 	scanLocalDir([self documentsDirectory], @"On My iPhone");
 
 	for (NSDictionary* record in ARMSX2ExternalGameDirectoryRecords()) {
@@ -2350,6 +2377,29 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
         if (MTGS::IsOpen())
             MTGS::ApplySettings();
     }
+}
+
++ (nullable NSString *)linkedDiscPathForELF:(nonnull NSString *)elfName {
+    NSString* resolvedPath = ARMSX2ResolveISOPath(elfName);
+    if (resolvedPath.length == 0)
+        return nil;
+    const std::string discPath = VMManager::GetDiscOverrideFromGameSettings(resolvedPath.UTF8String);
+    return discPath.empty() ? nil : ARMSX2NSStringFromStdString(discPath);
+}
+
++ (void)setLinkedDiscPath:(nullable NSString *)discPath forELF:(nonnull NSString *)elfName {
+    GameList::Entry entry;
+    if (!ARMSX2PopulateGameListEntryForISO(elfName, &entry, nil) || entry.crc == 0)
+        return;
+    FileSystem::CreateDirectoryPath(EmuFolders::GameSettings.c_str(), false);
+    INISettingsInterface si(VMManager::GetGameSettingsPath(std::string_view(), entry.crc));
+    si.Load();
+    NSString* trimmed = [discPath stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (trimmed.length > 0)
+        si.SetStringValue("EmuCore", "DiscPath", (ARMSX2ResolveISOPath(trimmed) ?: trimmed).UTF8String);
+    else
+        si.DeleteValue("EmuCore", "DiscPath");
+    si.Save();
 }
 
 + (nonnull NSString *)clearCacheForISO:(nonnull NSString *)isoName {

--- a/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/app/src/main/cpp/ARMSX2Bridge.mm
@@ -2245,7 +2245,8 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
         return result;
     }
 
-    ARMSX2ApplyPerGameSettingsOverrides(result, entry.serial, entry.crc);
+    const std::string settingsSerial = (entry.type == GameList::EntryType::ELF) ? std::string() : entry.serial;
+    ARMSX2ApplyPerGameSettingsOverrides(result, settingsSerial, entry.crc);
     return result;
 }
 
@@ -2257,7 +2258,7 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
         return nil;
 
     NSMutableDictionary<NSString*, id>* result = ARMSX2BuildGlobalGameSettingsResult();
-    const std::string serial = VMManager::GetDiscSerial();
+    const std::string serial = VMManager::GetSerialForGameSettings();
     const u32 crc = VMManager::GetDiscCRC();
     if (serial.empty() && crc == 0)
         return result;
@@ -2306,7 +2307,8 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
         return;
     }
 
-    ARMSX2WriteGameSettingsForIdentity(entry.serial, entry.crc, enabled, upscaleMultiplier, aspectRatio,
+    const std::string settingsSerial = (entry.type == GameList::EntryType::ELF) ? std::string() : entry.serial;
+    ARMSX2WriteGameSettingsForIdentity(settingsSerial, entry.crc, enabled, upscaleMultiplier, aspectRatio,
                                         textureFiltering, hardwareMipmapping, blendingAccuracy, interlaceMode,
                                         trilinearFiltering, halfPixelOffset, roundSprite, alignSpriteOverride,
                                         alignSprite, mergeSpriteOverride, mergeSprite, wildArmsOffsetOverride,
@@ -2354,7 +2356,7 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
         return;
     }
 
-    const std::string serial = VMManager::GetDiscSerial();
+    const std::string serial = VMManager::GetSerialForGameSettings();
     const u32 crc = VMManager::GetDiscCRC();
     if (crc == 0) {
         NSLog(@"[ARMSX2Bridge] Current game settings save rejected serial=%@ crc=%08X",
@@ -2396,7 +2398,12 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
     si.Load();
     NSString* trimmed = [discPath stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     if (trimmed.length > 0)
-        si.SetStringValue("EmuCore", "DiscPath", trimmed.UTF8String);
+    {
+        NSString* root = [ARMSX2NSStringFromStdString(EmuFolders::DataRoot).stringByStandardizingPath stringByAppendingString:@"/"];
+        NSString* full = trimmed.stringByStandardizingPath;
+        NSString* rel = [full hasPrefix:root] ? [full substringFromIndex:root.length] : trimmed;
+        si.SetStringValue("EmuCore", "DiscPath", rel.UTF8String);
+    }
     else
         si.DeleteValue("EmuCore", "DiscPath");
     si.Save();

--- a/app/src/main/cpp/ios_main.mm
+++ b/app/src/main/cpp/ios_main.mm
@@ -3949,18 +3949,10 @@ INISettingsInterface* g_p44_settings_interface = nullptr;
                         boot_params.elf_override = isoPath;
                         boot_params.source_type = CDVD_SourceType::NoDisc;
                         boot_params.fast_boot = true;
-                        std::string discName = VMManager::GetDiscOverrideFromGameSettings(isoPath);
-                        if (!discName.empty()) {
-                            std::string discPath = (discName.front() == '/') ? discName : (isoDir + "/" + discName);
-                            if (discName.front() != '/' && !FileSystem::FileExists(discPath.c_str())) {
-                                std::string rootDisc = EmuFolders::DataRoot + "/" + discName;
-                                if (FileSystem::FileExists(rootDisc.c_str()))
-                                    discPath = rootDisc;
-                            }
-                            if (FileSystem::FileExists(discPath.c_str())) {
-                                boot_params.filename = discPath;
-                                boot_params.source_type = CDVD_SourceType::Iso;
-                            }
+                        std::string discPath = VMManager::GetDiscOverrideFromGameSettings(isoPath);
+                        if (!discPath.empty() && FileSystem::FileExists(discPath.c_str())) {
+                            boot_params.filename = discPath;
+                            boot_params.source_type = CDVD_SourceType::Iso;
                         }
                     } else {
                         boot_params.filename = isoPath;

--- a/app/src/main/cpp/ios_main.mm
+++ b/app/src/main/cpp/ios_main.mm
@@ -3950,9 +3950,14 @@ INISettingsInterface* g_p44_settings_interface = nullptr;
                         boot_params.source_type = CDVD_SourceType::NoDisc;
                         boot_params.fast_boot = true;
                         std::string discPath = VMManager::GetDiscOverrideFromGameSettings(isoPath);
-                        if (!discPath.empty() && FileSystem::FileExists(discPath.c_str())) {
-                            boot_params.filename = discPath;
-                            boot_params.source_type = CDVD_SourceType::Iso;
+                        if (!discPath.empty()) {
+                            if (FileSystem::FileExists(discPath.c_str())) {
+                                boot_params.filename = discPath;
+                                boot_params.source_type = CDVD_SourceType::Iso;
+                            } else {
+                                Host::ReportErrorAsync("Linked disc not found",
+                                    "This ELF has a linked disc, but the disc file is missing. Booting without it. Re-link it in the game's Disc Path menu.");
+                            }
                         }
                     } else {
                         boot_params.filename = isoPath;

--- a/app/src/main/cpp/ios_main.mm
+++ b/app/src/main/cpp/ios_main.mm
@@ -3949,10 +3949,18 @@ INISettingsInterface* g_p44_settings_interface = nullptr;
                         boot_params.elf_override = isoPath;
                         boot_params.source_type = CDVD_SourceType::NoDisc;
                         boot_params.fast_boot = true;
-                        std::string discPath = VMManager::GetDiscOverrideFromGameSettings(isoPath);
-                        if (!discPath.empty() && FileSystem::FileExists(discPath.c_str())) {
-                            boot_params.filename = discPath;
-                            boot_params.source_type = CDVD_SourceType::Iso;
+                        std::string discName = VMManager::GetDiscOverrideFromGameSettings(isoPath);
+                        if (!discName.empty()) {
+                            std::string discPath = (discName.front() == '/') ? discName : (isoDir + "/" + discName);
+                            if (discName.front() != '/' && !FileSystem::FileExists(discPath.c_str())) {
+                                std::string rootDisc = EmuFolders::DataRoot + "/" + discName;
+                                if (FileSystem::FileExists(rootDisc.c_str()))
+                                    discPath = rootDisc;
+                            }
+                            if (FileSystem::FileExists(discPath.c_str())) {
+                                boot_params.filename = discPath;
+                                boot_params.source_type = CDVD_SourceType::Iso;
+                            }
                         }
                     } else {
                         boot_params.filename = isoPath;

--- a/app/src/main/cpp/ios_main.mm
+++ b/app/src/main/cpp/ios_main.mm
@@ -3949,10 +3949,11 @@ INISettingsInterface* g_p44_settings_interface = nullptr;
                         boot_params.elf_override = isoPath;
                         boot_params.source_type = CDVD_SourceType::NoDisc;
                         boot_params.fast_boot = true;
-                        std::fprintf(stderr, "@@ISO_BOOT@@ path=%s fast_boot=1 mode=ELF INI=\"%s\"\n",
-                            isoPath.c_str(), isoFilename.c_str());
-                        std::fflush(stderr);
-                        Console.WriteLn("@@ISO_BOOT@@ path=%s fast_boot=1 mode=ELF (INI: %s)", isoPath.c_str(), isoFilename.c_str());
+                        std::string discPath = VMManager::GetDiscOverrideFromGameSettings(isoPath);
+                        if (!discPath.empty() && FileSystem::FileExists(discPath.c_str())) {
+                            boot_params.filename = discPath;
+                            boot_params.source_type = CDVD_SourceType::Iso;
+                        }
                     } else {
                         boot_params.filename = isoPath;
                         boot_params.source_type = CDVD_SourceType::Iso;

--- a/app/src/main/cpp/pcsx2/IopBios.cpp
+++ b/app/src/main/cpp/pcsx2/IopBios.cpp
@@ -32,8 +32,15 @@
 #include <io.h>
 #else
 #include <unistd.h>
+#endif
+
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#if TARGET_OS_IOS
+#define ARMSX2_HOSTFS_CASE_INSENSITIVE 1
 #include <dirent.h>
 #include <strings.h>
+#endif
 #endif
 
 #if !defined(S_ISREG) && defined(S_IFMT) && defined(S_IFREG)
@@ -618,7 +625,7 @@ namespace R3000A
 			return (path.compare(0, 4, "host") == 0 && path[not_number_pos] == ':');
 		}
 
-#ifndef _WIN32
+#ifdef ARMSX2_HOSTFS_CASE_INSENSITIVE
 		static std::string resolve_case_insensitive(const std::string& root, const std::string& full_path)
 		{
 			if (full_path.empty() || FileSystem::FileExists(full_path.c_str()) || FileSystem::DirectoryExists(full_path.c_str()))
@@ -704,7 +711,7 @@ namespace R3000A
 				}
 			}
 
-#ifndef _WIN32
+#ifdef ARMSX2_HOSTFS_CASE_INSENSITIVE
 			if (!new_path.empty())
 				new_path = resolve_case_insensitive(hostRoot, new_path);
 #endif

--- a/app/src/main/cpp/pcsx2/IopBios.cpp
+++ b/app/src/main/cpp/pcsx2/IopBios.cpp
@@ -32,6 +32,8 @@
 #include <io.h>
 #else
 #include <unistd.h>
+#include <dirent.h>
+#include <strings.h>
 #endif
 
 #if !defined(S_ISREG) && defined(S_IFMT) && defined(S_IFREG)
@@ -616,6 +618,50 @@ namespace R3000A
 			return (path.compare(0, 4, "host") == 0 && path[not_number_pos] == ':');
 		}
 
+#ifndef _WIN32
+		static std::string resolve_case_insensitive(const std::string& root, const std::string& full_path)
+		{
+			if (full_path.empty() || FileSystem::FileExists(full_path.c_str()) || FileSystem::DirectoryExists(full_path.c_str()))
+				return full_path;
+			if (full_path.size() < root.size() || full_path.compare(0, root.size(), root) != 0)
+				return full_path;
+
+			std::string resolved = root;
+			size_t pos = root.size();
+			while (pos < full_path.size())
+			{
+				while (pos < full_path.size() && full_path[pos] == '/')
+					pos++;
+				size_t next = full_path.find('/', pos);
+				if (next == std::string::npos)
+					next = full_path.size();
+				const std::string comp = full_path.substr(pos, next - pos);
+				pos = next;
+				if (comp.empty())
+					continue;
+
+				std::string candidate = resolved + "/" + comp;
+				if (FileSystem::FileExists(candidate.c_str()) || FileSystem::DirectoryExists(candidate.c_str()))
+				{
+					resolved = std::move(candidate);
+					continue;
+				}
+
+				std::string match;
+				if (DIR* dir = opendir(resolved.c_str()))
+				{
+					while (struct dirent* ent = readdir(dir))
+						if (strcasecmp(ent->d_name, comp.c_str()) == 0) { match = ent->d_name; break; }
+					closedir(dir);
+				}
+				if (match.empty())
+					return full_path;
+				resolved += "/" + match;
+			}
+			return resolved;
+		}
+#endif
+
 		std::string host_path(const std::string_view path, bool allow_open_host_root)
 		{
 			// We are NOT allowing to use the root of the host unit.
@@ -657,6 +703,11 @@ namespace R3000A
 					new_path.clear();
 				}
 			}
+
+#ifndef _WIN32
+			if (!new_path.empty())
+				new_path = resolve_case_insensitive(hostRoot, new_path);
+#endif
 
 			return new_path;
 		}

--- a/app/src/main/cpp/pcsx2/IopBios.cpp
+++ b/app/src/main/cpp/pcsx2/IopBios.cpp
@@ -40,6 +40,9 @@
 #define ARMSX2_HOSTFS_CASE_INSENSITIVE 1
 #include <dirent.h>
 #include <strings.h>
+#include <unordered_map>
+#include <mutex>
+#include <vector>
 #endif
 #endif
 
@@ -93,16 +96,31 @@ typedef struct
 
 static std::string hostRoot;
 
+#ifdef ARMSX2_HOSTFS_CASE_INSENSITIVE
+static std::mutex s_hostfsCaseCacheMutex;
+static std::unordered_map<std::string, std::string> s_hostfsCaseCache;
+static void hostfs_invalidate_case_cache()
+{
+	std::lock_guard<std::mutex> lock(s_hostfsCaseCacheMutex);
+	s_hostfsCaseCache.clear();
+}
+#endif
 
 void Hle_SetHostRoot(const char* bootFilename)
 {
 	hostRoot = Path::ToNativePath(Path::GetDirectory(bootFilename));
+#ifdef ARMSX2_HOSTFS_CASE_INSENSITIVE
+	hostfs_invalidate_case_cache();
+#endif
 	Console.WriteLn("HLE Host: Set 'host:' root path to: %s\n", hostRoot.c_str());
 }
 
 void Hle_ClearHostRoot()
 {
 	hostRoot = {};
+#ifdef ARMSX2_HOSTFS_CASE_INSENSITIVE
+	hostfs_invalidate_case_cache();
+#endif
 }
 
 // [TEMP_DIAG] IOP reboot counter — defined in R3000AInterpreter.cpp
@@ -310,6 +328,11 @@ namespace R3000A
 			const int hostfd = FileSystem::OpenFDFile(file_path.c_str(), native_flags, native_mode);
 			if (hostfd < 0)
 				return translate_error(hostfd);
+
+#ifdef ARMSX2_HOSTFS_CASE_INSENSITIVE
+			if (flags & IOP_O_CREAT)
+				hostfs_invalidate_case_cache();
+#endif
 
 			*file = new HostFile(hostfd);
 			if (!*file)
@@ -633,19 +656,27 @@ namespace R3000A
 			if (full_path.size() < root.size() || full_path.compare(0, root.size(), root) != 0)
 				return full_path;
 
+			{
+				std::lock_guard<std::mutex> lock(s_hostfsCaseCacheMutex);
+				const auto it = s_hostfsCaseCache.find(full_path);
+				if (it != s_hostfsCaseCache.end())
+					return it->second;
+			}
+
 			std::string resolved = root;
 			size_t pos = root.size();
 			while (pos < full_path.size())
 			{
 				while (pos < full_path.size() && full_path[pos] == '/')
 					pos++;
+				if (pos >= full_path.size())
+					break;
+				const size_t comp_start = pos;
 				size_t next = full_path.find('/', pos);
 				if (next == std::string::npos)
 					next = full_path.size();
 				const std::string comp = full_path.substr(pos, next - pos);
 				pos = next;
-				if (comp.empty())
-					continue;
 
 				std::string candidate = resolved + "/" + comp;
 				if (FileSystem::FileExists(candidate.c_str()) || FileSystem::DirectoryExists(candidate.c_str()))
@@ -654,17 +685,31 @@ namespace R3000A
 					continue;
 				}
 
-				std::string match;
+				std::vector<std::string> folded;
 				if (DIR* dir = opendir(resolved.c_str()))
 				{
 					while (struct dirent* ent = readdir(dir))
-						if (strcasecmp(ent->d_name, comp.c_str()) == 0) { match = ent->d_name; break; }
+						if (strcasecmp(ent->d_name, comp.c_str()) == 0)
+							folded.emplace_back(ent->d_name);
 					closedir(dir);
 				}
-				if (match.empty())
-					return full_path;
-				resolved += "/" + match;
+
+				if (folded.empty())
+				{
+					resolved += "/" + full_path.substr(comp_start);
+					break;
+				}
+				if (folded.size() > 1)
+				{
+					std::sort(folded.begin(), folded.end());
+					Console.Warning(fmt::format("IopHLE: host: ambiguous case-insensitive match for '{}' in '{}' ({} candidates), using '{}'",
+						comp, resolved, folded.size(), folded.front()));
+				}
+				resolved += "/" + folded.front();
 			}
+
+			std::lock_guard<std::mutex> lock(s_hostfsCaseCacheMutex);
+			s_hostfsCaseCache.emplace(full_path, resolved);
 			return resolved;
 		}
 #endif
@@ -981,6 +1026,9 @@ namespace R3000A
 				const std::string path = full_path.substr(full_path.find(':') + 1);
 				const std::string file_path(host_path(path, false));
 				const bool succeeded = FileSystem::DeleteFilePath(file_path.c_str());
+#ifdef ARMSX2_HOSTFS_CASE_INSENSITIVE
+				hostfs_invalidate_case_cache();
+#endif
 				if (!succeeded)
 					Console.Warning("IOPHLE remove_HLE failed for '%s'", file_path.c_str());
 				v0 = succeeded ? 0 : -IOP_EIO;
@@ -998,6 +1046,9 @@ namespace R3000A
 				const std::string path = full_path.substr(full_path.find(':') + 1);
 				const std::string folder_path(host_path(path, false)); // NOTE: Don't allow creating the ELF directory.
 				const bool succeeded = FileSystem::CreateDirectoryPath(folder_path.c_str(), false);
+#ifdef ARMSX2_HOSTFS_CASE_INSENSITIVE
+				hostfs_invalidate_case_cache();
+#endif
 				if (!succeeded)
 					Console.Warning("IOPHLE mkdir_HLE failed for '%s'", folder_path.c_str());
 				v0 = succeeded ? 0 : -IOP_EIO;
@@ -1047,6 +1098,9 @@ namespace R3000A
 				const std::string path = full_path.substr(full_path.find(':') + 1);
 				const std::string folder_path(host_path(path, false)); // NOTE: Don't allow removing the elf directory itself.
 				const bool succeeded = FileSystem::DeleteDirectory(folder_path.c_str());
+#ifdef ARMSX2_HOSTFS_CASE_INSENSITIVE
+				hostfs_invalidate_case_cache();
+#endif
 				if (!succeeded)
 					Console.Warning("IOPHLE rmdir_HLE failed for '%s'", folder_path.c_str());
 				v0 = succeeded ? 0 : -IOP_EIO;

--- a/app/src/main/cpp/pcsx2/VMManager.cpp
+++ b/app/src/main/cpp/pcsx2/VMManager.cpp
@@ -973,6 +973,14 @@ std::string VMManager::GetDiscOverrideFromGameSettings(const std::string& elf_pa
 		if (si.Load())
 		{
 			iso_path = si.GetStringValue("EmuCore", "DiscPath");
+			if (!iso_path.empty() && !Path::IsAbsolute(iso_path))
+			{
+				std::string resolved(Path::Combine(EmuFolders::DataRoot, iso_path));
+				if (!FileSystem::FileExists(resolved.c_str()))
+					resolved = Path::Combine(EmuFolders::DataRoot, "iso/" + iso_path);
+				if (FileSystem::FileExists(resolved.c_str()))
+					iso_path = std::move(resolved);
+			}
 			if (!iso_path.empty())
 				Console.WriteLn(fmt::format("Disc override for ELF at '{}' is '{}'", elf_path, iso_path));
 		}

--- a/app/src/main/swift/Views/GameListView.swift
+++ b/app/src/main/swift/Views/GameListView.swift
@@ -23,6 +23,10 @@ struct ISOEntry: Identifiable {
 		isExternal ? (bootPath ?? fileURL?.path ?? name) : name
 	}
 
+	var isELF: Bool {
+		(bootPath ?? fileURL?.path ?? name).lowercased().hasSuffix(".elf")
+	}
+
 	var coverInfo: CoverGameInfo {
 		CoverGameInfo(name: name, fileURL: fileURL, metadata: metadata, hasCover: coverURL != nil)
 	}
@@ -81,6 +85,7 @@ struct GameListView: View {
     @State private var gameInfoTarget: ISOEntry?
     @State private var gameSettingsTarget: ISOEntry?
     @State private var gameCompatibilityTarget: ISOEntry?
+    @State private var discLinkTarget: ISOEntry?
     @State private var pendingDeleteGame: ISOEntry?
     @State private var pendingDeleteDataGame: ISOEntry?
     @State private var gameActionTitle = ""
@@ -467,6 +472,13 @@ struct GameListView: View {
             .sheet(item: $gameCompatibilityTarget) { game in
                 GameCompatibilityPanel(game: game)
                     .presentationDetents([.medium, .large])
+            }
+            .sheet(item: $discLinkTarget) { game in
+                DiscLinkPicker(discs: games.filter { !$0.isELF && $0.id != game.id }) { selected in
+                    ARMSX2Bridge.setLinkedDiscPath(selected?.bootName, forELF: game.bootName)
+                    loadGames()
+                }
+                .presentationDetents([.medium, .large])
             }
         }
 	        .onAppear {
@@ -893,6 +905,10 @@ struct GameListView: View {
             Label(settings.localized("Per-Game Settings"), systemImage: "slider.horizontal.3")
         }
 
+        if game.isELF {
+            discPathMenu(for: game)
+        }
+
         Button {
             presentMenuPanel("compatibility_lab") {
                 gameCompatibilityTarget = game
@@ -983,6 +999,28 @@ struct GameListView: View {
 		NSLog("[ARMSX2 iOS GameListMenu] present \(name)")
 		DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
 			action()
+		}
+	}
+
+	@ViewBuilder
+	private func discPathMenu(for game: ISOEntry) -> some View {
+		let linkedDisc = ARMSX2Bridge.linkedDiscPath(forELF: game.bootName)
+		Menu {
+			Button {
+				discLinkTarget = game
+			} label: {
+				Label(settings.localized(linkedDisc?.isEmpty == false ? "Change Disc Image" : "Link Disc Image"), systemImage: "link")
+			}
+			if let linkedDisc, !linkedDisc.isEmpty {
+				Button(role: .destructive) {
+					ARMSX2Bridge.setLinkedDiscPath(nil, forELF: game.bootName)
+					loadGames()
+				} label: {
+					Label(settings.localized("Remove Disc Link"), systemImage: "xmark.circle")
+				}
+			}
+		} label: {
+			Label(settings.localized("Disc Path"), systemImage: "opticaldisc")
 		}
 	}
 
@@ -2200,6 +2238,42 @@ struct PerGameSettingsPanel: View {
             return clampedEnd
         }
         return SettingsStore.normalizedSkipDrawEnd(start: start, end: clampedEnd)
+    }
+}
+
+private struct DiscLinkPicker: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var settings = SettingsStore.shared
+
+    let discs: [ISOEntry]
+    let onSelect: (ISOEntry?) -> Void
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if discs.isEmpty {
+                    Text(settings.localized("No disc images found. Import an ISO first, then link it here."))
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(discs) { disc in
+                        Button {
+                            onSelect(disc)
+                            dismiss()
+                        } label: {
+                            Text(disc.name).lineLimit(1)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+            .navigationTitle(settings.localized("Disc Path"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(settings.localized("Cancel")) { dismiss() }
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/swift/Views/GameListView.swift
+++ b/app/src/main/swift/Views/GameListView.swift
@@ -475,7 +475,7 @@ struct GameListView: View {
             }
             .sheet(item: $discLinkTarget) { game in
                 DiscLinkPicker(discs: games.filter { !$0.isELF && $0.id != game.id }) { selected in
-                    ARMSX2Bridge.setLinkedDiscPath(selected?.bootName, forELF: game.bootName)
+                    ARMSX2Bridge.setLinkedDiscPath(selected?.fileURL?.path ?? selected?.bootName, forELF: game.bootName)
                     loadGames()
                 }
                 .presentationDetents([.medium, .large])


### PR DESCRIPTION
QuickLoad — boot PS2 games from an extracted-disc folder (iOS):

- Boot a game's .elf straight from its extracted folder, with the matching ISO mounted as the disc. Big load-time win on disc-heavy games like Resident Evil Outbreak File 1 & 2 (door loads roughly 8s -> 2s), and lets their online modes work.
- New Disc Path menu to link / change / remove an ISO for an ELF (stored per game by ELF CRC, mounted as cdrom0: at boot).
- Case-insensitive host: file resolution on iOS. Fixes the black screen where the game requested host:0flist.dir but the file on disk was 0FLIST.DIR.

Review feedback:
- Linked disc is now stored as a relative library path instead of an absolute app-container path, so links survive app reinstall / container migration.
- Scoped the case-insensitive host: fix to iOS only (it was affecting every non-Windows build).

Bug fixes:
- ELF per-game settings (graphics, cheats, EE, MTVU, volume, game fixes) now actually apply. They were being saved under the wrong key and ignored at boot.
- Same-named ISOs in different folders no longer link to the wrong file.