### PR TITLE
feat(iOS): added toggle for hw download mode(per-game and global)

### DIFF
--- a/app/src/main/cpp/ARMSX2Bridge.h
+++ b/app/src/main/cpp/ARMSX2Bridge.h
@@ -124,6 +124,7 @@ typedef void (^ARMSX2RetroAchievementsCompletion)(BOOL success, NSString * _Nonn
             hardwareMipmapping:(BOOL)hardwareMipmapping
               blendingAccuracy:(int)blendingAccuracy
                interlaceMode:(int)interlaceMode
+              hwDownloadMode:(int)hwDownloadMode
         trilinearFiltering:(int)trilinearFiltering
           halfPixelOffset:(int)halfPixelOffset
               roundSprite:(int)roundSprite
@@ -153,7 +154,7 @@ typedef void (^ARMSX2RetroAchievementsCompletion)(BOOL success, NSString * _Nonn
                  enablePatches:(BOOL)enablePatches
               enableGameFixes:(BOOL)enableGameFixes
     enableGameDBHardwareFixes:(BOOL)enableGameDBHardwareFixes
-    NS_SWIFT_NAME(setGameSettings(forISO:enabled:upscaleMultiplier:aspectRatio:textureFiltering:hardwareMipmapping:blendingAccuracy:interlaceMode:trilinearFiltering:halfPixelOffset:roundSprite:alignSpriteOverride:alignSprite:mergeSpriteOverride:mergeSprite:wildArmsOffsetOverride:wildArmsOffset:textureOffsetXOverride:textureOffsetX:textureOffsetYOverride:textureOffsetY:skipDrawStartOverride:skipDrawStart:skipDrawEndOverride:skipDrawEnd:volumeOverride:volumePercent:eeCoreType:mtvu:eeCycleRateOverride:eeCycleRate:fastBootOverride:fastBoot:enableCheats:enablePatches:enableGameFixes:enableGameDBHardwareFixes:));
+    NS_SWIFT_NAME(setGameSettings(forISO:enabled:upscaleMultiplier:aspectRatio:textureFiltering:hardwareMipmapping:blendingAccuracy:interlaceMode:hwDownloadMode:trilinearFiltering:halfPixelOffset:roundSprite:alignSpriteOverride:alignSprite:mergeSpriteOverride:mergeSprite:wildArmsOffsetOverride:wildArmsOffset:textureOffsetXOverride:textureOffsetX:textureOffsetYOverride:textureOffsetY:skipDrawStartOverride:skipDrawStart:skipDrawEndOverride:skipDrawEnd:volumeOverride:volumePercent:eeCoreType:mtvu:eeCycleRateOverride:eeCycleRate:fastBootOverride:fastBoot:enableCheats:enablePatches:enableGameFixes:enableGameDBHardwareFixes:));
 + (void)setGameSettingsForCurrentGameWithEnabled:(BOOL)enabled
                                upscaleMultiplier:(float)upscaleMultiplier
                                      aspectRatio:(nonnull NSString *)aspectRatio
@@ -161,6 +162,7 @@ typedef void (^ARMSX2RetroAchievementsCompletion)(BOOL success, NSString * _Nonn
                               hardwareMipmapping:(BOOL)hardwareMipmapping
                                 blendingAccuracy:(int)blendingAccuracy
                                    interlaceMode:(int)interlaceMode
+                                  hwDownloadMode:(int)hwDownloadMode
                               trilinearFiltering:(int)trilinearFiltering
                                  halfPixelOffset:(int)halfPixelOffset
                                      roundSprite:(int)roundSprite
@@ -190,7 +192,7 @@ typedef void (^ARMSX2RetroAchievementsCompletion)(BOOL success, NSString * _Nonn
                                    enablePatches:(BOOL)enablePatches
                                  enableGameFixes:(BOOL)enableGameFixes
                       enableGameDBHardwareFixes:(BOOL)enableGameDBHardwareFixes
-    NS_SWIFT_NAME(setGameSettingsForCurrentGame(enabled:upscaleMultiplier:aspectRatio:textureFiltering:hardwareMipmapping:blendingAccuracy:interlaceMode:trilinearFiltering:halfPixelOffset:roundSprite:alignSpriteOverride:alignSprite:mergeSpriteOverride:mergeSprite:wildArmsOffsetOverride:wildArmsOffset:textureOffsetXOverride:textureOffsetX:textureOffsetYOverride:textureOffsetY:skipDrawStartOverride:skipDrawStart:skipDrawEndOverride:skipDrawEnd:volumeOverride:volumePercent:eeCoreType:mtvu:eeCycleRateOverride:eeCycleRate:fastBootOverride:fastBoot:enableCheats:enablePatches:enableGameFixes:enableGameDBHardwareFixes:));
+    NS_SWIFT_NAME(setGameSettingsForCurrentGame(enabled:upscaleMultiplier:aspectRatio:textureFiltering:hardwareMipmapping:blendingAccuracy:interlaceMode:hwDownloadMode:trilinearFiltering:halfPixelOffset:roundSprite:alignSpriteOverride:alignSprite:mergeSpriteOverride:mergeSprite:wildArmsOffsetOverride:wildArmsOffset:textureOffsetXOverride:textureOffsetX:textureOffsetYOverride:textureOffsetY:skipDrawStartOverride:skipDrawStart:skipDrawEndOverride:skipDrawEnd:volumeOverride:volumePercent:eeCoreType:mtvu:eeCycleRateOverride:eeCycleRate:fastBootOverride:fastBoot:enableCheats:enablePatches:enableGameFixes:enableGameDBHardwareFixes:));
 + (nullable NSString *)linkedDiscPathForELF:(nonnull NSString *)elfName NS_SWIFT_NAME(linkedDiscPath(forELF:));
 + (void)setLinkedDiscPath:(nullable NSString *)discPath forELF:(nonnull NSString *)elfName NS_SWIFT_NAME(setLinkedDiscPath(_:forELF:));
 + (nonnull NSString *)clearCacheForISO:(nonnull NSString *)isoName NS_SWIFT_NAME(clearCache(forISO:));

--- a/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/app/src/main/cpp/ARMSX2Bridge.mm
@@ -1500,6 +1500,7 @@ static NSMutableDictionary<NSString*, id>* ARMSX2BuildGlobalGameSettingsResult()
     const bool globalHardwareMipmapping = g_p44_settings_interface ? g_p44_settings_interface->GetBoolValue("EmuCore/GS", "hw_mipmap", true) : true;
     const int globalBlendingAccuracy = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "accurate_blending_unit", 1) : 1;
     const int globalInterlaceMode = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "deinterlace_mode", 7) : 7;
+    const int globalHwDownloadMode = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "HWDownloadMode", 0) : 0;
     const int globalTrilinearFiltering = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "TriFilter", -1) : -1;
     const int globalHalfPixelOffset = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "UserHacks_HalfPixelOffset", 0) : 0;
     const int globalRoundSprite = g_p44_settings_interface ? g_p44_settings_interface->GetIntValue("EmuCore/GS", "UserHacks_round_sprite_offset", 0) : 0;
