### PR TITLE
iOS: Restore fullscreen SDL window frame at landscape launch

### DIFF
--- a/platforms/android/app/src/main/cpp/3rdparty/sdl3/src/video/uikit/SDL_uikitwindow.m
+++ b/platforms/android/app/src/main/cpp/3rdparty/sdl3/src/video/uikit/SDL_uikitwindow.m
@@ -202,6 +202,13 @@ bool UIKit_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Properti
                                 "Initial geometry request failed: %s",
                                 [[error localizedDescription] UTF8String]);
                 }];
+#else
+                // initWithWindowScene: inherits the scene's frame, which iOS
+                // launches in the first plist orientation (portrait). Match
+                // SDL 3.3.0's initWithFrame:screen.bounds behaviour so the
+                // window fills the screen at creation regardless of the
+                // scene's initial orientation.
+                uiwindow.frame = data.uiscreen.bounds;
 #endif
             }
         }

--- a/platforms/ios/app/src/main/cpp/IOS/SceneDelegate.mm
+++ b/platforms/ios/app/src/main/cpp/IOS/SceneDelegate.mm
@@ -1134,6 +1134,26 @@ static void ARMSX2StartJITKeepalive()
 }
 
 - (void)sceneDidBecomeActive:(UIScene *)scene {
+    // Under host containers that resolve the scene's orientation after
+    // scene:willConnectTo: created the SDL window and its rootViewController,
+    // rootVC.view keeps its portrait bounds and nothing re-evaluates it, so
+    // the SwiftUI menu (pinned to rootVC.view via Auto Layout) renders in a
+    // portrait square inside a landscape window. When rootVC.view and the
+    // window disagree on orientation, snap the view to the window bounds and
+    // let Auto Layout propagate to the menu. No-op on the normal launch path.
+    UIViewController *rootVC = s_rootVC ?: self.window.rootViewController;
+    UIWindow *win = self.window;
+    if (rootVC == nil || win == nil) return;
+
+    const CGSize winSize = win.bounds.size;
+    const CGSize vcSize = rootVC.view.bounds.size;
+    const BOOL winLandscape = (winSize.width >= winSize.height && winSize.height > 0);
+    const BOOL vcLandscape = (vcSize.width >= vcSize.height && vcSize.height > 0);
+    if (winLandscape != vcLandscape) {
+        rootVC.view.frame = win.bounds;
+        [rootVC.view setNeedsLayout];
+        [rootVC.view layoutIfNeeded];
+    }
 }
 
 - (void)sceneWillResignActive:(UIScene *)scene {


### PR DESCRIPTION
At cold launch the app's root surface rendered as a left-aligned square inside a landscape screen. The window was sized for portrait because SDL 3.5.0's UIKit_CreateWindow creates the UIWindow via [[UIWindow alloc] initWithWindowScene:scene], which inherits the scene's bounds at a moment when iOS has not yet autorotated out of the first plist orientation (portrait). SDL 3.3.0 used initWithFrame:screen.bounds, which filled the screen regardless of the scene's initial orientation. SDL_SetWindowSize is a no-op for this path on iOS (only visionOS implements UIKit_SetWindowSize).

The SDL3 sources in this repo are vendored, not a submodule, so patch UIKit_CreateWindow's scene branch with an #else companion to the existing visionOS frame-setting block that assigns uiwindow.frame = data.uiscreen.bounds. This restores the fullscreen condition that UIKit_ComputeViewFrame's orientation-swap gate checks.

Under host containers that resolve orientation after the rootViewController is created in willConnectTo:, rootVC.view can stay pinned to portrait bounds. Add a one-shot re-sync in sceneDidBecomeActive: that snaps rootVC.view to the window's bounds when their orientations disagree, then lets Auto Layout propagate to the SwiftUI child. It is a no-op on the normal launch path where orientations already agree.

Verified by launching in held-landscape orientation on native sideload and host-container hosts: the menu fills the screen instead of rendering in a portrait-width square.