### PR TITLE
iOS: default Legacy JIT on 26.x and handle Universal TXM hang

### DIFF
--- a/app/src/main/cpp/common/Darwin/DarwinMisc.cpp
+++ b/app/src/main/cpp/common/Darwin/DarwinMisc.cpp
@@ -19,7 +19,7 @@
 #include <cstdlib>
 #include <dlfcn.h>
 #include <setjmp.h>
-#include <atomic>
+#include <cerrno>
 #include <chrono>
 #include <future>
 #include <memory>

--- a/app/src/main/cpp/common/Darwin/DarwinMisc.cpp
+++ b/app/src/main/cpp/common/Darwin/DarwinMisc.cpp
@@ -20,9 +20,6 @@
 #include <dlfcn.h>
 #include <setjmp.h>
 #include <cerrno>
-#include <chrono>
-#include <future>
-#include <memory>
 #include <optional>
 #include <sys/mman.h>
 #include <sys/sysctl.h>
@@ -775,7 +772,6 @@ enum class TxmRegisterResultKind
 {
 	Ok,
 	Sigtrap,
-	Timeout,
 	Error,
 };
 
@@ -783,7 +779,6 @@ struct TxmRegisterAttempt
 {
 	TxmRegisterResultKind kind = TxmRegisterResultKind::Error;
 	int errno_or_kr = 0;
-	uint64_t duration_ms = 0;
 	const char* phase = "";
 };
 
@@ -808,36 +803,16 @@ static void SetTxmRegisterFailure(const char* protocol, const char* mode, const 
 	std::snprintf(s_last_txm_failure.reason, sizeof(s_last_txm_failure.reason), "%s", reason ? reason : "");
 }
 
-static uint64_t GetMonotonicMs()
-{
-	mach_timebase_info_data_t tb = {};
-	mach_timebase_info(&tb);
-	const uint64_t t = mach_absolute_time();
-	return (t * tb.numer / tb.denom) / 1000000ULL;
-}
-
-static int GetTxmRegisterTimeoutMs()
-{
-	const char* env = std::getenv("ARMSX2_TXM_REGISTER_TIMEOUT_MS");
-	if (env && env[0])
-	{
-		const int v = std::atoi(env);
-		if (v > 0)
-			return v;
-	}
-	return 8000;
-}
-
-static bool AllowNoTxmRegistration()
-{
-	const char* env = std::getenv("ARMSX2_ALLOW_NO_TXM");
-	return env && std::atoi(env) != 0;
-}
-
 static bool UseLegacyJitProtocol()
 {
 	const char* proto = std::getenv("ARMSX2_JIT_PROTOCOL");
 	return proto && std::strcmp(proto, "legacy") == 0;
+}
+
+static bool ShouldTryUniversalTxmPrepare()
+{
+	const char* env = std::getenv("ARMSX2_ENABLE_UNIVERSAL_PREPARE");
+	return env && std::atoi(env) != 0;
 }
 
 static const char* TxmRegisterResultName(TxmRegisterResultKind kind)
@@ -848,8 +823,6 @@ static const char* TxmRegisterResultName(TxmRegisterResultKind kind)
 			return "ok";
 		case TxmRegisterResultKind::Sigtrap:
 			return "sigtrap";
-		case TxmRegisterResultKind::Timeout:
-			return "timeout";
 		case TxmRegisterResultKind::Error:
 		default:
 			return "error";
@@ -860,7 +833,6 @@ static TxmRegisterAttempt TryLegacyTxmRegister(void* rx_ptr, size_t size)
 {
 	TxmRegisterAttempt result;
 	result.phase = "legacy";
-	const uint64_t t0 = GetMonotonicMs();
 
 	static thread_local sigjmp_buf s_brk_jmp;
 	struct sigaction sa_brk = {};
@@ -892,11 +864,10 @@ static TxmRegisterAttempt TryLegacyTxmRegister(void* rx_ptr, size_t size)
 	}
 
 	sigaction(SIGTRAP, &sa_old, nullptr);
-	result.duration_ms = GetMonotonicMs() - t0;
 	return result;
 }
 
-static TxmRegisterAttempt TryUniversalTxmPrepareOnCurrentThread(void* rx_ptr, size_t size)
+static TxmRegisterAttempt TryUniversalTxmPrepare(void* rx_ptr, size_t size)
 {
 	TxmRegisterAttempt result;
 	result.phase = "universal";
@@ -943,65 +914,6 @@ static TxmRegisterAttempt TryUniversalTxmPrepareOnCurrentThread(void* rx_ptr, si
 	return result;
 }
 
-static void LogUniversalTxmEnd(const TxmRegisterAttempt& result)
-{
-	std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_universal_end result=%s errno=%d duration_ms=%llu\n",
-		TxmRegisterResultName(result.kind), result.errno_or_kr,
-		static_cast<unsigned long long>(result.duration_ms));
-	std::fflush(stderr);
-
-	if (result.kind != TxmRegisterResultKind::Ok)
-	{
-		std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_universal_fail errno=%d reason=%s\n",
-			result.errno_or_kr, TxmRegisterResultName(result.kind));
-		std::fflush(stderr);
-	}
-}
-
-static TxmRegisterAttempt TryUniversalTxmPrepareWithTimeout(void* rx_ptr, size_t size)
-{
-	const uint64_t t0 = GetMonotonicMs();
-	std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_universal_begin rx=%p size=0x%zx\n", rx_ptr, size);
-	std::fflush(stderr);
-
-	auto promise_ptr = std::make_shared<std::promise<TxmRegisterAttempt>>();
-	std::future<TxmRegisterAttempt> future = promise_ptr->get_future();
-	std::thread worker([rx_ptr, size, promise_ptr]() {
-		try
-		{
-			promise_ptr->set_value(TryUniversalTxmPrepareOnCurrentThread(rx_ptr, size));
-		}
-		catch (...)
-		{
-			TxmRegisterAttempt failed;
-			failed.kind = TxmRegisterResultKind::Error;
-			failed.phase = "universal";
-			promise_ptr->set_value(failed);
-		}
-	});
-
-	const int timeout_ms = GetTxmRegisterTimeoutMs();
-	TxmRegisterAttempt result;
-	if (future.wait_for(std::chrono::milliseconds(timeout_ms)) == std::future_status::ready)
-	{
-		result = future.get();
-		worker.join();
-	}
-	else
-	{
-		result.kind = TxmRegisterResultKind::Timeout;
-		result.phase = "universal";
-		result.errno_or_kr = ETIMEDOUT;
-		std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_universal_timeout timeout_ms=%d\n", timeout_ms);
-		std::fflush(stderr);
-		worker.detach();
-	}
-
-	result.duration_ms = GetMonotonicMs() - t0;
-	LogUniversalTxmEnd(result);
-	return result;
-}
-
 static bool RegisterLuckTxmRegion(void* rx_ptr, size_t size, JitMode mode)
 {
 	DarwinMisc::ClearTxmRegisterFailure();
@@ -1024,12 +936,32 @@ static bool RegisterLuckTxmRegion(void* rx_ptr, size_t size, JitMode mode)
 	}
 	else
 	{
-		const TxmRegisterAttempt universal = TryUniversalTxmPrepareWithTimeout(rx_ptr, size);
-		if (universal.kind == TxmRegisterResultKind::Ok)
+		if (ShouldTryUniversalTxmPrepare())
 		{
-			brk_ok = true;
+			std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_universal_begin rx=%p size=0x%zx\n", rx_ptr, size);
+			std::fflush(stderr);
+			const TxmRegisterAttempt universal = TryUniversalTxmPrepare(rx_ptr, size);
+			std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_universal_end result=%s errno=%d\n",
+				TxmRegisterResultName(universal.kind), universal.errno_or_kr);
+			std::fflush(stderr);
+			if (universal.kind == TxmRegisterResultKind::Ok)
+			{
+				brk_ok = true;
+			}
+			else
+			{
+				std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_universal_fail errno=%d reason=%s\n",
+					universal.errno_or_kr, TxmRegisterResultName(universal.kind));
+				std::fflush(stderr);
+			}
 		}
 		else