@@ -1539,6 +1540,8 @@ static NSMutableDictionary<NSString*, id>* ARMSX2BuildGlobalGameSettingsResult()
         @"hardwareMipmapping": @(globalHardwareMipmapping),
         @"blendingAccuracy": @(globalBlendingAccuracy),
         @"interlaceMode": @(globalInterlaceMode),
+        @"hwDownloadMode": @(globalHwDownloadMode),
+        @"hasHwDownloadModeOverride": @NO,
         @"trilinearFiltering": @(globalTrilinearFiltering),
         @"hasTrilinearFilteringOverride": @NO,
         @"halfPixelOffset": @(globalHalfPixelOffset),
@@ -1613,6 +1616,7 @@ static void ARMSX2ApplyPerGameSettingsOverrides(NSMutableDictionary<NSString*, i
         si.ContainsValue("EmuCore/GS", "hw_mipmap") ||
         si.ContainsValue("EmuCore/GS", "accurate_blending_unit") ||
         si.ContainsValue("EmuCore/GS", "deinterlace_mode") ||
+        si.ContainsValue("EmuCore/GS", "HWDownloadMode") ||
         si.ContainsValue("EmuCore/GS", "TriFilter") ||
         si.ContainsValue("EmuCore/GS", "UserHacks_HalfPixelOffset") ||
         si.ContainsValue("EmuCore/GS", "UserHacks_round_sprite_offset") ||
@@ -1652,6 +1656,8 @@ static void ARMSX2ApplyPerGameSettingsOverrides(NSMutableDictionary<NSString*, i
     result[@"hardwareMipmapping"] = @(si.GetBoolValue("EmuCore/GS", "hw_mipmap", [result[@"hardwareMipmapping"] boolValue]));
     result[@"blendingAccuracy"] = @(si.GetIntValue("EmuCore/GS", "accurate_blending_unit", [result[@"blendingAccuracy"] intValue]));
     result[@"interlaceMode"] = @(si.GetIntValue("EmuCore/GS", "deinterlace_mode", [result[@"interlaceMode"] intValue]));
+    result[@"hasHwDownloadModeOverride"] = @(si.ContainsValue("EmuCore/GS", "HWDownloadMode"));
+    result[@"hwDownloadMode"] = @(ARMSX2ClampInt(si.GetIntValue("EmuCore/GS", "HWDownloadMode", [result[@"hwDownloadMode"] intValue]), 0, 4));
     result[@"hasTrilinearFilteringOverride"] = @(si.ContainsValue("EmuCore/GS", "TriFilter"));
     result[@"trilinearFiltering"] = @(ARMSX2ClampInt(si.GetIntValue("EmuCore/GS", "TriFilter", [result[@"trilinearFiltering"] intValue]), -1, 2));
     result[@"hasHalfPixelOffsetOverride"] = @(si.ContainsValue("EmuCore/GS", "UserHacks_HalfPixelOffset"));
@@ -1693,6 +1699,7 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
                                                 BOOL hardwareMipmapping,
                                                 int blendingAccuracy,
                                                 int interlaceMode,
+                                                int hwDownloadMode,
                                                 int trilinearFiltering,
                                                 int halfPixelOffset,
                                                 int roundSprite,
@@ -1741,6 +1748,10 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
         si.SetBoolValue("EmuCore/GS", "hw_mipmap", hardwareMipmapping);
         si.SetIntValue("EmuCore/GS", "accurate_blending_unit", blendingAccuracy);
         si.SetIntValue("EmuCore/GS", "deinterlace_mode", interlaceMode);
+        if (hwDownloadMode == ARMSX2UseGlobalIntSentinel)
+            si.DeleteValue("EmuCore/GS", "HWDownloadMode");
+        else
+            si.SetIntValue("EmuCore/GS", "HWDownloadMode", ARMSX2ClampInt(hwDownloadMode, 0, 4));
         if (trilinearFiltering == ARMSX2TriFilterUseGlobalSentinel)
             si.DeleteValue("EmuCore/GS", "TriFilter");
         else
@@ -2449,6 +2460,7 @@ static void ARMSX2SetPatchEnableListForIdentity(NSArray<NSString*>* values, cons
             hardwareMipmapping:(BOOL)hardwareMipmapping
               blendingAccuracy:(int)blendingAccuracy
                interlaceMode:(int)interlaceMode
+              hwDownloadMode:(int)hwDownloadMode
         trilinearFiltering:(int)trilinearFiltering
           halfPixelOffset:(int)halfPixelOffset
               roundSprite:(int)roundSprite
@@ -2488,7 +2500,7 @@ static void ARMSX2SetPatchEnableListForIdentity(NSArray<NSString*>* values, cons
     const std::string settingsSerial = (entry.type == GameList::EntryType::ELF) ? std::string() : entry.serial;
     ARMSX2WriteGameSettingsForIdentity(settingsSerial, entry.crc, enabled, upscaleMultiplier, aspectRatio,
                                         textureFiltering, hardwareMipmapping, blendingAccuracy, interlaceMode,
-                                        trilinearFiltering, halfPixelOffset, roundSprite, alignSpriteOverride,
+                                        hwDownloadMode, trilinearFiltering, halfPixelOffset, roundSprite, alignSpriteOverride,
                                         alignSprite, mergeSpriteOverride, mergeSprite, wildArmsOffsetOverride,
                                         wildArmsOffset, textureOffsetXOverride, textureOffsetX,
                                         textureOffsetYOverride, textureOffsetY, skipDrawStartOverride,
@@ -2505,6 +2517,7 @@ static void ARMSX2SetPatchEnableListForIdentity(NSArray<NSString*>* values, cons
                               hardwareMipmapping:(BOOL)hardwareMipmapping
                                 blendingAccuracy:(int)blendingAccuracy
                                    interlaceMode:(int)interlaceMode
+                                  hwDownloadMode:(int)hwDownloadMode
                               trilinearFiltering:(int)trilinearFiltering
                                  halfPixelOffset:(int)halfPixelOffset
                                      roundSprite:(int)roundSprite
@@ -2549,7 +2562,7 @@ static void ARMSX2SetPatchEnableListForIdentity(NSArray<NSString*>* values, cons
 
     ARMSX2WriteGameSettingsForIdentity(serial, crc, enabled, upscaleMultiplier, aspectRatio,
                                         textureFiltering, hardwareMipmapping, blendingAccuracy, interlaceMode,
-                                        trilinearFiltering, halfPixelOffset, roundSprite, alignSpriteOverride,
+                                        hwDownloadMode, trilinearFiltering, halfPixelOffset, roundSprite, alignSpriteOverride,
                                         alignSprite, mergeSpriteOverride, mergeSprite, wildArmsOffsetOverride,
                                         wildArmsOffset, textureOffsetXOverride, textureOffsetX,
                                         textureOffsetYOverride, textureOffsetY, skipDrawStartOverride,

--- a/app/src/main/swift/Models/SettingsStore.swift
+++ b/app/src/main/swift/Models/SettingsStore.swift
@@ -263,6 +263,9 @@ final class SettingsStore: @unchecked Sendable {
     var blendingAccuracy: Int {
         didSet { ARMSX2Bridge.setINIInt("EmuCore/GS", key: "accurate_blending_unit", value: Int32(blendingAccuracy)) }
     }
+    var hwDownloadMode: Int {
+        didSet { ARMSX2Bridge.setINIInt("EmuCore/GS", key: "HWDownloadMode", value: Int32(hwDownloadMode)) }
+    }
     var dithering: Int {
         didSet { ARMSX2Bridge.setINIInt("EmuCore/GS", key: "dithering_ps2", value: Int32(dithering)) }
     }
@@ -674,6 +677,7 @@ final class SettingsStore: @unchecked Sendable {
         interlaceMode = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "deinterlace_mode", defaultValue: 7))
         aspectRatio = Self.aspectRatioValue(from: ARMSX2Bridge.getINIString("EmuCore/GS", key: "AspectRatio", defaultValue: "Auto 4:3/3:2"))
         blendingAccuracy = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "accurate_blending_unit", defaultValue: 1))
+        hwDownloadMode = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "HWDownloadMode", defaultValue: 0))
         dithering = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "dithering_ps2", defaultValue: 2))
         trilinearFiltering = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "TriFilter", defaultValue: -1))
         halfPixelOffset = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "UserHacks_HalfPixelOffset", defaultValue: 0))
