### PR TITLE
GS/Vulkan: retain V3D feedback passes across compatible draws

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -6601,10 +6601,20 @@ void GSDeviceVK::RenderHW(GSHWDrawConfig& config)
 			m_pipeline_selector.ds = true;
 		}
 
-		// Keep feedback-loop state draw-local. Carrying it over can leave later draws
-		// in the previous feedback render pass/layout and cause Vulkan-only flicker.
-		// Matches sashkinbro/EmuCoreX exactly (the carry is removed globally there — no
-		// vendor-scoping, unlike my earlier reverted attempt).
+		// V3D pays heavily for closing and reopening a tile render pass. When the
+		// attachments are unchanged, retain the feedback layout until either target
+		// changes. This is the legacy tuned behaviour, scoped to Broadcom because
+		// other drivers have shown flicker when feedback state is carried across draws.
+		if (IsDeviceBroadcom())
+		{
+			if (draw_rt)
+				pipe.feedback_loop_flags |= m_current_framebuffer_feedback_loop & FeedbackLoopFlag_ReadAndWriteRT;
+			if (draw_ds)
+			{
+				pipe.feedback_loop_flags |= (m_current_framebuffer_feedback_loop &
+					(FeedbackLoopFlag_ReadAndWriteDepth | FeedbackLoopFlag_ReadDepth));
+			}
+		}
 	}
 
 	if (draw_rt && ((config.require_one_barrier && (config.IsFeedbackLoopRT(config.ps) || config.IsFeedbackLoopRT(config.alpha_second_pass.ps)))) && !m_features.texture_barrier)

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h
@@ -83,6 +83,9 @@ public:
 	/// Returns true if running on an AMD GPU.
 	__fi bool IsDeviceAMD() const { return (m_device_properties.vendorID == 0x1002); }
 
+	/// Returns true if running on a Broadcom V3D GPU (vendorID 0x14E4).
+	__fi bool IsDeviceBroadcom() const { return (m_device_properties.vendorID == 0x14E4u); }
+
 	/// Returns true if running on an ARM Mali GPU (vendorID 0x13B5).
 	__fi bool IsDeviceMali() const { return (m_device_properties.vendorID == 0x13B5u); }
 


### PR DESCRIPTION
### Description of Changes

- Detect Broadcom Vulkan devices through vendor ID 0x14E4.
- On Broadcom only, retain the active framebuffer feedback-loop flags across compatible hardware draws while the render targets remain unchanged.
- Keep the existing draw-local behavior on every other vendor.

### Rationale behind Changes

V3D is a tile-based renderer and pays a large cost when a compatible feedback render pass is closed and reopened between draws. The globally draw-local behavior avoids flicker observed on other Vulkan drivers, but on Raspberry Pi 5 it caused the same Shadow of the Colossus frame to use 157 render passes instead of 61 in the tuned build.

The vendor-scoped carry reduces that frame to 62 render passes without changing behavior on non-Broadcom GPUs. In the same frame-locked Raspberry Pi 5 Vulkan benchmark, median frame time improved from roughly 67-69 ms before the change to 42.7 ms after it.

Post-change A/B checks against the previous tuned PGO build:

| Game | Throughput change | Modern p50 |
| --- | ---: | ---: |
| Shadow of the Colossus | -0.66% | 41.02 ms |
| GTA Vice City | +2.87% | 21.01 ms |
| God of War II | +1.11% | 30.64 ms |
| Beyond Good & Evil | -0.21% | 15.68 ms |

The two small negative results are effectively parity; Shadow of the Colossus also had better p95 and p99 latency than the comparison build.

### Suggested Testing Steps

1. Run a framebuffer-feedback-heavy game on Raspberry Pi 5 with the V3DV Vulkan driver.
2. Compare render-pass counts and frame times before and after this change using the same savestate or GS dump.
3. Verify feedback-loop effects in Shadow of the Colossus, GTA Vice City, God of War II, and Beyond Good & Evil.
4. Confirm that other Vulkan vendors retain the existing draw-local feedback state behavior.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. An AI coding agent helped compare benchmark logs, add temporary opt-in render-pass diagnostics, isolate the Broadcom-specific state transition, and prepare the patch. The diagnostics were removed from the submitted branch; the author reviewed the code and benchmark results.