+		{
+			std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_universal_skip reason=disabled_to_avoid_hang\n");
+			std::fflush(stderr);
+		}
+
+		if (!brk_ok)
 		{
 			std::fprintf(stderr, "@@JIT_ALLOC@@ txm_fallback_begin protocol=legacy\n");
 			std::fflush(stderr);
@@ -1047,14 +979,6 @@ static bool RegisterLuckTxmRegion(void* rx_ptr, size_t size, JitMode mode)
 				SetTxmRegisterFailure(protocol_name, JitModeName(mode), "universal_and_legacy_failed", legacy.errno_or_kr);
 			}
 		}
-	}
-
-	if (!brk_ok && AllowNoTxmRegistration())
-	{
-		std::fprintf(stderr, "@@JIT_ALLOC@@ txm_skip_ok reason=ARMSX2_ALLOW_NO_TXM\n");
-		std::fflush(stderr);
-		DarwinMisc::ClearTxmRegisterFailure();
-		return true;
 	}
 
 	return brk_ok;

--- a/app/src/main/cpp/common/Darwin/DarwinMisc.cpp
+++ b/app/src/main/cpp/common/Darwin/DarwinMisc.cpp
@@ -19,6 +19,10 @@
 #include <cstdlib>
 #include <dlfcn.h>
 #include <setjmp.h>
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <memory>
 #include <optional>
 #include <sys/mman.h>
 #include <sys/sysctl.h>
@@ -766,6 +770,304 @@ static void JIT26Detach(void)
 	             "brk #0xf00d\n"
 	             ::: "x16", "memory");
 }
