### PR TITLE
Localize in-game toasts and guard driver URI scheme

### DIFF
--- a/app/src/main/java/kr/co/iefriends/pcsx2/activities/GpuDriverManagerActivity.java
+++ b/app/src/main/java/kr/co/iefriends/pcsx2/activities/GpuDriverManagerActivity.java
@@ -215,7 +215,7 @@ public class GpuDriverManagerActivity extends AppCompatActivity {
     @Nullable
     private String getFileNameFromUri(@NonNull Uri uri) {
         String result = null;
-        if (uri.getScheme().equals("content")) {
+        if ("content".equals(uri.getScheme())) {
             try (android.database.Cursor cursor = getContentResolver().query(uri, null, null, null, null)) {
                 if (cursor != null && cursor.moveToFirst()) {
                     int nameIndex = cursor.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME);

--- a/app/src/main/java/kr/co/iefriends/pcsx2/activities/MainActivity.java
+++ b/app/src/main/java/kr/co/iefriends/pcsx2/activities/MainActivity.java
@@ -5136,7 +5136,7 @@ public class MainActivity extends AppCompatActivity {
             int crcInt = NativeApp.getGameCRC();
 
             if (TextUtils.isEmpty(serial) || crcInt == 0) {
-                Toast.makeText(this, "Erro: Start the Game First", Toast.LENGTH_SHORT).show();
+                Toast.makeText(this, R.string.drawer_cheat_import_start_game_first, Toast.LENGTH_SHORT).show();
                 return;
             }
 
@@ -5152,10 +5152,10 @@ public class MainActivity extends AppCompatActivity {
             NativeApp.setEnableCheats(false);
             NativeApp.setEnableCheats(true);
 
-            Toast.makeText(this, "Cheat Imported: " + fileName, Toast.LENGTH_LONG).show();
+            Toast.makeText(this, getString(R.string.drawer_cheat_imported, fileName), Toast.LENGTH_LONG).show();
 
         } catch (Exception e) {
-            Toast.makeText(this, "Erro: " + e.getMessage(), Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, getString(R.string.drawer_cheat_import_error, e.getMessage()), Toast.LENGTH_SHORT).show();
         }
     }
 
@@ -5447,9 +5447,9 @@ public class MainActivity extends AppCompatActivity {
                             displayName = uri.getLastPathSegment();
                         }
                         if (NativeApp.changeDisc(uri.toString())) {
-                            Toast.makeText(this, "Disc Changed: " + displayName, Toast.LENGTH_SHORT).show();
+                            Toast.makeText(this, getString(R.string.disc_changed, displayName), Toast.LENGTH_SHORT).show();
                         } else {
-                            Toast.makeText(this, "Failure to Change Disk: " + displayName, Toast.LENGTH_LONG).show();
+                            Toast.makeText(this, getString(R.string.disc_change_failed, displayName), Toast.LENGTH_LONG).show();
                         }
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,6 +144,11 @@ Open it later from Settings → Open ARMSX2 directory.</string>
     <string name="drawer_error_import_cheats_title">Cheat Import Failed</string>
     <string name="drawer_error_import_textures_title">Texture Import Failed</string>
     <string name="drawer_error_import_unknown">Import failed but no reason was provided.</string>
+    <string name="drawer_cheat_import_start_game_first">Error: start the game first</string>
+    <string name="drawer_cheat_imported">Cheat imported: %1$s</string>
+    <string name="drawer_cheat_import_error">Error: %1$s</string>
+    <string name="disc_changed">Disc changed: %1$s</string>
+    <string name="disc_change_failed">Failed to change disc: %1$s</string>
     <string name="settings_fxaa">FXAA</string>
     <string name="settings_graphics_advanced_heading">Advanced Rendering</string>
     <string name="settings_graphics_renderer">Renderer</string>


### PR DESCRIPTION
## What

Two small, self-contained cleanups in the Android app, found while scouting for low-hanging fruit after the in-game back-button PR:

1. **Localize five hardcoded in-game toasts** (cheat import + disc change) in `MainActivity`, moving them into `res/values/strings.xml` following the existing `drawer_*` / `%1$s` convention used by the surrounding import strings.
2. **Guard a possible NPE** in `GpuDriverManagerActivity#getFileNameFromUri`.

## Why

- The moved literals contained two visible defects: the typo `"Erro:"` (now **"Error:"**) and `"Change Disk"` (now **"Disc"**, matching the rest of the UI). They were also the only user-facing toasts in this path bypassing the app's established localization, so non-English locales showed the mistyped English text with no way to translate it. They now fall back to proper string resources.
- `uri.getScheme().equals("content")` NPEs if a `Uri` has a null scheme (possible from a custom document provider). Flipping to `"content".equals(uri.getScheme())` makes it null-safe, consistent with the defensive checks elsewhere in that file.

## Notes for reviewers

- Only the English `values/strings.xml` gains the 5 new keys; `values-ar` and `values-zh-rCN` fall back to English until translated (standard Android behavior).
- The `getString(R.string.x, arg)` format-arg pattern used here is already used 17× in `MainActivity.java`.
- Branch name mentions "ui-thread-io" — that larger work (GPU driver ZIP extraction and 64MB memory-card write both blocking the UI thread) is **not** in this PR and is a planned follow-up.

No behavior changes beyond the corrected wording; purely a string-resource move plus a null-safety flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)