@@ -809,6 +813,7 @@ final class SettingsStore: @unchecked Sendable {
         interlaceMode = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "deinterlace_mode", defaultValue: 7))
         aspectRatio = Self.aspectRatioValue(from: ARMSX2Bridge.getINIString("EmuCore/GS", key: "AspectRatio", defaultValue: "Auto 4:3/3:2"))
         blendingAccuracy = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "accurate_blending_unit", defaultValue: 1))
+        hwDownloadMode = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "HWDownloadMode", defaultValue: 0))
         dithering = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "dithering_ps2", defaultValue: 2))
         trilinearFiltering = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "TriFilter", defaultValue: -1))
         halfPixelOffset = Int(ARMSX2Bridge.getINIInt("EmuCore/GS", key: "UserHacks_HalfPixelOffset", defaultValue: 0))
@@ -1113,6 +1118,7 @@ final class SettingsStore: @unchecked Sendable {
         interlaceMode = 7       // Adaptive
         aspectRatio = 1         // Auto 4:3/3:2
         blendingAccuracy = 1    // Basic
+        hwDownloadMode = 0      // Accurate (Recommended)
         dithering = 2           // Scaled
         trilinearFiltering = -1 // Automatic
         halfPixelOffset = 0

--- a/app/src/main/swift/Views/GameListView.swift
+++ b/app/src/main/swift/Views/GameListView.swift
@@ -1520,6 +1520,14 @@ struct PerGameSettingsPanel: View {
         PickerOption(id: 1, title: "Half"),
         PickerOption(id: 2, title: "Full")
     ]
+    private static let hwDownloadModeOptions = [
+        PickerOption(id: useGlobalSentinel, title: "Use Global"),
+        PickerOption(id: 0, title: "Accurate (Recommended)"),
+        PickerOption(id: 1, title: "Accurate Force Full"),
+        PickerOption(id: 2, title: "Disable Readbacks"),
+        PickerOption(id: 3, title: "Unsynchronized"),
+        PickerOption(id: 4, title: "Disabled (Ignore Transfers)")
+    ]
 
     let game: ISOEntry
     let onDone: (() -> Void)?
@@ -1532,6 +1540,7 @@ struct PerGameSettingsPanel: View {
     @State private var hardwareMipmapping: Bool
     @State private var blendingAccuracy: Int
     @State private var interlaceMode: Int
+    @State private var hwDownloadMode: Int
     @State private var trilinearFiltering: Int
     @State private var halfPixelOffset: Int
     @State private var roundSprite: Int
@@ -1597,6 +1606,7 @@ struct PerGameSettingsPanel: View {
         _hardwareMipmapping = State(initialValue: Self.boolValue(info["hardwareMipmapping"], defaultValue: true))
         _blendingAccuracy = State(initialValue: Self.intValue(info["blendingAccuracy"], defaultValue: 1))
         _interlaceMode = State(initialValue: Self.intValue(info["interlaceMode"], defaultValue: 7))
+        _hwDownloadMode = State(initialValue: Self.boolValue(info["hasHwDownloadModeOverride"], defaultValue: false) ? Self.intValue(info["hwDownloadMode"], defaultValue: 0) : Self.useGlobalSentinel)
         _trilinearFiltering = State(initialValue: Self.boolValue(info["hasTrilinearFilteringOverride"], defaultValue: false) ? Self.intValue(info["trilinearFiltering"], defaultValue: -1) : Self.trilinearUseGlobalSentinel)
         _halfPixelOffset = State(initialValue: Self.boolValue(info["hasHalfPixelOffsetOverride"], defaultValue: false) ? Self.intValue(info["halfPixelOffset"], defaultValue: 0) : Self.useGlobalSentinel)
         _roundSprite = State(initialValue: Self.boolValue(info["hasRoundSpriteOverride"], defaultValue: false) ? Self.intValue(info["roundSprite"], defaultValue: 0) : Self.useGlobalSentinel)
@@ -1938,6 +1948,19 @@ struct PerGameSettingsPanel: View {
                         }
                     }
                     .disabled(!enabled)
+
+                    Picker(settings.localized("Hardware Download Mode"), selection: $hwDownloadMode) {
+                        ForEach(Self.hwDownloadModeOptions) { option in
+                            Text(settings.localized(option.title)).tag(option.id)
+                        }
+                    }
+                    .disabled(!enabled)
+
+                    if hwDownloadMode != Self.useGlobalSentinel && hwDownloadMode != 0 {
+                        Text(settings.localized("Non-accurate download modes may break rendering in some games."))
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
                 }
 
                 Section(settings.localized("Advanced Upscaling Hacks")) {
@@ -2165,6 +2188,7 @@ struct PerGameSettingsPanel: View {
                 hardwareMipmapping: hardwareMipmapping,
                 blendingAccuracy: Int32(blendingAccuracy),
                 interlaceMode: Int32(interlaceMode),
+                hwDownloadMode: Int32(hwDownloadMode),
                 trilinearFiltering: Int32(trilinearFiltering),
                 halfPixelOffset: Int32(halfPixelOffset),
                 roundSprite: Int32(roundSprite),
@@ -2205,6 +2229,7 @@ struct PerGameSettingsPanel: View {
                 hardwareMipmapping: hardwareMipmapping,
                 blendingAccuracy: Int32(blendingAccuracy),
                 interlaceMode: Int32(interlaceMode),
+                hwDownloadMode: Int32(hwDownloadMode),
                 trilinearFiltering: Int32(trilinearFiltering),
                 halfPixelOffset: Int32(halfPixelOffset),
                 roundSprite: Int32(roundSprite),

--- a/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
+++ b/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
@@ -158,6 +158,22 @@ struct GraphicsSettingsView: View {
                     Text(settings.localized("Unscaled")).tag(1)
                     Text(settings.localized("Scaled (Default)")).tag(2)
                 }
+
+                Picker(settings.localized("Hardware Download Mode"), selection: $settings.hwDownloadMode) {
+                    Text(settings.localized("Accurate (Recommended)")).tag(0)
+                    Text(settings.localized("Accurate Force Full")).tag(1)
+                    Text(settings.localized("Disable Readbacks")).tag(2)
+                    Text(settings.localized("Unsynchronized")).tag(3)
+                    Text(settings.localized("Disabled (Ignore Transfers)")).tag(4)
+                }
+                Text(settings.localized("Controls GS readback synchronization. Accurate is safest; faster modes can break effects that read back the screen. Applies after restart."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if settings.hwDownloadMode != 0 {
+                    Text(settings.localized("Non-accurate download modes may break rendering in some games."))
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
             }
 
             Section(settings.localized("Advanced Upscaling Hacks")) {


### PR DESCRIPTION
Added toggle for HW Download Mode to both per-game settings and global settings to iOS version.

Mainly for Gran Turismo 4, as disabling this helps out with performance on specific tracks, does have drawbacks though as it affects some effects as well.