### PR TITLE
Android: add RetroAchievements host override receiver

### DIFF
--- a/ARMSX2/app/src/main/AndroidManifest.xml
+++ b/ARMSX2/app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
         android:largeHeap="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:isGame="true"
@@ -103,6 +104,15 @@
                 <data android:scheme="file" />
             </intent-filter>
         </activity-alias>
+
+        <receiver
+            android:name=".RetroAchievementsHostOverrideReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="${applicationId}.action.SET_RETROACHIEVEMENTS_HOST_OVERRIDE" />
+                <action android:name="${applicationId}.action.CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE" />
+            </intent-filter>
+        </receiver>
     </application>
 
 

--- a/ARMSX2/app/src/main/cpp/native-lib.cpp
+++ b/ARMSX2/app/src/main/cpp/native-lib.cpp
@@ -478,6 +478,65 @@ Java_kr_co_iefriends_pcsx2_NativeApp_isHardcoreMode(JNIEnv *env, jclass clazz) {
     return Achievements::IsHardcoreModeActive() ? JNI_TRUE : JNI_FALSE;
 }
 
+// Rebuild the rc_client so CreateClient re-reads the [Achievements] Host
+// setting. UpdateSettings' diff path never re-creates the client on a Host
+// change, so a live host switch needs an explicit teardown/reinit. No-op
+// unless achievements are enabled and active — otherwise the next
+// Initialize() picks the host up on its own.
+static void RestartAchievementsForHostChange() {
+    if (!EmuConfig.Achievements.Enabled || !Achievements::IsActive())
+        return;
+    Achievements::Shutdown(false);
+    Achievements::Initialize();
+}
+
+static void PersistAndApplyAchievementsSettings() {
+    if (s_settings_interface && s_settings_interface->IsDirty())
+        s_settings_interface->Save();
+    if (VMManager::HasValidVM())
+        VMManager::ApplySettings();
+}
+
+// Point the RetroAchievements client at a loopback proxy. Drives the same
+// [Achievements] Host setting CreateClient reads, so the override survives a
+// cold start. A loopback proxy is not the canonical RA server, so hardcore
+// is forced off while an override is active and the prior choice is saved
+// under HostOverrideSavedHardcore for clearAchievementsHostOverride to
+// restore. An empty host is ignored (use the clear path instead).
+extern "C"
+JNIEXPORT void JNICALL
+Java_kr_co_iefriends_pcsx2_NativeApp_setAchievementsHostOverride(JNIEnv *env, jclass clazz, jstring p_host) {
+    const std::string host = GetJavaString(env, p_host);
+    if (host.empty())
+        return;
+
+    const bool had_override = !Host::GetBaseStringSettingValue("Achievements", "Host", "").empty();
+    if (!had_override)
+        Host::SetBaseBoolSettingValue("Achievements", "HostOverrideSavedHardcore",
+                                      Host::GetBaseBoolSettingValue("Achievements", "HardcoreMode", false));
+
+    Host::SetBaseStringSettingValue("Achievements", "Host", host.c_str());
+    Host::SetBaseBoolSettingValue("Achievements", "HardcoreMode", false);
+
+    PersistAndApplyAchievementsSettings();
+    RestartAchievementsForHostChange();
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_kr_co_iefriends_pcsx2_NativeApp_clearAchievementsHostOverride(JNIEnv *env, jclass clazz) {
+    Host::RemoveBaseSettingValue("Achievements", "Host");
+
+    if (Host::ContainsBaseSettingValue("Achievements", "HostOverrideSavedHardcore")) {
+        const bool restore = Host::GetBaseBoolSettingValue("Achievements", "HostOverrideSavedHardcore", false);
+        Host::RemoveBaseSettingValue("Achievements", "HostOverrideSavedHardcore");
+        Host::SetBaseBoolSettingValue("Achievements", "HardcoreMode", restore);
+    }
+
+    PersistAndApplyAchievementsSettings();
+    RestartAchievementsForHostChange();
+}
+
 // Live HW/SW state from the GS thread's POV. The in-game overlay's renderer
 // pill mirrors this on every poll so an emucore-driven swap (e.g. SoftwareRendererFMVHack
 // flipping to SW during an FMV) doesn't desync the UI from the actual state.

--- a/ARMSX2/app/src/main/java/com/armsx2/RetroAchievementsHostOverrideReceiver.java
+++ b/ARMSX2/app/src/main/java/com/armsx2/RetroAchievementsHostOverrideReceiver.java
@@ -1,0 +1,165 @@
+package com.armsx2;
+
+import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import android.text.TextUtils;
+
+import java.util.Locale;
+
+import kr.co.iefriends.pcsx2.NativeApp;
+
+/**
+ * Repoints the RetroAchievements client at a loopback proxy (e.g. an
+ * offline RA proxy) over an intent. The native side persists the host in
+ * the [Achievements] Host setting that CreateClient already reads, so a
+ * change made while the emulator is running survives the next cold start.
+ *
+ * When the broadcast arrives before the native library is initialized the
+ * desired action is queued in SharedPreferences and replayed from
+ * {@link #applyPending(Context)} once NativeApp.initializeOnce has run.
+ *
+ * Only http loopback hosts (127.0.0.1 / localhost) with an explicit port
+ * are accepted; anything else clears the override.
+ */
+public class RetroAchievementsHostOverrideReceiver extends BroadcastReceiver {
+    private static final String ACTION_SET_SUFFIX = ".action.SET_RETROACHIEVEMENTS_HOST_OVERRIDE";
+    private static final String ACTION_CLEAR_SUFFIX = ".action.CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE";
+
+    private static final String PREFS_NAME = "retroachievements_host_override";
+    private static final String KEY_PENDING_HOST = "pending_host";
+    private static final String KEY_PENDING_CLEAR = "pending_clear";
+
+    public static final String EXTRA_HOST = "host";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (intent == null || intent.getAction() == null) {
+            return;
+        }
+
+        final String packageName = context.getPackageName();
+        final String action = intent.getAction();
+
+        if ((packageName + ACTION_CLEAR_SUFFIX).equals(action)) {
+            applyClear(context);
+            setResultCode(Activity.RESULT_OK);
+            return;
+        }
+
+        if (!(packageName + ACTION_SET_SUFFIX).equals(action)) {
+            return;
+        }
+
+        final String host = normalizeHost(intent.getStringExtra(EXTRA_HOST));
+        if (host == null) {
+            applyClear(context);
+            setResultCode(Activity.RESULT_OK);
+            return;
+        }
+
+        applySet(context, host);
+        setResultCode(Activity.RESULT_OK);
+    }
+
+    /** Replays a queued override once native is up. Called from NativeApp.initializeOnce. */
+    public static void applyPending(Context context) {
+        SharedPreferences prefs = sharedPreferences(context);
+        String host = prefs.getString(KEY_PENDING_HOST, null);
+        boolean pendingClear = prefs.getBoolean(KEY_PENDING_CLEAR, false);
+
+        if (!TextUtils.isEmpty(host)) {
+            NativeApp.setAchievementsHostOverride(host);
+        } else if (pendingClear) {
+            NativeApp.clearAchievementsHostOverride();
+        } else {
+            return;
+        }
+
+        clearPending(context);
+    }
+
+    private static void applySet(Context context, String host) {
+        sharedPreferences(context).edit()
+                .putString(KEY_PENDING_HOST, host)
+                .remove(KEY_PENDING_CLEAR)
+                .apply();
+        flushIfNativeReady(context);
+    }
+
+    private static void applyClear(Context context) {
+        sharedPreferences(context).edit()
+                .remove(KEY_PENDING_HOST)
+                .putBoolean(KEY_PENDING_CLEAR, true)
+                .apply();
+        flushIfNativeReady(context);
+    }
+
+    private static void flushIfNativeReady(Context context) {
+        if (NativeApp.getContext() != null) {
+            applyPending(context);
+        }
+    }
+
+    private static void clearPending(Context context) {
+        sharedPreferences(context).edit()
+                .remove(KEY_PENDING_HOST)
+                .remove(KEY_PENDING_CLEAR)
+                .apply();
+    }
+
+    private static SharedPreferences sharedPreferences(Context context) {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+    }
+
+    private static String normalizeHost(String value) {
+        String trimmed = value == null ? "" : value.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+
+        String candidate = trimmed.contains("://") ? trimmed : "http://" + trimmed;
+        Uri uri = Uri.parse(candidate);
+        if (uri == null) {
+            return null;
+        }
+
+        String scheme = uri.getScheme();
+        String host = uri.getHost();
+        if (scheme == null || host == null) {
+            return null;
+        }
+
+        String normalizedScheme = scheme.toLowerCase(Locale.US);
+        String normalizedHost = host.toLowerCase(Locale.US);
+        if (!"http".equals(normalizedScheme)) {
+            return null;
+        }
+
+        if (!"127.0.0.1".equals(normalizedHost) && !"localhost".equals(normalizedHost)) {
+            return null;
+        }
+
+        int port = uri.getPort();
+        if (port < 1 || port > 65535) {
+            return null;
+        }
+
+        String authority = uri.getEncodedAuthority();
+        if ((authority != null && authority.contains("@"))
+                || !TextUtils.isEmpty(uri.getEncodedQuery())
+                || !TextUtils.isEmpty(uri.getEncodedFragment())) {
+            return null;
+        }
+
+        String path = uri.getEncodedPath();
+        if (!TextUtils.isEmpty(path) && !"/".equals(path)) {
+            return null;
+        }
+
+        return normalizedScheme + "://" + normalizedHost + ":" + port;
+    }
+}

