### PR TITLE
(iOS) feat: OSD overlay custom preset and corner cutoff fixes

### DIFF
--- a/app/src/main/cpp/ios_main.mm
+++ b/app/src/main/cpp/ios_main.mm
@@ -317,8 +317,13 @@ void ARMSX2ConfigureImGuiFonts(const char* reason)
     int w = std::max(1, (int)(self.bounds.size.width * scale + 0.5));
     int h = std::max(1, (int)(self.bounds.size.height * scale + 0.5));
     float s = (float)scale;
-    MTGS::RunOnGSThread([w, h, s]() {
+
+    // Indent corner-anchored OSD by a small fixed clearance so it isn't clipped by the display's rounded corners
+    constexpr double kOsdCornerInsetPt = 18.0;
+    const float osd_inset = (float)(kOsdCornerInsetPt * scale);
+    MTGS::RunOnGSThread([w, h, s, osd_inset]() {
         GSResizeDisplayWindow(w, h, s);
+        ImGuiManager::SetOSDSafeAreaInsets(osd_inset, osd_inset, osd_inset, osd_inset);
     });
 }
 @end
@@ -878,39 +883,29 @@ void ARMSX2ApplyIOSOsdPresetFromConfig(const char* reason)
     if (!s_settings_interface)
         return;
 
-    const int preset = std::clamp(s_settings_interface->GetIntValue("ARMSX2iOS/UI", "OsdPreset", 0), 0, 3);
+    ARMSX2SetIOSOsdFlags(
+        s_settings_interface->GetBoolValue("EmuCore/GS", "OsdShowFPS", false),
+        s_settings_interface->GetBoolValue("EmuCore/GS", "OsdShowVPS", false),
+        s_settings_interface->GetBoolValue("EmuCore/GS", "OsdShowSpeed", false),
+        s_settings_interface->GetBoolValue("EmuCore/GS", "OsdShowCPU", false),
+        s_settings_interface->GetBoolValue("EmuCore/GS", "OsdShowGPU", false),
+        s_settings_interface->GetBoolValue("EmuCore/GS", "OsdShowResolution", false),
+        s_settings_interface->GetBoolValue("EmuCore/GS", "OsdShowGSStats", false),
+        s_settings_interface->GetBoolValue("EmuCore/GS", "OsdShowIndicators", false),
+        s_settings_interface->GetBoolValue("EmuCore/GS", "OsdShowSettings", false),
+        s_settings_interface->GetBoolValue("EmuCore/GS", "OsdShowInputs", false),
+        s_settings_interface->GetBoolValue("EmuCore/GS", "OsdShowFrameTimes", false),
+        s_settings_interface->GetBoolValue("EmuCore/GS", "OsdShowVersion", false),
+        s_settings_interface->GetBoolValue("EmuCore/GS", "OsdShowHardwareInfo", false));
+
     int position = s_settings_interface->GetIntValue("EmuCore/GS", "OsdPerformancePos", static_cast<int>(OsdOverlayPos::TopRight));
     if (position == static_cast<int>(OsdOverlayPos::TopCenter))
         position = static_cast<int>(OsdOverlayPos::TopRight);
-
-    switch (preset) {
-    case 1:
-        ARMSX2SetIOSOsdFlags(true, false, true, true, true, false, false, true, false, false, false, true, false);
-        break;
-    case 2:
-        ARMSX2SetIOSOsdFlags(true, true, true, true, true, true, false, true, false, false, false, true, false);
-        break;
-    case 3:
-        ARMSX2SetIOSOsdFlags(true, true, true, true, true, true, true, true, true, true, true, true, true);
-        break;
-    default:
-        ARMSX2SetIOSOsdFlags(false, false, false, false, false, false, false, false, false, false, false, false, false);
-        position = 0;
-        break;
-    }
-
-    if (preset != 0 && (position < static_cast<int>(OsdOverlayPos::TopLeft) || position > static_cast<int>(OsdOverlayPos::TopRight)))
-        position = static_cast<int>(OsdOverlayPos::TopRight);
-
     EmuConfig.GS.OsdPerformancePos = static_cast<OsdOverlayPos>(position);
     GSConfig.OsdPerformancePos = static_cast<OsdOverlayPos>(position);
-    ARMSX2WriteIOSOsdFlagsToSettings();
-    s_settings_interface->SetIntValue("ARMSX2iOS/UI", "OsdPreset", preset);
-    s_settings_interface->SetIntValue("EmuCore/GS", "OsdPerformancePos", position);
-    s_settings_interface->Save();
 
     Console.WriteLn("@@OSD@@ preset=%d position=%d reason=%s fps=%d vps=%d speed=%d gpu=%d device_stats=%d frame_times=%d version=%d hardware=%d",
-        preset, position, reason ? reason : "unknown",
+        s_settings_interface->GetIntValue("ARMSX2iOS/UI", "OsdPreset", 0), position, reason ? reason : "unknown",
         EmuConfig.GS.OsdShowFPS ? 1 : 0,
         EmuConfig.GS.OsdShowVPS ? 1 : 0,
         EmuConfig.GS.OsdShowSpeed ? 1 : 0,

--- a/app/src/main/cpp/pcsx2/ImGui/ImGuiManager.cpp
+++ b/app/src/main/cpp/pcsx2/ImGui/ImGuiManager.cpp
@@ -91,6 +91,11 @@ static std::vector<u8> s_icon_pf_font_data;
 
 static float s_window_width;
 static float s_window_height;
+// OSD safe-area insets (device pixels). 0 unless the platform sets them (iOS).
+static float s_osd_safe_area_left = 0.0f;
+static float s_osd_safe_area_top = 0.0f;
+static float s_osd_safe_area_right = 0.0f;
+static float s_osd_safe_area_bottom = 0.0f;
 static Common::Timer s_last_render_time;
 
 // cached copies of WantCaptureKeyboard/Mouse, used to know when to dispatch events
@@ -239,6 +244,34 @@ float ImGuiManager::GetWindowWidth()
 float ImGuiManager::GetWindowHeight()
 {
 	return s_window_height;
+}
+
+void ImGuiManager::SetOSDSafeAreaInsets(float left, float top, float right, float bottom)
+{
+	s_osd_safe_area_left = std::max(0.0f, left);
+	s_osd_safe_area_top = std::max(0.0f, top);
+	s_osd_safe_area_right = std::max(0.0f, right);
+	s_osd_safe_area_bottom = std::max(0.0f, bottom);
+}
+
+float ImGuiManager::GetOSDSafeAreaLeft()
+{
+	return s_osd_safe_area_left;
+}
+
+float ImGuiManager::GetOSDSafeAreaTop()
+{
+	return s_osd_safe_area_top;
+}
+
+float ImGuiManager::GetOSDSafeAreaRight()
+{
+	return s_osd_safe_area_right;
+}
+
+float ImGuiManager::GetOSDSafeAreaBottom()
+{
+	return s_osd_safe_area_bottom;
 }
 
 void ImGuiManager::WindowResized()
@@ -906,33 +939,37 @@ void ImGuiManager::DrawOSDMessages(Common::Timer::Value current_time)
 	const float margin = std::ceil(GSConfig.OsdMargin * scale);
 	const float padding = std::ceil(8.0f * scale);
 	const float rounding = std::ceil(5.0f * scale);
-	const float max_width = s_window_width - (margin + padding) * 2.0f;
-	
-	float position_y = margin;
+	const float eff_left = std::max(margin, s_osd_safe_area_left);
+	const float eff_right = std::max(margin, s_osd_safe_area_right);
+	const float eff_top = std::max(margin, s_osd_safe_area_top);
+	const float eff_bottom = std::max(margin, s_osd_safe_area_bottom);
+	const float max_width = s_window_width - eff_left - eff_right - padding * 2.0f;
+
+	float position_y = eff_top;
 	switch (GSConfig.OsdMessagesPos)
 	{
 		case OsdOverlayPos::TopLeft:
 		case OsdOverlayPos::TopCenter:
 		case OsdOverlayPos::TopRight:
-			position_y = margin;
+			position_y = eff_top;
 			break;
-			
+
 		case OsdOverlayPos::CenterLeft:
 		case OsdOverlayPos::Center:
 		case OsdOverlayPos::CenterRight:
 			position_y = s_window_height * 0.5f;
 			break;
-			
+
 		case OsdOverlayPos::BottomLeft:
 		case OsdOverlayPos::BottomCenter:
 		case OsdOverlayPos::BottomRight:
 			// For bottom positions, start from the bottom and let messages stack upward
-			position_y = s_window_height - margin;
+			position_y = s_window_height - eff_bottom;
 			break;
-			
+
 		case OsdOverlayPos::None:
 		default:
-			position_y = margin;
+			position_y = eff_top;
 			break;
 	}
 

--- a/app/src/main/cpp/pcsx2/ImGui/ImGuiManager.h
+++ b/app/src/main/cpp/pcsx2/ImGui/ImGuiManager.h
@@ -44,6 +44,13 @@ namespace ImGuiManager
 	/// Updates internal state when the window is size.
 	void WindowResized();
 
+	/// OSD safe-area insets in device pixels, fixes rounded corners/notch cutoff
+	void SetOSDSafeAreaInsets(float left, float top, float right, float bottom);
+	float GetOSDSafeAreaLeft();
+	float GetOSDSafeAreaTop();
+	float GetOSDSafeAreaRight();
+	float GetOSDSafeAreaBottom();
+
 	/// Updates scaling of the on-screen elements.
 	void RequestScaleUpdate();
 

--- a/app/src/main/cpp/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/app/src/main/cpp/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -114,26 +114,32 @@ static ImU32 ARMSX2IOSDeviceStatsColor()
 // OSD positioning funcs
 ImVec2 CalculateOSDPosition(OsdOverlayPos position, float margin, const ImVec2& text_size, float window_width, float window_height)
 {
+	// Fold per-edge safe-area insets into the margin so the HUD clears rounded
+	// corners / notch / home indicator on iOS. Insets are 0 elsewhere.
+	const float eff_left = std::max(margin, ImGuiManager::GetOSDSafeAreaLeft());
+	const float eff_top = std::max(margin, ImGuiManager::GetOSDSafeAreaTop());
+	const float eff_right = std::max(margin, ImGuiManager::GetOSDSafeAreaRight());
+	const float eff_bottom = std::max(margin, ImGuiManager::GetOSDSafeAreaBottom());
 	switch (position)
 	{
 		case OsdOverlayPos::TopLeft:
-			return ImVec2(margin, margin);
+			return ImVec2(eff_left, eff_top);
 		case OsdOverlayPos::TopCenter:
-			return ImVec2((window_width - text_size.x) * 0.5f, margin);
+			return ImVec2((window_width - text_size.x) * 0.5f, eff_top);
 		case OsdOverlayPos::TopRight:
-			return ImVec2(window_width - margin - text_size.x, margin);
+			return ImVec2(window_width - eff_right - text_size.x, eff_top);
 		case OsdOverlayPos::CenterLeft:
-			return ImVec2(margin, (window_height - text_size.y) * 0.5f);
+			return ImVec2(eff_left, (window_height - text_size.y) * 0.5f);
 		case OsdOverlayPos::Center:
 			return ImVec2((window_width - text_size.x) * 0.5f, (window_height - text_size.y) * 0.5f);
 		case OsdOverlayPos::CenterRight:
-			return ImVec2(window_width - margin - text_size.x, (window_height - text_size.y) * 0.5f);
+			return ImVec2(window_width - eff_right - text_size.x, (window_height - text_size.y) * 0.5f);
 		case OsdOverlayPos::BottomLeft:
-			return ImVec2(margin, window_height - margin - text_size.y);
+			return ImVec2(eff_left, window_height - eff_bottom - text_size.y);
 		case OsdOverlayPos::BottomCenter:
-			return ImVec2((window_width - text_size.x) * 0.5f, window_height - margin - text_size.y);
+			return ImVec2((window_width - text_size.x) * 0.5f, window_height - eff_bottom - text_size.y);
 		case OsdOverlayPos::BottomRight:
-			return ImVec2(window_width - margin - text_size.x, window_height - margin - text_size.y);
+			return ImVec2(window_width - eff_right - text_size.x, window_height - eff_bottom - text_size.y);
 		case OsdOverlayPos::None:
 		default:
 			return ImVec2(0.0f, 0.0f);
@@ -143,6 +149,10 @@ ImVec2 CalculateOSDPosition(OsdOverlayPos position, float margin, const ImVec2& 
 ImVec2 CalculatePerformanceOverlayTextPosition(OsdOverlayPos position, float margin, const ImVec2& text_size, float window_width, float position_y)
 {
 	const float abs_margin = std::abs(margin);
+	// Fold horizontal safe-area insets so left/right-anchored text clears the
+	// notch / rounded corners on iOS (insets are 0 elsewhere).
+	const float eff_left = std::max(abs_margin, ImGuiManager::GetOSDSafeAreaLeft());
+	const float eff_right = std::max(abs_margin, ImGuiManager::GetOSDSafeAreaRight());
 
 	// Get the X position based on horizontal alignment
 	float x_pos;
@@ -151,7 +161,7 @@ ImVec2 CalculatePerformanceOverlayTextPosition(OsdOverlayPos position, float mar
 		case OsdOverlayPos::TopLeft:
 		case OsdOverlayPos::CenterLeft:
 		case OsdOverlayPos::BottomLeft:
-			x_pos = abs_margin; // Left alignment
+			x_pos = eff_left; // Left alignment
 			break;
 
 		case OsdOverlayPos::TopCenter:
@@ -164,7 +174,7 @@ ImVec2 CalculatePerformanceOverlayTextPosition(OsdOverlayPos position, float mar
 		case OsdOverlayPos::CenterRight:
 		case OsdOverlayPos::BottomRight:
 		default:
-			x_pos = window_width - text_size.x - abs_margin; // Right alignment
+			x_pos = window_width - text_size.x - eff_right; // Right alignment
 			break;
 	}
 
@@ -251,7 +261,7 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 		case OsdOverlayPos::BottomCenter:
 		case OsdOverlayPos::BottomRight:
 
-			position_y = GetWindowHeight() - margin - (line_height * 15.0f + spacing * 14.0f);
+			position_y = GetWindowHeight() - std::max(margin, ImGuiManager::GetOSDSafeAreaBottom()) - (line_height * 15.0f + spacing * 14.0f);
 			break;
 
 		case OsdOverlayPos::TopLeft:
@@ -915,9 +925,9 @@ __ri void ImGuiManager::DrawShaderCompileIndicator(float scale, float margin, fl
 	ImFont* const font = ImGuiManager::GetOSDFont();
 	const float font_size = ImGuiManager::GetFontSizeStandard();
 	const float baseline_y =
-		GetWindowHeight() - margin - (GSConfig.OsdShowSettings ? font_size : 0.0f);
+		GetWindowHeight() - std::max(margin, ImGuiManager::GetOSDSafeAreaBottom()) - (GSConfig.OsdShowSettings ? font_size : 0.0f);
 	const float radius = std::ceil(10.0f * scale);
-	const float cx = GetWindowWidth() - margin - radius;
+	const float cx = GetWindowWidth() - std::max(margin, ImGuiManager::GetOSDSafeAreaRight()) - radius;
 	const float cy = baseline_y - spacing - radius;
 	const ImVec2 center(cx, cy);
 
@@ -1093,12 +1103,12 @@ __ri void ImGuiManager::DrawSettingsOverlay(float scale, float margin, float spa
 	const float shadow_offset = std::ceil(scale);
 	ImFont* const font = ImGuiManager::GetOSDFont();
 	const float font_size = ImGuiManager::GetFontSizeStandard();
-	const float position_y = GetWindowHeight() - margin - font_size;
+	const float position_y = GetWindowHeight() - std::max(margin, ImGuiManager::GetOSDSafeAreaBottom()) - font_size;
 
 	ImDrawList* dl = ImGui::GetBackgroundDrawList();
 	ImVec2 text_size =
 		font->CalcTextSizeA(font_size, std::numeric_limits<float>::max(), -1.0f, text.c_str(), text.c_str() + text.length(), nullptr);
-	const ImVec2 text_pos(GetWindowWidth() - margin - text_size.x, position_y);
+	const ImVec2 text_pos(GetWindowWidth() - std::max(margin, ImGuiManager::GetOSDSafeAreaRight()) - text_size.x, position_y);
 	const bool bold_osd = GSConfig.OsdBoldText;
 	dl->AddText(font, font_size,
 		ImVec2(text_pos.x + shadow_offset, text_pos.y + shadow_offset), IM_COL32(0, 0, 0, 100),
@@ -1144,9 +1154,12 @@ __ri void ImGuiManager::DrawInputsOverlay(float scale, float margin, float spaci
 			num_ports++;
 	}
 
-	float current_x = ImFloor(margin);
-	float current_y = ImFloor(display_size.y - margin - ((static_cast<float>(num_ports) * (line_height + spacing)) - spacing));
-	const ImVec4 clip_rect(current_x, current_y, display_size.x - margin, display_size.y);
+	const float eff_left = std::max(margin, ImGuiManager::GetOSDSafeAreaLeft());
+	const float eff_right = std::max(margin, ImGuiManager::GetOSDSafeAreaRight());
+	const float eff_bottom = std::max(margin, ImGuiManager::GetOSDSafeAreaBottom());
+	float current_x = ImFloor(eff_left);
+	float current_y = ImFloor(display_size.y - eff_bottom - ((static_cast<float>(num_ports) * (line_height + spacing)) - spacing));
+	const ImVec4 clip_rect(current_x, current_y, display_size.x - eff_right, display_size.y);
 
 	SmallString text;
 
@@ -1281,9 +1294,9 @@ __ri void ImGuiManager::DrawInputRecordingOverlay(float& position_y, float scale
 	{ \
 		text_size = font->CalcTextSizeA(size, std::numeric_limits<float>::max(), -1.0f, (text), nullptr, nullptr); \
 		dl->AddText(font, size, \
-			ImVec2(GetWindowWidth() - margin - text_size.x + shadow_offset, position_y + shadow_offset), \
+			ImVec2(GetWindowWidth() - std::max(margin, ImGuiManager::GetOSDSafeAreaRight()) - text_size.x + shadow_offset, position_y + shadow_offset), \
 			IM_COL32(0, 0, 0, 100), (text)); \
-		dl->AddText(font, size, ImVec2(GetWindowWidth() - margin - text_size.x, position_y), color, (text)); \
+		dl->AddText(font, size, ImVec2(GetWindowWidth() - std::max(margin, ImGuiManager::GetOSDSafeAreaRight()) - text_size.x, position_y), color, (text)); \
 		position_y += text_size.y + spacing; \
 	} while (0)
 
@@ -1326,17 +1339,17 @@ __ri void ImGuiManager::DrawVideoCaptureOverlay(float& position_y, float scale, 
 
 	// Shadow
 	dl->AddText(osd_font, font_size,
-		ImVec2(GetWindowWidth() - margin - text_size.x - icon_size.x + shadow_offset, position_y + shadow_offset),
+		ImVec2(GetWindowWidth() - std::max(margin, ImGuiManager::GetOSDSafeAreaRight()) - text_size.x - icon_size.x + shadow_offset, position_y + shadow_offset),
 		IM_COL32(0, 0, 0, 100), ICON);
 	dl->AddText(osd_font, font_size,
-		ImVec2(GetWindowWidth() - margin - text_size.x + shadow_offset, position_y + shadow_offset),
+		ImVec2(GetWindowWidth() - std::max(margin, ImGuiManager::GetOSDSafeAreaRight()) - text_size.x + shadow_offset, position_y + shadow_offset),
 		IM_COL32(0, 0, 0, 100), text_msg.c_str(), text_msg.end_ptr());
 
 	// Text
 	dl->AddText(osd_font, font_size,
-		ImVec2(GetWindowWidth() - margin - text_size.x - icon_size.x, position_y), IM_COL32(255, 0, 0, 255), ICON);
+		ImVec2(GetWindowWidth() - std::max(margin, ImGuiManager::GetOSDSafeAreaRight()) - text_size.x - icon_size.x, position_y), IM_COL32(255, 0, 0, 255), ICON);
 	dl->AddText(osd_font, font_size,
-		ImVec2(GetWindowWidth() - margin - text_size.x, position_y), white_color, text_msg.c_str(),
+		ImVec2(GetWindowWidth() - std::max(margin, ImGuiManager::GetOSDSafeAreaRight()) - text_size.x, position_y), white_color, text_msg.c_str(),
 		text_msg.end_ptr());
 
 	position_y += std::max(icon_size.y, text_size.y) + spacing;
@@ -1374,7 +1387,7 @@ __ri void ImGuiManager::DrawTextureReplacementsOverlay(float& position_y, float 
 	}
 
 	ImVec2 text_size = osd_font->CalcTextSizeA(font_size, std::numeric_limits<float>::max(), -1.0f, texture_line.c_str(), nullptr, nullptr);
-	const ImVec2 text_pos(GetWindowWidth() - margin - text_size.x, position_y);
+	const ImVec2 text_pos(GetWindowWidth() - std::max(margin, ImGuiManager::GetOSDSafeAreaRight()) - text_size.x, position_y);
 
 	dl->AddText(osd_font, font_size, ImVec2(text_pos.x + shadow_offset, text_pos.y + shadow_offset), IM_COL32(0, 0, 0, 100), texture_line.c_str());
 	dl->AddText(osd_font, font_size, text_pos, white_color, texture_line.c_str());
@@ -1403,9 +1416,9 @@ __ri void ImGuiManager::DrawIndicatorsOverlay(float& position_y, float scale, fl
 		{ \
 			text_size = font->CalcTextSizeA(size, std::numeric_limits<float>::max(), -1.0f, (text), nullptr, nullptr); \
 			dl->AddText(font, size, \
-				ImVec2(GetWindowWidth() - margin - text_size.x + shadow_offset, position_y + shadow_offset), \
+				ImVec2(GetWindowWidth() - std::max(margin, ImGuiManager::GetOSDSafeAreaRight()) - text_size.x + shadow_offset, position_y + shadow_offset), \
 				IM_COL32(0, 0, 0, 100), (text)); \
-			dl->AddText(font, size, ImVec2(GetWindowWidth() - margin - text_size.x, position_y), color, (text)); \
+			dl->AddText(font, size, ImVec2(GetWindowWidth() - std::max(margin, ImGuiManager::GetOSDSafeAreaRight()) - text_size.x, position_y), color, (text)); \
 			position_y += text_size.y + spacing; \
 		} while (0)
 
@@ -1868,7 +1881,8 @@ void ImGuiManager::RenderOverlays()
 	const float scale = ImGuiManager::GetGlobalScale();
 	const float margin = std::ceil(GSConfig.OsdMargin * scale);
 	const float spacing = std::ceil(5.0f * scale);
-	float position_y = margin;
+	// Start the top-anchored overlay stack below the top safe-area inset (0 off-iOS).
+	float position_y = std::max(margin, ImGuiManager::GetOSDSafeAreaTop());
 
 	DrawIndicatorsOverlay(position_y, scale, margin, spacing);
 	DrawVideoCaptureOverlay(position_y, scale, margin, spacing);

--- a/app/src/main/swift/Models/SettingsStore.swift
+++ b/app/src/main/swift/Models/SettingsStore.swift
@@ -10,6 +10,7 @@ enum OsdPreset: Int, CaseIterable {
     case simple = 1    // FPS + speed + CPU usage + device stats
     case detail = 2    // All except frame times graph
     case full = 3      // Everything
+    case custom = 4    // User-defined toggle set (not derived from a preset table)
 
     var label: String {
         switch self {
@@ -17,6 +18,7 @@ enum OsdPreset: Int, CaseIterable {
         case .simple: return "Simple"
         case .detail: return "Detail"
         case .full: return "Full"
+        case .custom: return "Custom"
         }
     }
 }
@@ -85,6 +87,8 @@ final class SettingsStore {
     /// Manual EmuCore/Gamefixes toggles — see SettingsStore+GameFixes.swift.
 
     @ObservationIgnored private var suppressINIWrites = false
+    @ObservationIgnored private var isProgrammaticOsdFlagChange = false
+    @ObservationIgnored private var isAutoMarkingCustom = false
     @ObservationIgnored private var frameLimiterDisabledForFastForward = false
     @ObservationIgnored private var graphicsApplyWorkItem: DispatchWorkItem?
     @ObservationIgnored private var visualSliderDragCount = 0
@@ -1016,6 +1020,10 @@ final class SettingsStore {
     // ── OSD Overlay ──
     var osdPreset: OsdPreset {
         didSet {
+            // Only an explicit user change should cascade the preset into the
+            // individual OSD flags. During a bulk reload (suppressINIWrites), skip
+            // so applyOsdPreset() can't overwrite the user OSD settings.
+            guard !suppressINIWrites else { return }
             ARMSX2Bridge.setINIInt("ARMSX2iOS/UI", key: "OsdPreset", value: Int32(osdPreset.rawValue))
             if osdPreset == .off {
                 if oldValue != .off {
@@ -1024,7 +1032,13 @@ final class SettingsStore {
             } else {
                 lastActiveOsdPreset = osdPreset
             }
-            applyOsdPreset(osdPreset)
+            if osdPreset == .custom {
+                if !isAutoMarkingCustom {
+                    restoreCustomOsd()
+                }
+            } else {
+                applyOsdPreset(osdPreset)
+            }
         }
     }
     let _lastActiveOsdPresetConfig = Setting<OsdPreset>(
@@ -1065,6 +1079,7 @@ final class SettingsStore {
         guard !(_osdShowFPSConfig.suppressible && suppressINIWrites) else { return }
         _osdShowFPSConfig.writer(_osdShowFPSConfig.section, _osdShowFPSConfig.key, osdShowFPS)
         _osdShowFPSConfig.onSet?(osdShowFPS)
+        markOsdCustom()
     }}
     let _osdShowVPSConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "OsdShowVPS", default: false,
@@ -1074,6 +1089,7 @@ final class SettingsStore {
         guard !(_osdShowVPSConfig.suppressible && suppressINIWrites) else { return }
         _osdShowVPSConfig.writer(_osdShowVPSConfig.section, _osdShowVPSConfig.key, osdShowVPS)
         _osdShowVPSConfig.onSet?(osdShowVPS)
+        markOsdCustom()
     }}
     let _osdShowSpeedConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "OsdShowSpeed", default: false,
@@ -1083,6 +1099,7 @@ final class SettingsStore {
         guard !(_osdShowSpeedConfig.suppressible && suppressINIWrites) else { return }
         _osdShowSpeedConfig.writer(_osdShowSpeedConfig.section, _osdShowSpeedConfig.key, osdShowSpeed)
         _osdShowSpeedConfig.onSet?(osdShowSpeed)
+        markOsdCustom()
     }}
     let _osdShowCPUConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "OsdShowCPU", default: false,
@@ -1092,6 +1109,7 @@ final class SettingsStore {
         guard !(_osdShowCPUConfig.suppressible && suppressINIWrites) else { return }
         _osdShowCPUConfig.writer(_osdShowCPUConfig.section, _osdShowCPUConfig.key, osdShowCPU)
         _osdShowCPUConfig.onSet?(osdShowCPU)
+        markOsdCustom()
     }}
     let _osdShowGPUConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "OsdShowGPU", default: false,
@@ -1101,6 +1119,7 @@ final class SettingsStore {
         guard !(_osdShowGPUConfig.suppressible && suppressINIWrites) else { return }
         _osdShowGPUConfig.writer(_osdShowGPUConfig.section, _osdShowGPUConfig.key, osdShowGPU)
         _osdShowGPUConfig.onSet?(osdShowGPU)
+        markOsdCustom()
     }}
     let _osdShowResolutionConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "OsdShowResolution", default: false,
@@ -1110,6 +1129,7 @@ final class SettingsStore {
         guard !(_osdShowResolutionConfig.suppressible && suppressINIWrites) else { return }
         _osdShowResolutionConfig.writer(_osdShowResolutionConfig.section, _osdShowResolutionConfig.key, osdShowResolution)
         _osdShowResolutionConfig.onSet?(osdShowResolution)
+        markOsdCustom()
     }}
     let _osdShowGSStatsConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "OsdShowGSStats", default: false,
@@ -1119,6 +1139,7 @@ final class SettingsStore {
         guard !(_osdShowGSStatsConfig.suppressible && suppressINIWrites) else { return }
         _osdShowGSStatsConfig.writer(_osdShowGSStatsConfig.section, _osdShowGSStatsConfig.key, osdShowGSStats)
         _osdShowGSStatsConfig.onSet?(osdShowGSStats)
+        markOsdCustom()
     }}
     let _osdShowIndicatorsConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "OsdShowIndicators", default: false,
@@ -1128,6 +1149,7 @@ final class SettingsStore {
         guard !(_osdShowIndicatorsConfig.suppressible && suppressINIWrites) else { return }
         _osdShowIndicatorsConfig.writer(_osdShowIndicatorsConfig.section, _osdShowIndicatorsConfig.key, osdShowIndicators)
         _osdShowIndicatorsConfig.onSet?(osdShowIndicators)
+        markOsdCustom()
     }}
     let _osdShowSettingsConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "OsdShowSettings", default: false,
@@ -1137,6 +1159,7 @@ final class SettingsStore {
         guard !(_osdShowSettingsConfig.suppressible && suppressINIWrites) else { return }
         _osdShowSettingsConfig.writer(_osdShowSettingsConfig.section, _osdShowSettingsConfig.key, osdShowSettings)
         _osdShowSettingsConfig.onSet?(osdShowSettings)
+        markOsdCustom()
     }}
     let _osdShowInputsConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "OsdShowInputs", default: false,
@@ -1146,6 +1169,7 @@ final class SettingsStore {
         guard !(_osdShowInputsConfig.suppressible && suppressINIWrites) else { return }
         _osdShowInputsConfig.writer(_osdShowInputsConfig.section, _osdShowInputsConfig.key, osdShowInputs)
         _osdShowInputsConfig.onSet?(osdShowInputs)
+        markOsdCustom()
     }}
     let _osdShowFrameTimesConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "OsdShowFrameTimes", default: false,
@@ -1155,6 +1179,7 @@ final class SettingsStore {
         guard !(_osdShowFrameTimesConfig.suppressible && suppressINIWrites) else { return }
         _osdShowFrameTimesConfig.writer(_osdShowFrameTimesConfig.section, _osdShowFrameTimesConfig.key, osdShowFrameTimes)
         _osdShowFrameTimesConfig.onSet?(osdShowFrameTimes)
+        markOsdCustom()
     }}
     let _osdShowVersionConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "OsdShowVersion", default: false,
@@ -1164,6 +1189,7 @@ final class SettingsStore {
         guard !(_osdShowVersionConfig.suppressible && suppressINIWrites) else { return }
         _osdShowVersionConfig.writer(_osdShowVersionConfig.section, _osdShowVersionConfig.key, osdShowVersion)
         _osdShowVersionConfig.onSet?(osdShowVersion)
+        markOsdCustom()
     }}
     let _osdShowHardwareInfoConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "OsdShowHardwareInfo", default: false,
@@ -1173,6 +1199,7 @@ final class SettingsStore {
         guard !(_osdShowHardwareInfoConfig.suppressible && suppressINIWrites) else { return }
         _osdShowHardwareInfoConfig.writer(_osdShowHardwareInfoConfig.section, _osdShowHardwareInfoConfig.key, osdShowHardwareInfo)
         _osdShowHardwareInfoConfig.onSet?(osdShowHardwareInfo)
+        markOsdCustom()
     }}
     let _osdShowTextureReplacementsConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "OsdShowTextureReplacements", default: false,
@@ -1191,6 +1218,7 @@ final class SettingsStore {
         guard !(_osdShowDeviceStatsConfig.suppressible && suppressINIWrites) else { return }
         _osdShowDeviceStatsConfig.writer(_osdShowDeviceStatsConfig.section, _osdShowDeviceStatsConfig.key, osdShowDeviceStats)
         _osdShowDeviceStatsConfig.onSet?(osdShowDeviceStats)
+        markOsdCustom()
     }}
 
     // ── Gamepad / UI ──
@@ -1624,8 +1652,17 @@ final class SettingsStore {
         normalizeDEV9Settings()
         VPadSkinLibraryStore.shared.adoptLegacySelection(virtualPadSkin)
         ARMSX2Bridge.setINIString("EmuCore/GS", key: "AspectRatio", value: Self.aspectRatioName(for: aspectRatio))
-        // Apply OSD preset
-        ARMSX2Bridge.applyOsdPreset(Int32(osdPreset.rawValue))
+        // Do NOT re-apply the OSD preset here. The saved per-item OSD flags are the
+        // source of truth and are pushed into the live GSConfig natively by
+        // ARMSX2ApplyIOSOsdPresetFromConfig() at scene startup. Calling
+        // applyOsdPreset(preset) at load rewrote every flag from the preset and
+        // discarded the user settings.
+        // Seed the Custom OSD snapshot once from the loaded flags so cycling to Custom
+        // before any manual edit shows the current set rather than an empty overlay.
+        if !ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "OsdCustomSeeded", defaultValue: false) {
+            snapshotCustomOsd()
+            ARMSX2Bridge.setINIBool("ARMSX2iOS/UI", key: "OsdCustomSeeded", value: true)
+        }
     }
 
     /// Reload ALL settings from INI (call on VM start/stop)
@@ -1932,15 +1969,18 @@ final class SettingsStore {
 
     /// Apply OSD preset — writes ALL OSD flags to INI + GSConfig
     private func applyOsdPreset(_ preset: OsdPreset) {
+        guard preset != .custom else { return }
         ARMSX2Bridge.applyOsdPreset(Int32(preset.rawValue))
         if preset == .off {
             osdPerformancePosition = 0
-        } else if osdPerformancePosition == 0 {
-            osdPerformancePosition = Self.defaultOsdPerformancePosition
+        } else {
+            revealOsdPerformancePositionIfHidden()
         }
         let isSimple = preset == .simple
         let isDetail = preset == .detail
         let isFull = preset == .full
+        isProgrammaticOsdFlagChange = true
+        defer { isProgrammaticOsdFlagChange = false }
         osdShowFPS = isSimple || isDetail || isFull
         osdShowVPS = isDetail || isFull
         osdShowSpeed = isSimple || isDetail || isFull
@@ -1955,6 +1995,56 @@ final class SettingsStore {
         osdShowVersion = isSimple || isDetail || isFull
         osdShowHardwareInfo = isFull
         osdShowDeviceStats = isSimple || isDetail || isFull
+    }
+
+    /// If the perf overlay is at the hidden position (None/0), restore it to the default
+    /// so newly-enabled perf stats become visible. Shared by applyOsdPreset + restoreCustomOsd.
+    private func revealOsdPerformancePositionIfHidden() {
+        if osdPerformancePosition == 0 {
+            osdPerformancePosition = Self.defaultOsdPerformancePosition
+        }
+    }
+
+    private static let osdCustomFlagKeyPaths: [(ReferenceWritableKeyPath<SettingsStore, Bool>, String)] = [
+        (\.osdShowFPS, "OsdCustomShowFPS"),
+        (\.osdShowVPS, "OsdCustomShowVPS"),
+        (\.osdShowSpeed, "OsdCustomShowSpeed"),
+        (\.osdShowCPU, "OsdCustomShowCPU"),
+        (\.osdShowGPU, "OsdCustomShowGPU"),
+        (\.osdShowResolution, "OsdCustomShowResolution"),
+        (\.osdShowGSStats, "OsdCustomShowGSStats"),
+        (\.osdShowIndicators, "OsdCustomShowIndicators"),
+        (\.osdShowSettings, "OsdCustomShowSettings"),
+        (\.osdShowInputs, "OsdCustomShowInputs"),
+        (\.osdShowFrameTimes, "OsdCustomShowFrameTimes"),
+        (\.osdShowVersion, "OsdCustomShowVersion"),
+        (\.osdShowHardwareInfo, "OsdCustomShowHardwareInfo"),
+        (\.osdShowDeviceStats, "OsdCustomShowDeviceStats"),
+    ]
+
+    private func snapshotCustomOsd() {
+        for (keyPath, key) in Self.osdCustomFlagKeyPaths {
+            ARMSX2Bridge.setINIBool("ARMSX2iOS/UI", key: key, value: self[keyPath: keyPath])
+        }
+    }
+
+    private func restoreCustomOsd() {
+        revealOsdPerformancePositionIfHidden()
+        isProgrammaticOsdFlagChange = true
+        for (keyPath, key) in Self.osdCustomFlagKeyPaths {
+            self[keyPath: keyPath] = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: key, defaultValue: self[keyPath: keyPath])
+        }
+        isProgrammaticOsdFlagChange = false
+    }
+
+    private func markOsdCustom() {
+        guard !suppressINIWrites, !isProgrammaticOsdFlagChange else { return }
+        isAutoMarkingCustom = true
+        if osdPreset != .custom {
+            osdPreset = .custom
+        }
+        isAutoMarkingCustom = false
+        snapshotCustomOsd()
     }
 
     /// Reset emulator settings to ARMSX2 iOS defaults

--- a/app/src/main/swift/Views/GameScreenView.swift
+++ b/app/src/main/swift/Views/GameScreenView.swift
@@ -987,7 +987,7 @@ struct GameScreenView: View {
     }
 
     private func cycleOsdPreset() {
-        let allPresets: [OsdPreset] = [.off, .simple, .detail, .full]
+        let allPresets: [OsdPreset] = OsdPreset.allCases
         guard let currentIndex = allPresets.firstIndex(of: settings.osdPreset) else {
             return
         }


### PR DESCRIPTION
This fixes Overlay(OSD) Settings toggles resetting whenever you reboot app or start a game. 

It also adds 'Custom' preset, so whenever you change any toggle in Settings, it will automatically switch you to 'Custom' preset. So basically, you can still use other OSD presets and freely switch between them in-game, but you can now also have your own OSD preset.

This also fixes OSD data and information pop-ups being cut off by rounded corners.

Tested on iPhone 17 Pro