### PR TITLE
iOS: Ignore unrelated UIKit text fields in SDL text input

### DIFF
--- a/platforms/android/app/src/main/cpp/3rdparty/sdl3/src/video/uikit/SDL_uikitviewcontroller.m
+++ b/platforms/android/app/src/main/cpp/3rdparty/sdl3/src/video/uikit/SDL_uikitviewcontroller.m
@@ -578,6 +578,15 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 
 - (void)textFieldTextDidChange:(NSNotification *)notification
 {
+    // The observer above is registered with object:nil, so this fires for every
+    // UITextField in the app. Ignore notifications not from this controller's
+    // own field; otherwise app-level text fields (e.g. SwiftUI-hosted forms)
+    // would trigger SDL_StartTextInput/SDL_StopTextInput and steal first
+    // responder on every keystroke.
+    if (notification.object != textField) {
+        return;
+    }
+
     // When opening a password manager overlay to select a password and have it auto-filled,
     // text input becomes stopped as a result of the keyboard being hidden or the text field losing focus.
     // As a workaround, ensure text input is activated on any changes to the text field.


### PR DESCRIPTION
SDL_uikitviewcontroller registers its UITextFieldTextDidChangeNotification observer with object:nil, so textFieldTextDidChange: fires for every UITextField in the app, not just SDL's own hidden field. The handler unconditionally calls SDL_StartTextInput(window) (and the marked-text path later calls SDL_StopTextInput), so any app-level text input notably SwiftUI-hosted login forms, was stealing first responder on every keystroke: the user typed one character, the keyboard was dismissed and re-presented, and they had to tap the field again before the next character. 

Filter the notification at the top of the handler: if notification.object is not this controller's textField, return early. SDL's own field still goes through the existing password-manager workaround unchanged. 

The SDL3 sources in this repo are vendored, not a submodule, so this patch lives in tree until the next SDL sync. 

Verified by typing into the RetroAchievements login sheet: each keystroke now keeps first responder and the keyboard stays up for the whole credential entry.