--- a/ARMSX2/app/src/main/java/kr/co/iefriends/pcsx2/NativeApp.java
+++ b/ARMSX2/app/src/main/java/kr/co/iefriends/pcsx2/NativeApp.java
@@ -49,7 +49,7 @@ public class NativeApp {
 
 	protected static WeakReference<Context> mContext;
 	public static Context getContext() {
-		return mContext.get();
+		return mContext != null ? mContext.get() : null;
 	}
 
 	public static void initializeOnce(Context context) {
@@ -82,6 +82,10 @@ public class NativeApp {
 		}
 
 		initialize(dataPath, biosFolder, android.os.Build.VERSION.SDK_INT);
+
+		// Replay a host override that arrived via broadcast while the native
+		// library was not yet loaded.
+		com.armsx2.RetroAchievementsHostOverrideReceiver.applyPending(context);
 	}
 
 	public static native void initialize(String path, String biosFolder, int apiVer);
@@ -173,6 +177,16 @@ public class NativeApp {
 	/** True iff the rcheevos hardcore flag is currently set. The Kotlin
 	 *  achievements panel polls this for the badge / button colour. */
 	public static native boolean isHardcoreMode();
+
+	/** Repoint the RetroAchievements client at a loopback proxy. Persists
+	 *  the [Achievements] Host setting (read by CreateClient), forces
+	 *  hardcore off while active — saving the prior choice — and rebuilds
+	 *  the client so a running session picks up the new host. */
+	public static native void setAchievementsHostOverride(String host);
+
+	/** Drop the host override set by {@link #setAchievementsHostOverride},
+	 *  restoring the saved hardcore choice and rebuilding the client. */
+	public static native void clearAchievementsHostOverride();
 
 	/** True iff the GS is currently in a HW renderer (OGL/VK), false for
 	 *  SW. Mirrors GSIsHardwareRenderer() from the GS thread. Polled by

--- a/ARMSX2/app/src/main/res/xml/network_security_config.xml
+++ b/ARMSX2/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">127.0.0.1</domain>
+        <domain includeSubdomains="false">localhost</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
[RAOfflineProxy](https://github.com/misantronic/RAOfflineProxy) is a local proxy that sits
between the emulator and retroachievements.org to cache RA data and enable offline
achievement tracking. It needs emulators to expose a host override so it can point them
at the loopback proxy.

This adds that to the refresh line — a port of #164 (merged to `master`), re-implemented
for the refresh architecture (`native-lib.cpp` JNI, `com.armsx2`, the existing
`[Achievements] Host` setting).

### What it does
- **network_security_config**: allow cleartext to `127.0.0.1`/`localhost` (targetSdk 36 blocks it by default).
- **RetroAchievementsHostOverrideReceiver**: broadcast to set/clear a loopback host; validated, persisted, and replayed on next launch if set while the app is closed.
- **native-lib JNI**: drives the existing `[Achievements] Host` setting, forces hardcore off while active (restored on clear), and rebuilds the client.

### Usage
```
adb shell am broadcast -a com.armsx2.action.SET_RETROACHIEVEMENTS_HOST_OVERRIDE \
  -e host "127.0.0.1:8080" -n com.armsx2/com.armsx2.RetroAchievementsHostOverrideReceiver
```
Clear with `CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE`. Tested on device.

### Related work
- #164 (ARMSX2 master)
- hrydgard/ppsspp#21760
- dolphin-emu/dolphin#14671
- rafaelvcaetano/melonDS-android#1633
- libretro/RetroArch#19093
- flyinghead/flycast#2371