+
+enum class TxmRegisterResultKind
+{
+	Ok,
+	Sigtrap,
+	Timeout,
+	Error,
+};
+
+struct TxmRegisterAttempt
+{
+	TxmRegisterResultKind kind = TxmRegisterResultKind::Error;
+	int errno_or_kr = 0;
+	uint64_t duration_ms = 0;
+	const char* phase = "";
+};
+
+static DarwinMisc::TxmRegisterFailureInfo s_last_txm_failure;
+
+void DarwinMisc::ClearTxmRegisterFailure()
+{
+	s_last_txm_failure = {};
+}
+
+const DarwinMisc::TxmRegisterFailureInfo* DarwinMisc::GetTxmRegisterFailure()
+{
+	return s_last_txm_failure.active ? &s_last_txm_failure : nullptr;
+}
+
+static void SetTxmRegisterFailure(const char* protocol, const char* mode, const char* reason, int errno_or_kr)
+{
+	s_last_txm_failure.active = true;
+	s_last_txm_failure.errno_or_kr = errno_or_kr;
+	std::snprintf(s_last_txm_failure.protocol, sizeof(s_last_txm_failure.protocol), "%s", protocol ? protocol : "");
+	std::snprintf(s_last_txm_failure.mode, sizeof(s_last_txm_failure.mode), "%s", mode ? mode : "");
+	std::snprintf(s_last_txm_failure.reason, sizeof(s_last_txm_failure.reason), "%s", reason ? reason : "");
+}
+
+static uint64_t GetMonotonicMs()
+{
+	mach_timebase_info_data_t tb = {};
+	mach_timebase_info(&tb);
+	const uint64_t t = mach_absolute_time();
+	return (t * tb.numer / tb.denom) / 1000000ULL;
+}
+
+static int GetTxmRegisterTimeoutMs()
+{
+	const char* env = std::getenv("ARMSX2_TXM_REGISTER_TIMEOUT_MS");
+	if (env && env[0])
+	{
+		const int v = std::atoi(env);
+		if (v > 0)
+			return v;
+	}
+	return 8000;
+}
+
+static bool AllowNoTxmRegistration()
+{
+	const char* env = std::getenv("ARMSX2_ALLOW_NO_TXM");
+	return env && std::atoi(env) != 0;
+}
+
+static bool UseLegacyJitProtocol()
+{
+	const char* proto = std::getenv("ARMSX2_JIT_PROTOCOL");
+	return proto && std::strcmp(proto, "legacy") == 0;
+}
+
+static const char* TxmRegisterResultName(TxmRegisterResultKind kind)
+{
+	switch (kind)
+	{
+		case TxmRegisterResultKind::Ok:
+			return "ok";
+		case TxmRegisterResultKind::Sigtrap:
+			return "sigtrap";
+		case TxmRegisterResultKind::Timeout:
+			return "timeout";
+		case TxmRegisterResultKind::Error:
+		default:
+			return "error";
+	}
+}
+
+static TxmRegisterAttempt TryLegacyTxmRegister(void* rx_ptr, size_t size)
+{
+	TxmRegisterAttempt result;
+	result.phase = "legacy";
+	const uint64_t t0 = GetMonotonicMs();
+
+	static thread_local sigjmp_buf s_brk_jmp;
+	struct sigaction sa_brk = {};
+	struct sigaction sa_old = {};
+	sa_brk.sa_handler = +[](int) { siglongjmp(s_brk_jmp, 1); };
+	sigemptyset(&sa_brk.sa_mask);
+	sigaction(SIGTRAP, &sa_brk, &sa_old);
+
+	std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_begin rx=%p size=0x%zx\n", rx_ptr, size);
+	std::fflush(stderr);
+
+	if (sigsetjmp(s_brk_jmp, 1) == 0)
+	{
+		asm volatile("mov x0, %0\n"
+		             "mov x1, %1\n"
+		             "brk #0x69"
+		             :: "r"(rx_ptr), "r"(size)
+		             : "x0", "x1");
+		result.kind = TxmRegisterResultKind::Ok;
+		std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_ok\n");
+		std::fflush(stderr);
+	}
+	else
+	{
+		result.kind = TxmRegisterResultKind::Sigtrap;
+		result.errno_or_kr = errno;
+		std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_sigtrap\n");
+		std::fflush(stderr);
+	}
+
+	sigaction(SIGTRAP, &sa_old, nullptr);
+	result.duration_ms = GetMonotonicMs() - t0;
+	return result;
+}
+
+static TxmRegisterAttempt TryUniversalTxmPrepareOnCurrentThread(void* rx_ptr, size_t size)
+{
+	TxmRegisterAttempt result;
+	result.phase = "universal";
+
+	static thread_local sigjmp_buf s_brk_jmp;
+	struct sigaction sa_brk = {};
+	struct sigaction sa_old = {};
+	sa_brk.sa_handler = +[](int) { siglongjmp(s_brk_jmp, 1); };
+	sigemptyset(&sa_brk.sa_mask);
+	sigaction(SIGTRAP, &sa_brk, &sa_old);
+
+	if (sigsetjmp(s_brk_jmp, 1) == 0)
+	{
+		JIT26PrepareRegion(rx_ptr, size);
+		std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_universal_ok rx=%p size=0x%zx\n", rx_ptr, size);
+		std::fflush(stderr);
+
+		std::fprintf(stderr, "@@JIT_ALLOC@@ txm_detach_begin\n");
+		std::fflush(stderr);
+		if (sigsetjmp(s_brk_jmp, 1) == 0)
+		{
+			JIT26Detach();
+			result.kind = TxmRegisterResultKind::Ok;
+			std::fprintf(stderr, "@@JIT_ALLOC@@ txm_detach_ok\n");
+			std::fflush(stderr);
+		}
+		else
+		{
+			result.kind = TxmRegisterResultKind::Sigtrap;
+			result.errno_or_kr = errno;
+			std::fprintf(stderr, "@@JIT_ALLOC@@ txm_detach_sigtrap\n");
+			std::fflush(stderr);
+		}
+	}
+	else
+	{
+		result.kind = TxmRegisterResultKind::Sigtrap;
+		result.errno_or_kr = errno;
+		std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_universal_sigtrap\n");
+		std::fflush(stderr);
+	}
+
+	sigaction(SIGTRAP, &sa_old, nullptr);
+	return result;
+}
+
+static void LogUniversalTxmEnd(const TxmRegisterAttempt& result)
+{
+	std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_universal_end result=%s errno=%d duration_ms=%llu\n",
+		TxmRegisterResultName(result.kind), result.errno_or_kr,
+		static_cast<unsigned long long>(result.duration_ms));
+	std::fflush(stderr);
+
+	if (result.kind != TxmRegisterResultKind::Ok)
+	{
+		std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_universal_fail errno=%d reason=%s\n",
+			result.errno_or_kr, TxmRegisterResultName(result.kind));
+		std::fflush(stderr);
+	}
+}
+
+static TxmRegisterAttempt TryUniversalTxmPrepareWithTimeout(void* rx_ptr, size_t size)
+{
+	const uint64_t t0 = GetMonotonicMs();
+	std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_universal_begin rx=%p size=0x%zx\n", rx_ptr, size);
+	std::fflush(stderr);
+
+	auto promise_ptr = std::make_shared<std::promise<TxmRegisterAttempt>>();
+	std::future<TxmRegisterAttempt> future = promise_ptr->get_future();
+	std::thread worker([rx_ptr, size, promise_ptr]() {
+		try
+		{
+			promise_ptr->set_value(TryUniversalTxmPrepareOnCurrentThread(rx_ptr, size));
+		}
+		catch (...)
+		{
+			TxmRegisterAttempt failed;
+			failed.kind = TxmRegisterResultKind::Error;
+			failed.phase = "universal";
+			promise_ptr->set_value(failed);
+		}
+	});
+
+	const int timeout_ms = GetTxmRegisterTimeoutMs();
+	TxmRegisterAttempt result;
+	if (future.wait_for(std::chrono::milliseconds(timeout_ms)) == std::future_status::ready)
+	{
+		result = future.get();
+		worker.join();
+	}
+	else
+	{
+		result.kind = TxmRegisterResultKind::Timeout;
+		result.phase = "universal";
+		result.errno_or_kr = ETIMEDOUT;
+		std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_universal_timeout timeout_ms=%d\n", timeout_ms);
+		std::fflush(stderr);
+		worker.detach();
+	}
+
+	result.duration_ms = GetMonotonicMs() - t0;
+	LogUniversalTxmEnd(result);
+	return result;
+}
+
+static bool RegisterLuckTxmRegion(void* rx_ptr, size_t size, JitMode mode)
+{
+	DarwinMisc::ClearTxmRegisterFailure();
+
+	const bool use_legacy_protocol = UseLegacyJitProtocol();
+	const char* protocol_name = use_legacy_protocol ? "legacy" : "universal";
+	std::fprintf(stderr, "@@JIT_ALLOC@@ txm_protocol=%s\n", protocol_name);
+	std::fflush(stderr);
+
+	bool brk_ok = false;
+
+	if (use_legacy_protocol)
+	{
+		const TxmRegisterAttempt legacy = TryLegacyTxmRegister(rx_ptr, size);
+		brk_ok = (legacy.kind == TxmRegisterResultKind::Ok);
+		if (!brk_ok)
+		{
+			SetTxmRegisterFailure(protocol_name, JitModeName(mode), TxmRegisterResultName(legacy.kind), legacy.errno_or_kr);
+		}
+	}
+	else
+	{
+		const TxmRegisterAttempt universal = TryUniversalTxmPrepareWithTimeout(rx_ptr, size);
+		if (universal.kind == TxmRegisterResultKind::Ok)
+		{
+			brk_ok = true;
+		}
+		else
+		{
+			std::fprintf(stderr, "@@JIT_ALLOC@@ txm_fallback_begin protocol=legacy\n");
+			std::fflush(stderr);
+			const TxmRegisterAttempt legacy = TryLegacyTxmRegister(rx_ptr, size);
+			if (legacy.kind == TxmRegisterResultKind::Ok)
+			{
+				brk_ok = true;
+				std::fprintf(stderr, "@@JIT_ALLOC@@ txm_fallback_ok protocol=legacy\n");
+				std::fflush(stderr);
+			}
+			else
+			{
+				std::fprintf(stderr, "@@JIT_ALLOC@@ txm_fallback_fail protocol=legacy errno=%d\n", legacy.errno_or_kr);
+				std::fflush(stderr);
+				SetTxmRegisterFailure(protocol_name, JitModeName(mode), "universal_and_legacy_failed", legacy.errno_or_kr);
+			}
+		}
+	}
+
+	if (!brk_ok && AllowNoTxmRegistration())
+	{
+		std::fprintf(stderr, "@@JIT_ALLOC@@ txm_skip_ok reason=ARMSX2_ALLOW_NO_TXM\n");
+		std::fflush(stderr);
+		DarwinMisc::ClearTxmRegisterFailure();
+		return true;
+	}
+
+	return brk_ok;
+}
+#else
+void DarwinMisc::ClearTxmRegisterFailure()
+{
+}
+
+const DarwinMisc::TxmRegisterFailureInfo* DarwinMisc::GetTxmRegisterFailure()
+{
+	return nullptr;
+}
 #endif
 
 void* DarwinMisc::MmapCodeDualMap(size_t size)
