### PR TITLE
Fix/burnout clouds sky render

### DIFF
--- a/app/src/main/cpp/pcsx2/GS/Renderers/HW/GSHwHack.cpp
+++ b/app/src/main/cpp/pcsx2/GS/Renderers/HW/GSHwHack.cpp
@@ -585,11 +585,7 @@ bool GSHwHack::GSC_BurnoutGames(GSRendererHW& r, int& skip)
 		}
 	}
 
-#if defined(__APPLE__) && TARGET_OS_IPHONE
-	return true;
-#else
 	return GSC_BlackAndBurnoutSky(r, skip);
-#endif
 }
 
 bool GSHwHack::GSC_BlackAndBurnoutSky(GSRendererHW& r, int& skip)


### PR DESCRIPTION
PCSX2 has a skybox hack for Burnout 3/Burnout Revenge which fixes skybox/clouds not rendering at correct height(https://github.com/PCSX2/pcsx2/pull/8671).

We have a hack for this here as well, but at some point iOS check was added which skips this hack altogether on iOS devices.

I removed the check to resolve this.