### PR TITLE
Fix in-game back button to open options menu instead of quitting

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -199,6 +199,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'com.caverock:androidsvg:1.4'
     implementation 'androidx.browser:browser:1.9.0'
+    testImplementation 'junit:junit:4.13.2'
     if (enableRN) {
         // React Native core and Hermes engine (brownfield integration)
         implementation 'com.facebook.react:react-android:0.74.3'

--- a/app/src/main/java/kr/co/iefriends/pcsx2/activities/MainActivity.java
+++ b/app/src/main/java/kr/co/iefriends/pcsx2/activities/MainActivity.java
@@ -118,6 +118,7 @@ import kr.co.iefriends.pcsx2.input.view.DPadView;
 import kr.co.iefriends.pcsx2.input.view.JoystickView;
 import kr.co.iefriends.pcsx2.input.view.PSButtonView;
 import kr.co.iefriends.pcsx2.input.view.PSShoulderButtonView;
+import kr.co.iefriends.pcsx2.utils.BackPressPolicy;
 import kr.co.iefriends.pcsx2.utils.DataDirectoryManager;
 import kr.co.iefriends.pcsx2.utils.DebugLog;
 import kr.co.iefriends.pcsx2.utils.DeviceProfiles;
@@ -233,11 +234,15 @@ public class MainActivity extends AppCompatActivity {
     
     private int currentControllerMode = 0; // 0=2 Sticks, 1=1 Stick+Face, 2=D-Pad Only
 
+    // Window during which a second back press exits the game instead of toggling the menu.
+    private static final long BACK_EXIT_CONFIRM_WINDOW_MS = 2000L;
+    private long lastBackExitPromptMs = 0L;
+
     private final OnBackPressedCallback onBackPressCallback =
         new OnBackPressedCallback(false) {
             @Override
             public void handleOnBackPressed() {
-                shutdownVmToHome();
+                handleInGameBackPress();
             }
         };
     private final OnBackPressedCallback onSearchBackPressCallback =
@@ -2192,6 +2197,8 @@ public class MainActivity extends AppCompatActivity {
                 public void onDrawerClosed(@NonNull View drawerView) {
                     lastInput = InputSource.TOUCH;
                     lastTouchTimeMs = System.currentTimeMillis();
+                    // Closing the menu (by any means) disarms the double-back exit shortcut.
+                    lastBackExitPromptMs = 0L;
                     maybeAutoHideControls();
                 }
             });
@@ -2385,6 +2392,32 @@ public class MainActivity extends AppCompatActivity {
     private void closeInGameDrawer() {
         if (inGameDrawer != null && inGameDrawer.isDrawerOpen(GravityCompat.START)) {
             inGameDrawer.closeDrawer(GravityCompat.START);
+        }
+    }
+
+    // System back while in-game: toggle the settings menu instead of killing the VM.
+    // A quick double-back (menu closed -> opens, then back again within the window) exits to the library.
+    private void handleInGameBackPress() {
+        long now = System.currentTimeMillis();
+        boolean drawerOpen = inGameDrawer != null && inGameDrawer.isDrawerOpen(GravityCompat.START);
+
+        switch (BackPressPolicy.decide(drawerOpen, lastBackExitPromptMs, now, BACK_EXIT_CONFIRM_WINDOW_MS)) {
+            case EXIT:
+                lastBackExitPromptMs = 0L;
+                shutdownVmToHome();
+                break;
+            case CLOSE_MENU:
+                // Menu already open (e.g. via the toggle button) -> back just closes it.
+                closeInGameDrawer();
+                break;
+            case OPEN_MENU_ARM:
+                // Menu closed -> open it and arm the exit confirmation for a quick second back press.
+                lastBackExitPromptMs = now;
+                toggleInGameDrawer();
+                try {
+                    Toast.makeText(this, R.string.in_game_back_exit_hint, Toast.LENGTH_SHORT).show();
+                } catch (Throwable ignored) {}
+                break;
         }
     }
 

--- a/app/src/main/java/kr/co/iefriends/pcsx2/utils/BackPressPolicy.java
+++ b/app/src/main/java/kr/co/iefriends/pcsx2/utils/BackPressPolicy.java
@@ -1,0 +1,40 @@
+package kr.co.iefriends.pcsx2.utils;
+
+/**
+ * Pure decision logic for the in-game system back button.
+ *
+ * Kept free of any Android dependencies so the behaviour can be unit-tested in isolation.
+ * The hosting Activity supplies the current state and performs the resulting side effect.
+ */
+public final class BackPressPolicy {
+
+    private BackPressPolicy() {}
+
+    public enum Action {
+        /** Exit the running game and return to the library. */
+        EXIT,
+        /** Close the in-game options menu. */
+        CLOSE_MENU,
+        /** Open the in-game options menu and arm the double-back exit shortcut. */
+        OPEN_MENU_ARM
+    }
+
+    /**
+     * Decide what a system back press should do while a game is running.
+     *
+     * @param drawerOpen    whether the in-game options drawer is currently open
+     * @param lastPromptMs  timestamp (ms) of the back press that armed the exit shortcut, or 0 if disarmed
+     * @param nowMs         current timestamp (ms)
+     * @param windowMs      how long the exit shortcut stays armed after opening the menu
+     */
+    public static Action decide(boolean drawerOpen, long lastPromptMs, long nowMs, long windowMs) {
+        boolean exitArmed = lastPromptMs != 0L && (nowMs - lastPromptMs) <= windowMs;
+        if (exitArmed) {
+            return Action.EXIT;
+        }
+        if (drawerOpen) {
+            return Action.CLOSE_MENU;
+        }
+        return Action.OPEN_MENU_ARM;
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,7 @@ Open it later from Settings → Open ARMSX2 directory.</string>
     <string name="settings_app_icon_error_loading">Unable to load this icon.</string>
     <string name="drawer_toggle_content_description">Toggle in-game options</string>
     <string name="drawer_title_in_game_options">In-game options</string>
+    <string name="in_game_back_exit_hint">Press back again to exit the game</string>
     <string name="drawer_reboot_content_description">Reboot the emulator</string>
     <string name="drawer_pause_content_description">Pause the game</string>
     <string name="drawer_resume_content_description">Resume the game</string>

--- a/app/src/test/java/kr/co/iefriends/pcsx2/utils/BackPressPolicyTest.java
+++ b/app/src/test/java/kr/co/iefriends/pcsx2/utils/BackPressPolicyTest.java
@@ -1,0 +1,79 @@
+package kr.co.iefriends.pcsx2.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import kr.co.iefriends.pcsx2.utils.BackPressPolicy.Action;
+
+import org.junit.Test;
+
+/**
+ * Regression coverage for the in-game system back button decision logic.
+ *
+ * The Activity turns a back press into one of three actions; these tests pin the full
+ * transition table so the "double-back to exit" timing and the older exit behaviour
+ * cannot silently regress.
+ */
+public class BackPressPolicyTest {
+
+    private static final long WINDOW_MS = 2000L;
+    private static final long NOW = 1_000_000L;
+
+    // --- Core transitions ---
+
+    @Test
+    public void closedAndDisarmed_opensMenuAndArms() {
+        assertEquals(Action.OPEN_MENU_ARM,
+            BackPressPolicy.decide(false, 0L, NOW, WINDOW_MS));
+    }
+
+    @Test
+    public void armed_secondBackImmediately_exits() {
+        assertEquals(Action.EXIT,
+            BackPressPolicy.decide(true, NOW, NOW, WINDOW_MS));
+    }
+
+    @Test
+    public void armed_secondBackJustInsideWindow_exits() {
+        assertEquals(Action.EXIT,
+            BackPressPolicy.decide(true, NOW, NOW + 1999, WINDOW_MS));
+    }
+
+    @Test
+    public void armed_secondBackAtWindowEdge_exits() {
+        assertEquals(Action.EXIT,
+            BackPressPolicy.decide(true, NOW, NOW + WINDOW_MS, WINDOW_MS));
+    }
+
+    @Test
+    public void windowExpired_menuOpen_closesMenu() {
+        assertEquals(Action.CLOSE_MENU,
+            BackPressPolicy.decide(true, NOW, NOW + WINDOW_MS + 1, WINDOW_MS));
+    }
+
+    @Test
+    public void windowExpired_menuClosed_reopensMenu() {
+        assertEquals(Action.OPEN_MENU_ARM,
+            BackPressPolicy.decide(false, NOW, NOW + WINDOW_MS + 1, WINDOW_MS));
+    }
+
+    // --- Regression guards ---
+
+    @Test
+    public void openedViaToggleButton_notArmed_closesMenuNotExit() {
+        // Menu opened by the floating toggle (never armed by a back press).
+        assertEquals(Action.CLOSE_MENU,
+            BackPressPolicy.decide(true, 0L, NOW, WINDOW_MS));
+    }
+
+    @Test
+    public void staleArmFromEarlier_treatedAsDisarmed() {
+        assertEquals(Action.OPEN_MENU_ARM,
+            BackPressPolicy.decide(false, NOW, NOW + 10_000_000L, WINDOW_MS));
+    }
+
+    @Test
+    public void zeroTimestampNeverArmed_evenAtClockZero() {
+        assertEquals(Action.OPEN_MENU_ARM,
+            BackPressPolicy.decide(false, 0L, 0L, WINDOW_MS));
+    }
+}


### PR DESCRIPTION
What: The system back button, while a game is running, immediately shut down the VM and returned to the library. It now toggles the in-game options menu instead. Exiting is a deliberate double-back — first press opens the menu and shows a "press back again to exit" hint; a second press within 2s quits. Closing the menu any other way disarms the shortcut, and the drawer's power button still exits directly, so no exit path is lost.

Why: Back-to-quit is non-standard for an emulator (RetroArch/PPSSPP/DuckStation all use back as the menu toggle), and it left the rich in-game options drawer reachable only via the auto-hiding floating toggle.

For reviewers: The decision logic is extracted into a dependency-free BackPressPolicy helper with unit tests covering the full transition table (timing window, double-back exit, and the "opened via toggle button" case). Run with ./gradlew testUnrestrictedDebugUnitTest. One thing worth an eyes-on check: behavior when disableTouchControls is active (drawer is LOCK_MODE_LOCKED_CLOSED) — programmatic open should still work, but I couldn't verify on-device.