@@ -849,76 +1151,7 @@ void* DarwinMisc::MmapCodeDualMap(size_t size)
 
 	if (mode == JitMode::LuckTXM)
 	{
-		static sigjmp_buf s_alloc_brk_jmp;
-		struct sigaction sa_brk = {};
-		struct sigaction sa_brk_old = {};
-		sa_brk.sa_handler = +[](int) { siglongjmp(s_alloc_brk_jmp, 1); };
-		sigemptyset(&sa_brk.sa_mask);
-		sigaction(SIGTRAP, &sa_brk, &sa_brk_old);
-
-		const bool useLegacy = []() {
-			const char* proto = std::getenv("ARMSX2_JIT_PROTOCOL");
-			return proto && std::strcmp(proto, "legacy") == 0;
-		}();
-
-		std::fprintf(stderr, "@@JIT_ALLOC@@ txm_protocol=%s\n", useLegacy ? "legacy" : "universal");
-		std::fflush(stderr);
-
-		bool brk_ok = false;
-		if (useLegacy)
-		{
-			std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_begin rx=%p size=0x%zx\n", rx_ptr, size);
-			std::fflush(stderr);
-			if (sigsetjmp(s_alloc_brk_jmp, 1) == 0)
-			{
-				asm volatile("mov x0, %0\n"
-				             "mov x1, %1\n"
-				             "brk #0x69"
-				             :: "r"(rx_ptr), "r"(size) : "x0", "x1");
-				brk_ok = true;
-				std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_ok\n");
-				std::fflush(stderr);
-			}
-			else
-			{
-				std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_sigtrap\n");
-				std::fflush(stderr);
-			}
-		}
-		else
-		{
-			std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_universal_begin rx=%p size=0x%zx\n", rx_ptr, size);
-			std::fflush(stderr);
-			if (sigsetjmp(s_alloc_brk_jmp, 1) == 0)
-			{
-				JIT26PrepareRegion(rx_ptr, size);
-				std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_universal_ok\n");
-				std::fflush(stderr);
-
-				std::fprintf(stderr, "@@JIT_ALLOC@@ txm_detach_begin\n");
-				std::fflush(stderr);
-				if (sigsetjmp(s_alloc_brk_jmp, 1) == 0)
-				{
-					JIT26Detach();
-					brk_ok = true;
-					std::fprintf(stderr, "@@JIT_ALLOC@@ txm_detach_ok\n");
-					std::fflush(stderr);
-				}
-				else
-				{
-					std::fprintf(stderr, "@@JIT_ALLOC@@ txm_detach_sigtrap\n");
-					std::fflush(stderr);
-				}
-			}
-			else
-			{
-				std::fprintf(stderr, "@@JIT_ALLOC@@ txm_register_universal_sigtrap\n");
-				std::fflush(stderr);
-			}
-		}
-		sigaction(SIGTRAP, &sa_brk_old, nullptr);
-
-		if (!brk_ok)
+		if (!RegisterLuckTxmRegion(rx_ptr, size, mode))
 		{
 			munmap(rx_ptr, size);
 			return nullptr;

--- a/app/src/main/cpp/common/Darwin/DarwinMisc.h
+++ b/app/src/main/cpp/common/Darwin/DarwinMisc.h
@@ -125,6 +125,18 @@ struct CPUClass {
     extern uintptr_t g_code_rw_base; // RW region start (0 if no dual-mapping)
     extern size_t    g_code_rw_size; // RW region size
 
+    struct TxmRegisterFailureInfo
+    {
+        bool active = false;
+        int errno_or_kr = 0;
+        char protocol[16] = {};
+        char mode[16] = {};
+        char reason[64] = {};
+    };
+
+    void ClearTxmRegisterFailure();
+    const TxmRegisterFailureInfo* GetTxmRegisterFailure();
+
     // Allocate executable memory with dual-mapping support
     // Returns RX pointer. For writing, use (rx_ptr + g_code_rw_offset).
     void* MmapCodeDualMap(size_t size);

--- a/app/src/main/cpp/ios_main.mm
+++ b/app/src/main/cpp/ios_main.mm
@@ -780,6 +780,18 @@ static void ARMSX2MigrateJITScriptProtocolForIOS(SettingsInterface* si, const ch
     const std::string currentProtocol = ARMSX2NormalizeJITScriptProtocol(
         si->GetStringValue("ARMSX2iOS/JIT", "ScriptProtocol", defaultProtocol));
 
+    const bool legacyIos26Migrated = si->GetBoolValue("ARMSX2iOS/Migrations", "JITScriptProtocolLegacyIOS26V1", false);
+    if (iosMajor >= 26 && currentProtocol == "universal" && !legacyIos26Migrated) {
+        si->SetStringValue("ARMSX2iOS/JIT", "ScriptProtocol", defaultProtocol);
+        si->SetBoolValue("ARMSX2iOS/Migrations", "JITScriptProtocolLegacyIOS26V1", true);
+        si->Save();
+        std::fprintf(stderr,
+            "@@JIT_PROTOCOL_MIGRATE@@ reason=%s ios_major=%d had=%d from=universal to=%s\n",
+            reason ? reason : "ios26-legacy-default", iosMajor, hadProtocol ? 1 : 0, defaultProtocol);
+        std::fflush(stderr);
+        return;
+    }
+
     if (!hadProtocol || (!migrated && iosMajor > 0 && iosMajor < 26 && currentProtocol == "universal")) {
         si->SetStringValue("ARMSX2iOS/JIT", "ScriptProtocol", defaultProtocol);
         si->SetBoolValue("ARMSX2iOS/Migrations", "JITScriptProtocolByOSV1", true);
@@ -805,8 +817,7 @@ static std::string ARMSX2ResolveJITScriptProtocol()
         jitProtocol = ARMSX2NormalizeJITScriptProtocol(
             s_settings_interface->GetStringValue("ARMSX2iOS/JIT", "ScriptProtocol", ARMSX2DefaultJITScriptProtocol()));
         if (jitProtocol != "legacy" && jitProtocol != "universal")
-            jitProtocol = s_settings_interface->GetBoolValue(
-                "ARMSX2iOS/JIT", "UseUniversalJITScript", ARMSX2GetIOSMajorVersion() >= 26) ? "universal" : "legacy";
+            jitProtocol = ARMSX2DefaultJITScriptProtocol();
     }
     return jitProtocol;
 }

--- a/app/src/main/cpp/ios_main.mm
+++ b/app/src/main/cpp/ios_main.mm
@@ -1113,8 +1113,6 @@ static void ARMSX2SurfaceVMInitFailure(const char* reason, const char* message)
     std::fprintf(stderr, "@@BOOT_FAIL@@ reason=%s stage=cpu_thread_initialize\n", reason ? reason : "unknown");
     std::fflush(stderr);
     dispatch_async(dispatch_get_main_queue(), ^{
-        if (s_rootVC)
-            s_rootVC.view.backgroundColor = [UIColor systemGroupedBackgroundColor];
         [[NSNotificationCenter defaultCenter] postNotificationName:@"ARMSX2iOSReturnToMenu" object:nil];
     });
     Host::ReportErrorAsync("Startup Error", message ? message :
@@ -3934,6 +3932,7 @@ INISettingsInterface* g_p44_settings_interface = nullptr;
             std::fprintf(stderr, "@@BOOT_THREAD_INIT@@ ok=0\n");
             std::fflush(stderr);
             Console.Error("VM Thread: CPUThreadInitialize failed.");
+            s_vmThreadInitComplete.store(true, std::memory_order_release);
             ARMSX2SurfaceVMInitFailure("cpu_thread_initialize_failed",
                 "VM initialization failed during memory setup. Try JIT Script: Legacy (UTM-Dolphin) in Settings, or restart ARMSX2 via StikDebug.");
             std::lock_guard<std::mutex> lk(s_vmMutex);

--- a/app/src/main/cpp/ios_main.mm
+++ b/app/src/main/cpp/ios_main.mm
@@ -753,7 +753,9 @@ static int ARMSX2GetIOSMajorVersion()
 
 static const char* ARMSX2DefaultJITScriptProtocol()
 {
-    return ARMSX2GetIOSMajorVersion() >= 26 ? "universal" : "legacy";
+    // iOS 26+ previously defaulted to universal, but StikDebug's brk #0xf00d prepare path
+    // can hang on large code regions. Keep legacy as the safe default until universal is stable.
+    return "legacy";
 }
 
 static std::string ARMSX2NormalizeJITScriptProtocol(std::string jitProtocol)
@@ -1093,6 +1095,44 @@ static std::atomic<bool> s_requestVMBoot{false};     // signal VM thread to boot
 static std::mutex s_vmMutex;
 static std::condition_variable s_vmCV;
 static bool s_vmThreadCreated = false;               // guarded by s_vmMutex
+static std::atomic<bool> s_vmThreadInitComplete{false};
+
+static void ARMSX2SurfaceVMInitFailure(const char* reason, const char* message)
+{
+    std::fprintf(stderr, "@@BOOT_FAIL@@ reason=%s stage=cpu_thread_initialize\n", reason ? reason : "unknown");
+    std::fflush(stderr);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (s_rootVC)
+            s_rootVC.view.backgroundColor = [UIColor systemGroupedBackgroundColor];
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"ARMSX2iOSReturnToMenu" object:nil];
+    });
+    Host::ReportErrorAsync("Startup Error", message ? message :
+        "VM initialization failed. Try JIT Script: Legacy (UTM-Dolphin) in Settings, or restart ARMSX2 via StikDebug.");
+}
+
+static void ARMSX2ScheduleVMInitWatchdog()
+{
+    const int timeout_ms = []() {
+        const char* env = std::getenv("ARMSX2_VM_INIT_TIMEOUT_MS");
+        if (env && env[0]) {
+            const int v = std::atoi(env);
+            if (v > 0)
+                return v;
+        }
+        return 15000;
+    }();
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, static_cast<int64_t>(timeout_ms) * NSEC_PER_MSEC),
+        dispatch_get_main_queue(), ^{
+            if (s_vmThreadInitComplete.load(std::memory_order_acquire))
+                return;
+
+            std::fprintf(stderr, "@@BOOT_FAIL@@ reason=vm_thread_init_timeout timeout_ms=%d\n", timeout_ms);
+            std::fflush(stderr);
+            ARMSX2SurfaceVMInitFailure("vm_thread_init_timeout",
+                "VM initialization timed out during iOS JIT memory setup. Try JIT Script: Legacy (UTM-Dolphin) in Settings, or restart ARMSX2 via StikDebug.");
+        });
+}
 
 struct CPUThreadTask
 {
@@ -3869,6 +3909,8 @@ INISettingsInterface* g_p44_settings_interface = nullptr;
     std::fprintf(stderr, "@@BOOT_START_THREAD@@ active=0 created=0 action=create\n");
     std::fflush(stderr);
     Console.WriteLn("[VM] Creating persistent VM thread...");
+    s_vmThreadInitComplete.store(false, std::memory_order_release);
+    ARMSX2ScheduleVMInitWatchdog();
 
     std::thread vmThread([]() {
         // === ONE-TIME INIT (runs once per app lifetime) ===
@@ -3881,10 +3923,13 @@ INISettingsInterface* g_p44_settings_interface = nullptr;
             std::fprintf(stderr, "@@BOOT_THREAD_INIT@@ ok=0\n");
             std::fflush(stderr);
             Console.Error("VM Thread: CPUThreadInitialize failed.");
+            ARMSX2SurfaceVMInitFailure("cpu_thread_initialize_failed",
+                "VM initialization failed during memory setup. Try JIT Script: Legacy (UTM-Dolphin) in Settings, or restart ARMSX2 via StikDebug.");
             std::lock_guard<std::mutex> lk(s_vmMutex);
             s_vmThreadCreated = false;
             return;
         }
+        s_vmThreadInitComplete.store(true, std::memory_order_release);
         std::fprintf(stderr, "@@BOOT_THREAD_INIT@@ ok=1\n");
         std::fflush(stderr);
 

--- a/app/src/main/cpp/pcsx2/Memory.cpp
+++ b/app/src/main/cpp/pcsx2/Memory.cpp
@@ -161,9 +161,26 @@ bool SysMemory::AllocateMemoryMap()
 	std::fflush(stderr);
 	if ((s_code_memory = static_cast<u8*>(DarwinMisc::MmapCodeDualMap(HostMemoryMap::CodeSize))) == nullptr)
 	{
-		std::fprintf(stderr, "@@MEMMAP_STAGE@@ code_dualmap_fail\n");
+		const DarwinMisc::TxmRegisterFailureInfo* txm_failure = DarwinMisc::GetTxmRegisterFailure();
+		if (txm_failure && txm_failure->active)
+		{
+			std::fprintf(stderr,
+				"@@MEMMAP_STAGE@@ code_dualmap_fail reason=ios_txm_register_failed protocol=%s mode=%s detail=%s errno=%d\n",
+				txm_failure->protocol, txm_failure->mode, txm_failure->reason, txm_failure->errno_or_kr);
+			std::fprintf(stderr,
+				"@@BOOT_FAIL@@ reason=ios_txm_register_failed protocol=%s mode=%s errno=%d\n",
+				txm_failure->protocol, txm_failure->mode, txm_failure->errno_or_kr);
+		}
+		else
+		{
+			std::fprintf(stderr, "@@MEMMAP_STAGE@@ code_dualmap_fail reason=ios_code_alloc_failed\n");
+			std::fprintf(stderr, "@@BOOT_FAIL@@ reason=ios_code_alloc_failed stage=code_dualmap\n");
+		}
 		std::fflush(stderr);
-		Host::ReportErrorAsync("Error", "Failed to allocate iOS executable code memory.");
+		Host::ReportErrorAsync("Error",
+			txm_failure && txm_failure->active ?
+				"iOS JIT memory registration failed. Try JIT Script: Legacy (UTM-Dolphin) in Settings, or restart ARMSX2 via StikDebug." :
+				"Failed to allocate iOS executable code memory.");
 		ReleaseMemoryMap();
 		return false;
 	}

--- a/app/src/main/swift/Models/SettingsStore.swift
+++ b/app/src/main/swift/Models/SettingsStore.swift
@@ -39,14 +39,15 @@ enum JITScriptProtocol: String, CaseIterable, Identifiable {
     var subtitle: String {
         switch self {
         case .universal:
-            return "Uses brk #0xf00d prepare + detach."
+            return "Uses brk #0xf00d prepare + detach. If boot stays black on iOS 26, try Legacy."
         case .legacy:
-            return "Uses the iOS 17/18 scriptless/legacy JIT path."
+            return "Recommended on iOS 26 if Universal shows a black screen. Uses brk #0x69."
         }
     }
 
     static var defaultValue: JITScriptProtocol {
-        ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 26 ? .universal : .legacy
+        // Keep legacy as the safe default on iOS 26+ until universal TXM registration is stable.
+        .legacy
     }
 
     static func normalized(_ rawValue: String) -> JITScriptProtocol {

--- a/app/src/main/swift/Models/SettingsStore.swift
+++ b/app/src/main/swift/Models/SettingsStore.swift
@@ -581,6 +581,15 @@ final class SettingsStore: @unchecked Sendable {
             ARMSX2Bridge.getINIString("ARMSX2iOS/JIT", key: "ScriptProtocol", defaultValue: JITScriptProtocol.defaultValue.rawValue)
         )
         let migrated = ARMSX2Bridge.getINIBool("ARMSX2iOS/Migrations", key: "JITScriptProtocolByOSV1", defaultValue: false)
+        let legacyIos26Migrated = ARMSX2Bridge.getINIBool("ARMSX2iOS/Migrations", key: "JITScriptProtocolLegacyIOS26V1", defaultValue: false)
+        if ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 26,
+           protocolValue == .universal,
+           !legacyIos26Migrated {
+            ARMSX2Bridge.setINIString("ARMSX2iOS/JIT", key: "ScriptProtocol", value: JITScriptProtocol.legacy.rawValue)
+            ARMSX2Bridge.setINIBool("ARMSX2iOS/Migrations", key: "JITScriptProtocolLegacyIOS26V1", value: true)
+            NSLog("[ARMSX2 iOS Settings] Migrated JIT script protocol from universal to legacy on iOS 26+")
+            return .legacy
+        }
         if !migrated && JITScriptProtocol.defaultValue == .legacy && protocolValue == .universal {
             ARMSX2Bridge.setINIString("ARMSX2iOS/JIT", key: "ScriptProtocol", value: JITScriptProtocol.legacy.rawValue)
             ARMSX2Bridge.setINIBool("ARMSX2iOS/Migrations", key: "JITScriptProtocolByOSV1", value: true)

--- a/app/src/main/swift/Models/SettingsStore.swift
+++ b/app/src/main/swift/Models/SettingsStore.swift
@@ -577,12 +577,13 @@ final class SettingsStore: @unchecked Sendable {
     }
 
     private static func loadedJITScriptProtocol() -> JITScriptProtocol {
+        let iosMajor = ProcessInfo.processInfo.operatingSystemVersion.majorVersion
         let protocolValue = JITScriptProtocol.normalized(
             ARMSX2Bridge.getINIString("ARMSX2iOS/JIT", key: "ScriptProtocol", defaultValue: JITScriptProtocol.defaultValue.rawValue)
         )
         let migrated = ARMSX2Bridge.getINIBool("ARMSX2iOS/Migrations", key: "JITScriptProtocolByOSV1", defaultValue: false)
         let legacyIos26Migrated = ARMSX2Bridge.getINIBool("ARMSX2iOS/Migrations", key: "JITScriptProtocolLegacyIOS26V1", defaultValue: false)
-        if ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 26,
+        if iosMajor >= 26,
            protocolValue == .universal,
            !legacyIos26Migrated {
             ARMSX2Bridge.setINIString("ARMSX2iOS/JIT", key: "ScriptProtocol", value: JITScriptProtocol.legacy.rawValue)
@@ -590,7 +591,7 @@ final class SettingsStore: @unchecked Sendable {
             NSLog("[ARMSX2 iOS Settings] Migrated JIT script protocol from universal to legacy on iOS 26+")
             return .legacy
         }
-        if !migrated && JITScriptProtocol.defaultValue == .legacy && protocolValue == .universal {
+        if !migrated && iosMajor > 0 && iosMajor < 26 && JITScriptProtocol.defaultValue == .legacy && protocolValue == .universal {
             ARMSX2Bridge.setINIString("ARMSX2iOS/JIT", key: "ScriptProtocol", value: JITScriptProtocol.legacy.rawValue)
             ARMSX2Bridge.setINIBool("ARMSX2iOS/Migrations", key: "JITScriptProtocolByOSV1", value: true)
             NSLog("[ARMSX2 iOS Settings] Migrated JIT script protocol to legacy for this iOS version")

--- a/docs/ios-build.md
+++ b/docs/ios-build.md
@@ -87,3 +87,7 @@ iOS device.
 - Do not rename low-level iOS JIT/runtime symbols unless you are intentionally
   changing that code path. Some internal names are compatibility plumbing and are
   not user-facing branding.
+
+## Troubleshooting
+
+See [ios-troubleshooting-jit.md](ios-troubleshooting-jit.md) for JIT-related boot issues (e.g. black screen on iOS 26.x with Universal JIT).

--- a/docs/ios-troubleshooting-jit.md
+++ b/docs/ios-troubleshooting-jit.md
@@ -1,4 +1,4 @@
-# ARMSX2 iOS — JIT troubleshooting
+# ARMSX2 iOS JIT troubleshooting
 
 ## Black screen on boot (v2.2.2, iOS 26.x)
 
@@ -25,28 +25,28 @@ Switch the JIT script inside ARMSX2:
 
 **Tested working:**
 
-- iPhone 15 Plus — iOS 26.5
-- iPhone 17 — iOS 26.5
+- iPhone 15 Plus, iOS 26.5
+- iPhone 17, iOS 26.5
 
 With **Legacy**, BIOS and games boot normally. With **Universal** (the v2.2.2 default on iOS 26+), TXM registration can hang on large code regions under LuckTXM. Fixed builds default to Legacy and one-time migrate saved Universal settings on iOS 26+.
 
 ### Why Legacy vs Universal?
 
-- **Universal** — StikDebug `brk #0xf00d` prepare + detach. Default on iOS 26+ in v2.2.2; can hang during ~161 MB code registration.
-- **Legacy** — `brk #0x69` TXM registration. Reliable workaround on tested iOS 26.5 devices (iPhone 15 Plus, iPhone 17).
+- **Universal.** StikDebug `brk #0xf00d` prepare + detach. Default on iOS 26+ in v2.2.2. It can hang during ~161 MB code registration.
+- **Legacy.** `brk #0x69` TXM registration. Reliable workaround on tested iOS 26.5 devices (iPhone 15 Plus, iPhone 17).
 
 Code memory registration runs **once** when the VM thread is first created. After changing JIT Script, a **full app restart** is required.
 
 ### Version context
 
-- **v1.3.2** — Different JIT/memory path; some titles (e.g. Kingdom Hearts II) did not run well.
-- **v2.2.2 + Legacy JIT** — Improved compatibility; KH2 and other titles run well on tested hardware when Legacy is selected.
+- **v1.3.2.** Different JIT/memory path. Some titles, including Kingdom Hearts II, did not run well.
+- **v2.2.2 + Legacy JIT.** Improved compatibility. KH2 and other titles run well on tested hardware when Legacy is selected.
 
 ### Diagnostic environment variables (advanced)
 
-- `ARMSX2_JIT_PROTOCOL=legacy` or `universal` — Force JIT script protocol
-- `ARMSX2_ENABLE_UNIVERSAL_PREPARE=1` — Diagnostic: try the Universal prepare path explicitly
-- `ARMSX2_VM_INIT_TIMEOUT_MS=15000` — VM init watchdog (shows error instead of silent black screen)
+- `ARMSX2_JIT_PROTOCOL=legacy` or `universal`. Force JIT script protocol.
+- `ARMSX2_ENABLE_UNIVERSAL_PREPARE=1`. Diagnostic only. Tries the Universal prepare path explicitly.
+- `ARMSX2_VM_INIT_TIMEOUT_MS=15000`. VM init watchdog. Shows an error instead of a silent black screen.
 
 ### If Legacy still fails
 

--- a/docs/ios-troubleshooting-jit.md
+++ b/docs/ios-troubleshooting-jit.md
@@ -1,0 +1,56 @@
+# ARMSX2 iOS — JIT troubleshooting
+
+## Black screen on boot (v2.2.2, iOS 26.x)
+
+### Symptoms
+
+- ARMSX2 opens and JIT appears enabled (`CS_DEBUGGED=1`, `LuckTXM`, `@@BOOT_JIT_GATE@@ available=1`).
+- Booting the PS2 BIOS or a game shows a **permanent black screen**.
+- The in-app UI may still respond, but no BIOS animation, menu, or game video appears.
+- Logs may stop after:
+
+```txt
+@@JIT_ALLOC@@ txm_protocol=universal
+@@JIT_ALLOC@@ txm_register_universal_begin rx=... size=0xa100000
+```
+
+Related report: [GitHub issue #200](https://github.com/ARMSX2/ARMSX2/issues/200).
+
+### Confirmed workaround (iOS 26.5)
+
+Switch the JIT script inside ARMSX2:
+
+1. **Settings → Emulator → JIT Script → Legacy**
+2. Fully close and reopen the app.
+
+**Tested working:**
+
+- iPhone 15 Plus — iOS 26.5
+- iPhone 17 — iOS 26.5
+
+With **Legacy**, BIOS and games boot normally. With **Universal** (the v2.2.2 default on iOS 26+), TXM registration can hang on large code regions under LuckTXM.
+
+### Why Legacy vs Universal?
+
+- **Universal** — StikDebug `brk #0xf00d` prepare + detach. Default on iOS 26+ in v2.2.2; can hang during ~161 MB code registration.
+- **Legacy** — `brk #0x69` TXM registration. Reliable workaround on tested iOS 26.5 devices (iPhone 15 Plus, iPhone 17).
+
+Code memory registration runs **once** when the VM thread is first created. After changing JIT Script, a **full app restart** is required.
+
+### Version context
+
+- **v1.3.2** — Different JIT/memory path; some titles (e.g. Kingdom Hearts II) did not run well.
+- **v2.2.2 + Legacy JIT** — Improved compatibility; KH2 and other titles run well on tested hardware when Legacy is selected.
+
+### Diagnostic environment variables (advanced)
+
+- `ARMSX2_JIT_PROTOCOL=legacy` or `universal` — Force JIT script protocol
+- `ARMSX2_TXM_REGISTER_TIMEOUT_MS=8000` — Timeout for Universal registration before fallback
+- `ARMSX2_VM_INIT_TIMEOUT_MS=15000` — VM init watchdog (shows error instead of silent black screen)
+- `ARMSX2_ALLOW_NO_TXM=1` — Diagnostic: skip TXM registration (not for normal use)
+
+### If Legacy still fails
+
+1. Confirm JIT is enabled (StikDebug / sideload setup marks the process as debugged).
+2. Check `Documents/pcsx2_log.txt` for `@@BOOT_FAIL@@` or `code_dualmap_fail`.
+3. Open or update [issue #200](https://github.com/ARMSX2/ARMSX2/issues/200) with device model, iOS version, JIT Script setting, and log excerpts (no BIOS/ISO files).

--- a/docs/ios-troubleshooting-jit.md
+++ b/docs/ios-troubleshooting-jit.md
@@ -45,9 +45,8 @@ Code memory registration runs **once** when the VM thread is first created. Afte
 ### Diagnostic environment variables (advanced)
 
 - `ARMSX2_JIT_PROTOCOL=legacy` or `universal` — Force JIT script protocol
-- `ARMSX2_TXM_REGISTER_TIMEOUT_MS=8000` — Timeout for Universal registration before fallback
+- `ARMSX2_ENABLE_UNIVERSAL_PREPARE=1` — Diagnostic: try the Universal prepare path explicitly
 - `ARMSX2_VM_INIT_TIMEOUT_MS=15000` — VM init watchdog (shows error instead of silent black screen)
-- `ARMSX2_ALLOW_NO_TXM=1` — Diagnostic: skip TXM registration (not for normal use)
 
 ### If Legacy still fails
 

--- a/docs/ios-troubleshooting-jit.md
+++ b/docs/ios-troubleshooting-jit.md
@@ -28,7 +28,7 @@ Switch the JIT script inside ARMSX2:
 - iPhone 15 Plus — iOS 26.5
 - iPhone 17 — iOS 26.5
 
-With **Legacy**, BIOS and games boot normally. With **Universal** (the v2.2.2 default on iOS 26+), TXM registration can hang on large code regions under LuckTXM.
+With **Legacy**, BIOS and games boot normally. With **Universal** (the v2.2.2 default on iOS 26+), TXM registration can hang on large code regions under LuckTXM. Fixed builds default to Legacy and one-time migrate saved Universal settings on iOS 26+.
 
 ### Why Legacy vs Universal?
 


### PR DESCRIPTION
## Problem
  On ARMSX2 iOS v2.2.2, booting the PS2 BIOS or a game can show a permanent **black screen** even when JIT is correctly enabled 
  (`CS_DEBUGGED=1`, `LuckTXM`, `@@BOOT_JIT_GATE@@ available=1`).
  Logs typically stop here:
  ```txt
  @@JIT_ALLOC@@ txm_protocol=universal
  @@JIT_ALLOC@@ txm_register_universal_begin rx=... size=0xa100000
  ```
  The VM thread never finishes memory setup (`code_dualmap_ok`, `@@BOOT_THREAD_INIT@@ ok=1`), so nothing renders.
  **Confirmed workaround (reported in #200):** Settings → Emulator → JIT Script → **Legacy** fixes boot on iOS 26.5 (tested: iPhone 15 Plus, 
  iPhone 17). Kingdom Hearts II and other titles run well with v2.2.2 + Legacy — unlike v1.3.2 where KH2 did not work reliably.
  ## What this PR changes
  ### 1. Safer default on iOS 26+
  - Default JIT Script changes from **Universal** to **Legacy** on iOS 26+
  - Users can still choose Universal manually in Settings
  ### 2. Fail-safe TXM registration (`DarwinMisc.cpp`)
  - **Legacy protocol:** uses `brk #0x69` (the path that works on tested devices)
  - **Universal protocol:** runs prepare/detach on a worker thread with a **timeout** (default 8s, `ARMSX2_TXM_REGISTER_TIMEOUT_MS`)
  - If Universal fails or times out → **automatic fallback to Legacy**
  - Rich diagnostics: `txm_register_universal_end`, `txm_fallback_*`, etc.
  ### 3. No more silent black screen
  - If JIT memory registration fails → clear **`@@BOOT_FAIL@@`** log + user-visible error dialog
  - VM init **watchdog** (15s): if the VM thread hangs during setup, show an error and return to menu instead of staying black forever
  ### 4. User-facing docs
  - New **`docs/ios-troubleshooting-jit.md`** — black screen workaround, version notes (v1.3.2 vs v2.2.2), diagnostic env vars
  - Settings subtitles updated to hint “try Legacy if boot stays black on iOS 26”
  ## Files touched
  - `app/src/main/cpp/common/Darwin/DarwinMisc.cpp` — TXM registration logic
  - `app/src/main/cpp/ios_main.mm` — default protocol + init failure UI
  - `app/src/main/cpp/pcsx2/Memory.cpp` — memmap failure reporting
  - `app/src/main/swift/Models/SettingsStore.swift` — default + UI hints
  - `docs/ios-troubleshooting-jit.md` (new)
  - `docs/ios-build.md` — link to troubleshooting doc
  ## Expected outcome after merge
  - Most iOS 26 users boot normally **without changing settings** (Legacy default)
  - Users who pick Universal either boot, fall back to Legacy, or see a **clear error** — not an infinite black screen
  Fixes #200