### PR TITLE
ARMSX2 iOS Dynamic Backgrounds

### DIFF
--- a/platforms/ios/app/src/main/swift/Models/AppState.swift
+++ b/platforms/ios/app/src/main/swift/Models/AppState.swift
@@ -7,6 +7,7 @@ import SwiftUI
 final class AppState: @unchecked Sendable {
     static let shared = AppState()
     static let systemChromeNeedsUpdateNotification = Notification.Name("ARMSX2iOSSystemChromeNeedsUpdate")
+    static let releaseMenuBackgroundResourcesNotification = Notification.Name("ARMSX2iOSReleaseMenuBackgroundResources")
 
     enum Screen {
         case menu
@@ -56,12 +57,14 @@ final class AppState: @unchecked Sendable {
             forName: NSNotification.Name("ARMSX2iOSAutoBootDidStart"),
             object: nil, queue: .main
         ) { [weak self] _ in
+            self?.releaseMenuBackgroundResourcesForGameplay()
             self?.runningGameName = "AutoBoot"
             self?.currentScreen = .playing
         }
     }
 
     func bootGame(isoName: String) {
+        releaseMenuBackgroundResourcesForGameplay()
         Task { @MainActor in
             StikDebugLauncher.autoOpenIfNeeded(reason: "game boot")
         }
@@ -75,6 +78,7 @@ final class AppState: @unchecked Sendable {
     }
 
     func bootBIOSOnly() {
+        releaseMenuBackgroundResourcesForGameplay()
         Task { @MainActor in
             StikDebugLauncher.autoOpenIfNeeded(reason: "BIOS boot")
         }
@@ -98,6 +102,7 @@ final class AppState: @unchecked Sendable {
 
     func returnToGame() {
         if runningGameName != nil {
+            releaseMenuBackgroundResourcesForGameplay()
             // [P44-2] Clear background so Metal surface shows through
             NotificationCenter.default.post(name: NSNotification.Name("ARMSX2iOSEnterGameScreen"), object: nil)
             currentScreen = .playing
@@ -127,5 +132,12 @@ final class AppState: @unchecked Sendable {
         } else {
             shutdownAndBoot(isoName: runningGameName)
         }
+    }
+
+    private func releaseMenuBackgroundResourcesForGameplay() {
+        NotificationCenter.default.post(
+            name: Self.releaseMenuBackgroundResourcesNotification,
+            object: nil
+        )
     }
 }

--- a/platforms/ios/app/src/main/swift/Models/BackgroundStorage.swift
+++ b/platforms/ios/app/src/main/swift/Models/BackgroundStorage.swift
@@ -112,7 +112,7 @@ enum BackgroundStorage {
 
         let primaryPath = defaults.string(forKey: "ARMSX2iOSLibraryBackgroundPath") ?? ""
         let landscapePath = defaults.string(forKey: "ARMSX2iOSLibraryLandscapeBackgroundPath") ?? ""
-        let dim = defaults.object(forKey: "ARMSX2iOSLibraryBackgroundDim") as? Double ?? 0.35
+        let dim = defaults.object(forKey: "ARMSX2iOSLibraryBackgroundDim") as? Double ?? 0.0
 
         var primaryAsset: BackgroundAsset?
         var landscapeAsset: BackgroundAsset?

--- a/platforms/ios/app/src/main/swift/Models/BackgroundValidation.swift
+++ b/platforms/ios/app/src/main/swift/Models/BackgroundValidation.swift
@@ -9,6 +9,7 @@ enum BackgroundValidation {
         testKindInference()
         testAssetCoding()
         testFitModeRoundTrip()
+        testDynamicAppearanceCoding()
     }
 
     private static func testKindInference() {
@@ -27,6 +28,20 @@ enum BackgroundValidation {
     private static func testFitModeRoundTrip() {
         for mode in BackgroundFitMode.allCases {
             assert(BackgroundFitMode(rawValue: mode.rawValue) == mode)
+        }
+    }
+
+    private static func testDynamicAppearanceCoding() {
+        for style in DynamicBackgroundStyle.allCases {
+            var preferences = DynamicAppearancePreferences.standard
+            preferences.dynamicBackground = style
+
+            let data = DynamicBackgroundCoding.encode(preferences)
+            let decoded = data.flatMap {
+                DynamicBackgroundCoding.decode(DynamicAppearancePreferences.self, from: $0)
+            }
+
+            assert(decoded == preferences)
         }
     }
 }

--- a/platforms/ios/app/src/main/swift/Models/CoverStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/CoverStore.swift
@@ -112,6 +112,7 @@ final class CoverStore: @unchecked Sendable {
         var attempted = Set<String>()
 
         for game in games {
+			guard !Task.isCancelled else { break }
             if game.hasCover || coverURL(forGameName: game.name, gamePath: game.fileURL, metadata: game.metadata) != nil {
                 skipped += 1
                 continue
@@ -125,6 +126,7 @@ final class CoverStore: @unchecked Sendable {
 
             var didDownload = false
             for url in candidates where attempted.insert(url.absoluteString).inserted {
+				guard !Task.isCancelled else { break }
                 if await downloadCover(from: url, forGameName: game.name, metadata: game.metadata) {
                     downloaded += 1
                     didDownload = true

--- a/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
@@ -1506,6 +1506,17 @@ final class SettingsStore {
     }}
 
     // ── Library Background ──
+    var dynamicBackgroundsEnabled: Bool = true {
+        didSet {
+            UserDefaults.standard.set(
+                dynamicBackgroundsEnabled,
+                forKey: "ARMSX2iOSDynamicBackgroundsEnabled"
+            )
+        }
+    }
+    var dynamicAppearancePreferences: DynamicAppearancePreferences = .standard {
+        didSet { dynamicAppearancePreferences.save() }
+    }
     var backgroundPrimaryAsset: BackgroundAsset? {
         didSet {
             if let asset = backgroundPrimaryAsset {
@@ -1733,12 +1744,16 @@ final class SettingsStore {
         dev9DNS2Mode = ARMSX2Bridge.getINIString("DEV9/Eth", key: "ModeDNS2", defaultValue: "Auto")
         dev9DNS2 = ARMSX2Bridge.getINIString("DEV9/Eth", key: "DNS2", defaultValue: "0.0.0.0")
         BackgroundStorage.migrateLegacyBackgroundsIfNeeded()
+        dynamicBackgroundsEnabled = UserDefaults.standard.object(
+            forKey: "ARMSX2iOSDynamicBackgroundsEnabled"
+        ) as? Bool ?? true
+        dynamicAppearancePreferences = DynamicAppearancePreferences.load() ?? .standard
         backgroundPrimaryAsset = Self.loadBackgroundAsset(forKey: "ARMSX2iOSBackgroundPrimaryAsset")
         backgroundLandscapeAsset = Self.loadBackgroundAsset(forKey: "ARMSX2iOSBackgroundLandscapeAsset")
         backgroundFitMode = BackgroundFitMode(rawValue: UserDefaults.standard.string(forKey: "ARMSX2iOSBackgroundFitMode") ?? "") ?? .fill
         backgroundLandscapeFitMode = BackgroundFitMode(rawValue: UserDefaults.standard.string(forKey: "ARMSX2iOSBackgroundLandscapeFitMode") ?? "") ?? .fill
         backgroundVideoMuted = UserDefaults.standard.object(forKey: "ARMSX2iOSBackgroundVideoMuted") as? Bool ?? true
-        backgroundDim = Self.clampedBackgroundDim(UserDefaults.standard.object(forKey: "ARMSX2iOSBackgroundDim") as? Double ?? 0.35)
+        backgroundDim = Self.clampedBackgroundDim(UserDefaults.standard.object(forKey: "ARMSX2iOSBackgroundDim") as? Double ?? 0.0)
         normalizeDEV9Settings()
         VPadSkinLibraryStore.shared.adoptLegacySelection(virtualPadSkin)
         ARMSX2Bridge.setINIString("EmuCore/GS", key: "AspectRatio", value: Self.aspectRatioName(for: aspectRatio))
@@ -1931,12 +1946,16 @@ final class SettingsStore {
         dev9DNS1 = ARMSX2Bridge.getINIString("DEV9/Eth", key: "DNS1", defaultValue: "0.0.0.0")
         dev9DNS2Mode = ARMSX2Bridge.getINIString("DEV9/Eth", key: "ModeDNS2", defaultValue: "Auto")
         dev9DNS2 = ARMSX2Bridge.getINIString("DEV9/Eth", key: "DNS2", defaultValue: "0.0.0.0")
+        dynamicBackgroundsEnabled = UserDefaults.standard.object(
+            forKey: "ARMSX2iOSDynamicBackgroundsEnabled"
+        ) as? Bool ?? true
+        dynamicAppearancePreferences = DynamicAppearancePreferences.load() ?? .standard
         backgroundPrimaryAsset = Self.loadBackgroundAsset(forKey: "ARMSX2iOSBackgroundPrimaryAsset")
         backgroundLandscapeAsset = Self.loadBackgroundAsset(forKey: "ARMSX2iOSBackgroundLandscapeAsset")
         backgroundFitMode = BackgroundFitMode(rawValue: UserDefaults.standard.string(forKey: "ARMSX2iOSBackgroundFitMode") ?? "") ?? .fill
         backgroundLandscapeFitMode = BackgroundFitMode(rawValue: UserDefaults.standard.string(forKey: "ARMSX2iOSBackgroundLandscapeFitMode") ?? "") ?? .fill
         backgroundVideoMuted = UserDefaults.standard.object(forKey: "ARMSX2iOSBackgroundVideoMuted") as? Bool ?? true
-        backgroundDim = Self.clampedBackgroundDim(UserDefaults.standard.object(forKey: "ARMSX2iOSBackgroundDim") as? Double ?? 0.35)
+        backgroundDim = Self.clampedBackgroundDim(UserDefaults.standard.object(forKey: "ARMSX2iOSBackgroundDim") as? Double ?? 0.0)
         normalizeDEV9Settings()
         VPadSkinLibraryStore.shared.adoptLegacySelection(virtualPadSkin)
     }
@@ -1969,7 +1988,7 @@ final class SettingsStore {
     }
 
     private static func clampedBackgroundDim(_ value: Double) -> Double {
-        guard value.isFinite else { return 0.35 }
+        guard value.isFinite else { return 0.0 }
         return min(max(value, 0.0), 1.0)
     }
 

--- a/platforms/ios/app/src/main/swift/Views/AnimatedLibraryBackgroundView.swift
+++ b/platforms/ios/app/src/main/swift/Views/AnimatedLibraryBackgroundView.swift
@@ -30,9 +30,14 @@ struct AnimatedLibraryBackgroundView: View {
             guard frames.isEmpty, !loadFailed else { return }
             // Decode off the MainActor so a large multi-frame image cannot
             // stall the UI while the library is presented.
-            let loaded = await Task.detached(priority: .utility) {
+			let loader = Task.detached(priority: .utility) {
                 AnimatedBackgroundLoader.loadFrames(from: url)
-            }.value
+			}
+			let loaded = await withTaskCancellationHandler {
+				await loader.value
+			} onCancel: {
+				loader.cancel()
+			}
             // `.task(id:)` cancels this task when url changes; drop the result.
             guard !Task.isCancelled else { return }
             if loaded.isEmpty {
@@ -78,7 +83,7 @@ private struct AnimatedFramePlayer: UIViewRepresentable {
     static func dismantleUIView(_ uiView: AnimatedBackgroundImageView, coordinator: ()) {
         // UIKit calls this on the main thread; assume MainActor to call the
         // UIView's MainActor-isolated cleanup.
-        MainActor.assumeIsolated { uiView.stop() }
+        MainActor.assumeIsolated { uiView.teardown() }
     }
 }
 
@@ -90,6 +95,7 @@ private final class AnimatedBackgroundImageView: UIView {
     private var displayLink: CADisplayLink?
     private var accumulated: CFTimeInterval = 0
     private var lastTimestamp: CFTimeInterval = 0
+    private var releasedForGameplay = false
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -100,8 +106,14 @@ private final class AnimatedBackgroundImageView: UIView {
             self, selector: #selector(pause),
             name: UIApplication.didEnterBackgroundNotification, object: nil)
         NotificationCenter.default.addObserver(
+            self, selector: #selector(pause),
+            name: UIScene.willDeactivateNotification, object: nil)
+        NotificationCenter.default.addObserver(
             self, selector: #selector(resumeIfReady),
-            name: UIApplication.willEnterForegroundNotification, object: nil)
+            name: UIScene.didActivateNotification, object: nil)
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(releaseResourcesForGameplay),
+            name: AppState.releaseMenuBackgroundResourcesNotification, object: nil)
     }
 
     @available(*, unavailable)
@@ -111,12 +123,12 @@ private final class AnimatedBackgroundImageView: UIView {
         // UIKit tears down views on the main thread; assert it so the
         // MainActor-isolated stop() can be called.
         MainActor.assumeIsolated {
-            stop()
-            NotificationCenter.default.removeObserver(self)
+            teardown()
         }
     }
 
     func configure(with frames: [AnimatedBackgroundLoader.Frame], fitMode: BackgroundFitMode) {
+        guard !releasedForGameplay else { return }
         imageView.contentMode = uiContentMode(for: fitMode)
         guard frames != self.frames, !frames.isEmpty else { return }
         stop()
@@ -133,6 +145,13 @@ private final class AnimatedBackgroundImageView: UIView {
         lastTimestamp = 0
     }
 
+    func teardown() {
+        stop()
+        frames.removeAll(keepingCapacity: false)
+        imageView.image = nil
+        NotificationCenter.default.removeObserver(self)
+    }
+
     @objc private func pause() {
         displayLink?.invalidate()
         displayLink = nil
@@ -140,11 +159,16 @@ private final class AnimatedBackgroundImageView: UIView {
     }
 
     @objc private func resumeIfReady() {
-        guard displayLink == nil, !frames.isEmpty,
+        guard !releasedForGameplay, displayLink == nil, !frames.isEmpty,
               UIApplication.shared.applicationState != .background else { return }
         let link = CADisplayLink(target: self, selector: #selector(tick))
         link.add(to: .main, forMode: .common)
         displayLink = link
+    }
+
+    @objc private func releaseResourcesForGameplay() {
+        releasedForGameplay = true
+        teardown()
     }
 
     @objc private func tick(link: CADisplayLink) {
@@ -209,6 +233,7 @@ enum AnimatedBackgroundLoader {
         var frames: [Frame] = []
         frames.reserveCapacity(count)
         for i in 0..<count {
+			guard !Task.isCancelled else { return [] }
             guard let cgImage = CGImageSourceCreateImageAtIndex(source, i, nil) else { continue }
             // Skip oversized frames to avoid memory spikes; treat as static.
             if CGFloat(cgImage.width) > maxFrameDimension || CGFloat(cgImage.height) > maxFrameDimension {

--- a/platforms/ios/app/src/main/swift/Views/Background/BackgroundContainerView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/BackgroundContainerView.swift
@@ -11,6 +11,7 @@ struct BackgroundContainerView: View {
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @Environment(\.colorSchemeContrast) private var colorSchemeContrast
     @State private var videoPoster: UIImage?
+    @State private var isRenderingEnabled = true
 
     private var activeAsset: BackgroundAsset? {
         if size.width > size.height, let landscape = settings.backgroundLandscapeAsset { return landscape }
@@ -29,23 +30,31 @@ struct BackgroundContainerView: View {
 
     var body: some View {
         ZStack {
-            if let asset = activeAsset {
-                let url = BackgroundStorage.fileURL(for: asset)
-                switch asset.kind {
-                case .image:
-                    backgroundImage(UIImage(contentsOfFile: url.path))
-                case .animatedImage:
-                    if reduceMotion {
+            if isRenderingEnabled {
+                if settings.dynamicBackgroundsEnabled {
+                    DynamicBackgroundRendererView(
+                        preferences: settings.dynamicAppearancePreferences
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .clipped()
+                } else if let asset = activeAsset {
+                    let url = BackgroundStorage.fileURL(for: asset)
+                    switch asset.kind {
+                    case .image:
                         backgroundImage(UIImage(contentsOfFile: url.path))
-                    } else {
-                        animated(url)
-                    }
-                case .video:
-                    if reduceMotion {
-                        backgroundImage(videoPoster)
-                            .task(id: url.path) { await generateVideoPoster(from: url) }
-                    } else {
-                        video(url)
+                    case .animatedImage:
+                        if reduceMotion {
+                            backgroundImage(UIImage(contentsOfFile: url.path))
+                        } else {
+                            animated(url)
+                        }
+                    case .video:
+                        if reduceMotion {
+                            backgroundImage(videoPoster)
+                                .task(id: url.path) { await generateVideoPoster(from: url) }
+                        } else {
+                            video(url)
+                        }
                     }
                 }
             }
@@ -53,6 +62,20 @@ struct BackgroundContainerView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .ignoresSafeArea()
+        .onAppear {
+            isRenderingEnabled = true
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIScene.willDeactivateNotification)) { _ in
+            isRenderingEnabled = false
+            videoPoster = nil
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIScene.didActivateNotification)) { _ in
+            isRenderingEnabled = true
+        }
+        .onReceive(NotificationCenter.default.publisher(for: AppState.releaseMenuBackgroundResourcesNotification)) { _ in
+            isRenderingEnabled = false
+            videoPoster = nil
+        }
     }
 
     private func animated(_ url: URL) -> some View {

--- a/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicBackgroundPresentation.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicBackgroundPresentation.swift
@@ -1,0 +1,281 @@
+// DynamicBackgroundPresentation.swift — ARMSX2 dynamic background integration
+// SPDX-License-Identifier: GPL-3.0+
+
+import SwiftUI
+import UIKit
+
+struct DynamicBackgroundRendererView: View {
+    let preferences: DynamicAppearancePreferences
+    @State private var isRenderingEnabled = true
+
+    var body: some View {
+        Group {
+            if isRenderingEnabled {
+                DynamicBackgroundContentView(
+                    style: preferences.dynamicBackground,
+                    theme: DynamicBackgroundTheme(preferences: preferences)
+                )
+            }
+        }
+        .onAppear {
+            isRenderingEnabled = true
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIScene.willDeactivateNotification)) { _ in
+            isRenderingEnabled = false
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIScene.didActivateNotification)) { _ in
+            isRenderingEnabled = true
+        }
+        .onReceive(NotificationCenter.default.publisher(for: AppState.releaseMenuBackgroundResourcesNotification)) { _ in
+            isRenderingEnabled = false
+        }
+    }
+}
+
+struct DynamicBackgroundContentView: View {
+    let style: DynamicBackgroundStyle
+    let theme: DynamicBackgroundTheme
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @ViewBuilder
+    var body: some View {
+        if reduceMotion {
+            StaticDynamicBackgroundView(theme: theme)
+        } else {
+            style.makeBackground(theme: theme)
+                .id(style.id)
+        }
+    }
+}
+
+private struct StaticDynamicBackgroundView: View {
+    let theme: DynamicBackgroundTheme
+
+    var body: some View {
+        let deep = theme.sharedColor(index: 0, time: 0)
+        let middle = theme.sharedColor(index: 1, time: 0)
+        let accent = theme.ribbonColor(index: 2, time: 0)
+        let gradient = theme.sharedGradientPoints(from: .topLeading, to: .bottomTrailing)
+
+        ZStack {
+            PaletteGradientField(
+                colors: [
+                    theme.paletteBackgroundColor(deep, darkness: 0.96),
+                    theme.paletteBackgroundColor(middle, darkness: 0.72),
+                    theme.paletteBackgroundColor(accent, darkness: 0.9),
+                    theme.paletteBackgroundColor(deep, darkness: 1),
+                ],
+                startPoint: gradient.start,
+                endPoint: gradient.end,
+                curvature: theme.sharedPaletteGradientCurvature
+            )
+
+            Circle()
+                .fill(accent.opacity(0.18))
+                .frame(width: 520, height: 520)
+                .blur(radius: 130)
+                .offset(x: 140, y: -90)
+        }
+        .ignoresSafeArea()
+    }
+}
+
+private extension DynamicBackgroundTheme {
+    init(preferences: DynamicAppearancePreferences) {
+        self.init(
+            sharedPalette: preferences.sharedPalette,
+            sharedCustomColor: preferences.sharedCustomColor,
+            sharedMultiColor: preferences.sharedMultiColor,
+            ribbonPalette: preferences.ribbonPalette,
+            ribbonCustomColor: preferences.ribbonCustomColor,
+            ribbonMultiColor: preferences.ribbonMultiColor,
+            particleSettings: preferences.particleSettings
+        )
+    }
+}
+
+struct DynamicBackgroundAppearanceSections: View {
+    @State private var settings = SettingsStore.shared
+    @Binding var preferences: DynamicAppearancePreferences
+    let isPreviewActive: Bool
+    let showPaletteEditor: () -> Void
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        Section {
+            Toggle(isOn: $settings.dynamicBackgroundsEnabled) {
+                Label(
+                    settings.localized("Use Dynamic Background"),
+                    systemImage: settings.dynamicBackgroundsEnabled ? "waveform.path" : "waveform.path.badge.minus"
+                )
+            }
+
+            Picker(
+                settings.localized("Background Style"),
+                selection: styleBinding
+            ) {
+                ForEach(DynamicBackgroundStyle.allCases) { style in
+                    Label(settings.localized(style.title), systemImage: style.systemImage)
+                        .tag(style)
+                }
+            }
+            .pickerStyle(.menu)
+        } header: {
+            Text(settings.localized("Dynamic Backgrounds"))
+        } footer: {
+            Text(settings.localized("Dynamic backgrounds replace imported library media while enabled. Your portrait and landscape backgrounds stay saved."))
+        }
+
+        Section {
+            dynamicPreview
+        } header: {
+            Text(settings.localized("Preview"))
+        } footer: {
+            if reduceMotion {
+                Text(settings.localized("Reduce Motion is enabled, so ARMSX2 shows a still palette preview."))
+            } else {
+                Text(settings.localized("The preview uses the same renderer as the game library."))
+            }
+        }
+
+        Section {
+            Button(action: showPaletteEditor) {
+                HStack {
+                    Label(settings.localized("Colours & Effects"), systemImage: "paintpalette.fill")
+                    Spacer()
+                    Text(paletteSummary)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.tertiary)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        } footer: {
+            Text(settings.localized("Personalize colours, ribbons, particles, motion, and each background's advanced controls."))
+        }
+    }
+
+    private var dynamicPreview: some View {
+        Group {
+            if isPreviewActive {
+                DynamicBackgroundRendererView(preferences: preferences)
+            } else {
+                Color.clear
+            }
+        }
+            .frame(maxWidth: .infinity)
+            .aspectRatio(16 / 9, contentMode: .fit)
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(.white.opacity(0.14), lineWidth: 0.75)
+            }
+            .overlay(alignment: .bottomLeading) {
+                Label(
+                    settings.localized(preferences.dynamicBackground.title),
+                    systemImage: preferences.dynamicBackground.systemImage
+                )
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 10)
+                .frame(height: 30)
+                .background(.black.opacity(0.42), in: Capsule())
+                .padding(10)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(
+                settings.localized("Preview: \(preferences.dynamicBackground.title)")
+            )
+            .listRowInsets(EdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10))
+    }
+
+    private var styleBinding: Binding<DynamicBackgroundStyle> {
+        Binding(
+            get: { preferences.dynamicBackground },
+            set: { style in
+                selectStyle(style)
+            }
+        )
+    }
+
+    private var paletteSummary: String {
+        return "\(preferences.sharedPalette.title) · \(preferences.ribbonPalette.title)"
+    }
+
+    private func selectStyle(_ style: DynamicBackgroundStyle) {
+        guard style != preferences.dynamicBackground else { return }
+
+        if style == .playStation3XMBByMart,
+           !preferences.hasSelectedPlayStation3XMBByMart {
+            preferences.sharedPalette = .blue
+            preferences.sharedCustomColor = nil
+            preferences.sharedMultiColor.isEnabled = false
+            preferences.ribbonPalette = .cyan
+            preferences.ribbonCustomColor = nil
+            preferences.ribbonMultiColor.isEnabled = false
+            if !preferences.isPlayStation3XMBPresetExplicit {
+                preferences.particleSettings.playStation3XMB.gradientPreset = .theme
+            }
+            preferences.hasSelectedPlayStation3XMBByMart = true
+        }
+
+        preferences.dynamicBackground = style
+        settings.dynamicAppearancePreferences = preferences
+        UISelectionFeedbackGenerator().selectionChanged()
+    }
+
+}
+
+extension View {
+    func glassSurface(
+        tint: Color? = nil,
+        interactive: Bool = false,
+        clear: Bool = false,
+        cornerRadius: CGFloat
+    ) -> some View {
+        modifier(
+            DynamicBackgroundGlassSurfaceModifier(
+                tint: tint,
+                interactive: interactive,
+                clear: clear,
+                cornerRadius: cornerRadius
+            )
+        )
+    }
+}
+
+private struct DynamicBackgroundGlassSurfaceModifier: ViewModifier {
+    let tint: Color?
+    let interactive: Bool
+    let clear: Bool
+    let cornerRadius: CGFloat
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            if clear {
+                content
+                    .glassEffect(
+                        .clear.tint(tint).interactive(interactive),
+                        in: .rect(cornerRadius: cornerRadius)
+                    )
+            } else {
+                content
+                    .glassEffect(
+                        .regular.tint(tint).interactive(interactive),
+                        in: .rect(cornerRadius: cornerRadius)
+                    )
+            }
+        } else {
+            content
+                .background(
+                    .ultraThinMaterial,
+                    in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                )
+        }
+    }
+}

--- a/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicBackgrounds.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicBackgrounds.swift
@@ -1,0 +1,5626 @@
+// DynamicBackgrounds.swift — SwiftUI dynamic library backgrounds
+// SPDX-License-Identifier: GPL-3.0+
+
+import Foundation
+@preconcurrency import MetalKit
+import SwiftUI
+import UIKit
+
+// MARK: - DynamicBackgroundStyle
+
+enum DynamicBackgroundStyle: String, CaseIterable, Identifiable, Codable {
+  case multicolorAmbient = "ambient"
+  case lightSpeed = "space"
+  case spatialRetro = "ps1"
+  case towersOrbs = "towers"
+  case playStation2Menu = "towersSky"
+  case playStation3XMBByMart = "xmbMart"
+  case faceButtons
+  case playStationPortableBlur = "xmb"
+  case playStation3Splines = "xmb3"
+  case playStation4Particles = "xmb4"
+  case playStation4Waves = "waves"
+  case playStationRibbons = "ps5"
+
+  var id: String { rawValue }
+
+  var title: String {
+    switch self {
+    case .multicolorAmbient:
+      return "Multicolor Ambient"
+    case .lightSpeed:
+      return "Light Speed"
+    case .spatialRetro:
+      return "Spatial Retro"
+    case .towersOrbs:
+      return "Towers Orbs"
+    case .playStation2Menu:
+      return "PlayStation 2 Menu by Henyckma"
+    case .playStation3XMBByMart:
+      return "PlayStation 3 XMB by Mart"
+    case .faceButtons:
+      return "Face Buttons"
+    case .playStationPortableBlur:
+      return "PlayStation Portable Blur"
+    case .playStation3Splines:
+      return "PlayStation 3 Splines"
+    case .playStation4Particles:
+      return "PlayStation 4 Particles"
+    case .playStation4Waves:
+      return "PlayStation 4 Waves"
+    case .playStationRibbons:
+      return "PlayStation Ribbons"
+    }
+  }
+
+  var systemImage: String {
+    switch self {
+    case .multicolorAmbient:
+      return "circle.hexagongrid.fill"
+    case .lightSpeed:
+      return "forward.end.fill"
+    case .spatialRetro:
+      return "square.grid.3x3.fill"
+    case .towersOrbs:
+      return "circle.grid.2x2.fill"
+    case .playStation2Menu:
+      return "cube.fill"
+    case .playStation3XMBByMart:
+      return "water.waves"
+    case .faceButtons:
+      return "gamecontroller.fill"
+    case .playStationPortableBlur:
+      return "drop.fill"
+    case .playStation3Splines:
+      return "waveform.path"
+    case .playStation4Particles:
+      return "sparkles"
+    case .playStation4Waves:
+      return "water.waves"
+    case .playStationRibbons:
+      return "scribble.variable"
+    }
+  }
+
+  var settingsExpansionIdentifier: String {
+    // Keep the pre-rename values so saved disclosure state survives app updates.
+    let legacyName: String
+
+    switch self {
+    case .multicolorAmbient: legacyName = "Orbit Ambient"
+    case .lightSpeed: legacyName = "Space"
+    case .spatialRetro: legacyName = "PS1 Style"
+    case .towersOrbs: legacyName = "PS2 Towers"
+    case .playStation2Menu: legacyName = "Towers Sky"
+    case .playStation3XMBByMart: legacyName = "PlayStation 3 XMB by Mart"
+    case .faceButtons: legacyName = "Face Buttons"
+    case .playStationPortableBlur: legacyName = "XMB"
+    case .playStation3Splines: legacyName = "XMB3"
+    case .playStation4Particles: legacyName = "XMB4"
+    case .playStation4Waves: legacyName = "PS4 Waves"
+    case .playStationRibbons: legacyName = "PS5 Style"
+    }
+
+    return "background.\(legacyName)"
+  }
+
+  // Creates the selected animated background with shared base colors and ribbon accents.
+  @ViewBuilder
+  func makeBackground(theme: DynamicBackgroundTheme) -> some View {
+    ZStack {
+      switch self {
+      case .multicolorAmbient:
+        MulticolorAmbientBackground(theme: theme)
+      case .lightSpeed:
+        LightSpeedBackground(theme: theme)
+      case .spatialRetro:
+        SpatialRetroBackground(theme: theme)
+      case .towersOrbs:
+        TowersOrbsBackground(theme: theme)
+      case .playStation2Menu:
+        PlayStation2MenuBackground(theme: theme)
+      case .playStation3XMBByMart:
+        PlayStation3XMBByMartBackground(theme: theme)
+      case .faceButtons:
+        FaceButtonsBackground(theme: theme)
+      case .playStationPortableBlur:
+        PlayStationPortableBlurBackground(theme: theme)
+      case .playStation3Splines:
+        PlayStation3SplinesBackground(theme: theme, ribbonSizing: .playStation3)
+      case .playStation4Particles:
+        PlayStation4ParticlesBackground(theme: theme)
+      case .playStation4Waves:
+        PlayStation4WavesBackground(theme: theme)
+      case .playStationRibbons:
+        PlayStationRibbonsBackground(theme: theme)
+      }
+
+      if theme.particleSettings.isEnabled {
+        DynamicParticleOverlay(theme: theme)
+      }
+
+      if self != .faceButtons && theme.particleSettings.faceButtonsEnabled {
+        FaceButtonsBackground(
+          theme: theme,
+          showsBackdrop: false,
+          showsLightBands: false
+        )
+      }
+    }
+  }
+}
+
+// MARK: - MulticolorAmbientBackground
+
+struct MulticolorAmbientBackground: View {
+  let theme: DynamicBackgroundTheme
+
+  var body: some View {
+    TimelineView(.animation(minimumInterval: 1 / 30)) { timeline in
+      let time =
+        timeline.date.timeIntervalSinceReferenceDate
+        * theme.particleSettings.backgrounds.multicolorAmbientSpeed
+      let primaryColor = theme.sharedColor(index: 0, time: time)
+      let secondaryColor = theme.ribbonColor(index: 1, time: time)
+      let darkColor = theme.sharedColor(index: 2, time: time)
+      let sharedGradient = theme.sharedGradientPoints(
+        from: .topLeading,
+        to: .bottomTrailing
+      )
+
+      ZStack {
+        PaletteGradientField(
+          colors: [
+            theme.paletteBackgroundColor(primaryColor, darkness: 0.91),
+            theme.paletteBackgroundColor(darkColor, darkness: 0.76),
+            theme.paletteBackgroundColor(primaryColor, darkness: 0.84),
+          ],
+          startPoint: sharedGradient.start,
+          endPoint: sharedGradient.end,
+          curvature: theme.sharedPaletteGradientCurvature
+        )
+
+        Circle()
+          .fill(primaryColor.opacity(0.34))
+          .frame(width: 330, height: 330)
+          .blur(radius: 80)
+          .offset(
+            x: CGFloat(sin(time * 0.21)) * 150 - 100,
+            y: CGFloat(cos(time * 0.17)) * 100 - 160
+          )
+
+        Circle()
+          .fill(secondaryColor.opacity(0.24))
+          .frame(width: 300, height: 300)
+          .blur(radius: 90)
+          .offset(
+            x: CGFloat(cos(time * 0.19)) * 170 + 130,
+            y: CGFloat(sin(time * 0.15)) * 150 + 120
+          )
+
+        Circle()
+          .fill(.white.opacity(0.12))
+          .frame(width: 250, height: 250)
+          .blur(radius: 70)
+          .offset(
+            x: CGFloat(cos(time * 0.13)) * 110,
+            y: CGFloat(sin(time * 0.23)) * 130 + 180
+          )
+
+        Canvas { context, size in
+          let particleColor = theme.ribbonColor(index: 2, time: time)
+          for index in 0..<26 {
+            let phase = Double(index) * 1.73
+            let x = (sin(time * 0.07 + phase) * 0.5 + 0.5) * size.width
+            let y = (cos(time * 0.05 + phase * 1.4) * 0.5 + 0.5) * size.height
+            let rect = CGRect(x: x, y: y, width: 1.5, height: 1.5)
+            context.fill(Path(ellipseIn: rect), with: .color(particleColor.opacity(0.22)))
+          }
+        }
+
+        Rectangle()
+          .fill(theme.paletteDarkOverlay(opacity: 0.08))
+      }
+      .ignoresSafeArea()
+    }
+  }
+}
+
+// MARK: - LightSpeedBackground
+
+struct LightSpeedBackground: View {
+  let theme: DynamicBackgroundTheme
+
+  var body: some View {
+    TimelineView(.animation(minimumInterval: 1 / 30)) { timeline in
+      let time =
+        timeline.date.timeIntervalSinceReferenceDate
+        * theme.particleSettings.backgrounds.lightSpeedMotionSpeed
+      let deepColor = theme.sharedColor(index: 0, time: time)
+      let primaryColor = theme.sharedColor(index: 1, time: time)
+      let sharedGradient = theme.sharedGradientPoints(
+        from: .topLeading,
+        to: .bottomTrailing
+      )
+
+      ZStack {
+        theme.paletteBackgroundColor(deepColor, darkness: 1)
+
+        PaletteGradientField(
+          colors: [
+            theme.paletteBackgroundColor(deepColor, darkness: 1),
+            theme.paletteBackgroundColor(deepColor, darkness: 0.86),
+            theme.paletteBackgroundColor(primaryColor, darkness: 0.95),
+            theme.paletteBackgroundColor(primaryColor, darkness: 1),
+          ],
+          startPoint: sharedGradient.start,
+          endPoint: sharedGradient.end,
+          curvature: theme.sharedPaletteGradientCurvature
+        )
+
+        Canvas { context, size in
+          let vanishingPoint = vanishingPoint(size: size, time: time)
+
+          drawBackgroundNebulas(
+            context: &context,
+            size: size,
+            time: time
+          )
+          drawStarParticles(
+            context: &context,
+            size: size,
+            time: time
+          )
+          drawLightSpeedStreaks(
+            context: &context,
+            size: size,
+            time: time,
+            vanishingPoint: vanishingPoint
+          )
+        }
+
+        LinearGradient(
+          colors: [
+            theme.paletteDarkOverlay(opacity: 0.12),
+            .clear,
+            theme.paletteDarkOverlay(opacity: 0.18),
+          ],
+          startPoint: .top,
+          endPoint: .bottom
+        )
+
+        RadialGradient(
+          colors: [
+            .clear,
+            theme.paletteDarkOverlay(opacity: 0.54),
+          ],
+          center: .center,
+          startRadius: 260,
+          endRadius: 780
+        )
+      }
+      .ignoresSafeArea()
+    }
+  }
+
+  private var settings: DynamicParticleSettings {
+    theme.particleSettings
+  }
+
+  private func drawLightSpeedStreaks(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval,
+    vanishingPoint: CGPoint
+  ) {
+    context.blendMode = .plusLighter
+
+    let diagonal = hypot(size.width, size.height)
+    let sizeScale = CGFloat(max(0.45, settings.size))
+    let brightness = max(0.42, settings.brightness)
+    let speed = max(0.25, settings.speed) * 0.25
+    let count = min(260, max(90, Int(150 * settings.amount)))
+
+    for index in 0..<count {
+      let seedA = DynamicBackgroundMath.seededUnit(index: index, salt: 22.77)
+      let seedB = DynamicBackgroundMath.seededUnit(index: index, salt: 65.21)
+      let seedC = DynamicBackgroundMath.seededUnit(index: index, salt: 91.73)
+      let angle =
+        seedA * .pi * 2
+        + sin(time * 0.02 + seedB * 10) * 0.055 * settings.dispersion
+      let progress = DynamicBackgroundMath.unit(
+        seedB
+          + time * (0.26 + seedC * 0.72) * speed
+      )
+      let fadeIn = DynamicBackgroundMath.smoothstep(value: progress / 0.16)
+      let fadeOut = 1 - DynamicBackgroundMath.smoothstep(value: (progress - 0.76) / 0.24)
+      let lifecycleFade = max(0, fadeIn * fadeOut)
+      let travel = CGFloat(pow(progress, 1.86))
+      let direction = CGVector(
+        dx: CGFloat(cos(angle)),
+        dy: CGFloat(sin(angle))
+      )
+      let radius = diagonal * (0.016 + travel * 0.96)
+      let length =
+        min(
+          diagonal * 0.24,
+          CGFloat(1.4 + pow(progress, 2.7) * 250)
+            * (0.48 + CGFloat(seedC) * 0.74)
+            * sizeScale
+        )
+      let start = CGPoint(
+        x: vanishingPoint.x + direction.dx * max(2, radius - length * 0.18),
+        y: vanishingPoint.y + direction.dy * max(2, radius - length * 0.18)
+      )
+      let end = CGPoint(
+        x: vanishingPoint.x + direction.dx * (radius + length * 0.82),
+        y: vanishingPoint.y + direction.dy * (radius + length * 0.82)
+      )
+      let color =
+        index.isMultiple(of: 9)
+        ? theme.highlightColor(index: index, time: time)
+        : theme.ribbonColor(index: index, time: time)
+      let opacity =
+        min(
+          1,
+          (0.08 + seedC * 0.26 + Double(travel) * 0.82)
+            * lifecycleFade
+            * brightness
+        )
+      let lineWidth =
+        (0.18 + CGFloat(seedC) * 0.42 + travel * 2.25)
+        * sizeScale
+
+      drawWarpStreak(
+        context: &context,
+        start: start,
+        end: end,
+        color: color,
+        opacity: opacity,
+        lineWidth: lineWidth
+      )
+    }
+  }
+
+  private func drawBackgroundNebulas(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval
+  ) {
+    for index in 0..<7 {
+      let seedA = DynamicBackgroundMath.seededUnit(index: index, salt: 13.19)
+      let seedB = DynamicBackgroundMath.seededUnit(index: index, salt: 71.73)
+      let seedC = DynamicBackgroundMath.seededUnit(index: index, salt: 41.11)
+      let phase = time * (0.008 + seedA * 0.006)
+      let center = CGPoint(
+        x: size.width * CGFloat(0.08 + seedB * 0.84)
+          + CGFloat(sin(phase + seedA * 8)) * size.width * 0.045,
+        y: size.height * CGFloat(0.06 + seedC * 0.88)
+          + CGFloat(cos(phase * 0.9 + seedB * 7)) * size.height * 0.04
+      )
+      let width = size.width * CGFloat(0.26 + seedA * 0.46)
+      let height = size.height * CGFloat(0.11 + seedB * 0.24)
+      let color =
+        index.isMultiple(of: 2)
+        ? theme.sharedColor(index: index, time: time)
+        : theme.ribbonColor(index: index, time: time)
+      let opacity = (0.012 + seedC * 0.016) * max(0.45, settings.brightness)
+
+      context.drawLayer { nebula in
+        nebula.blendMode = .plusLighter
+        nebula.addFilter(.blur(radius: 54 + CGFloat(index % 3) * 18))
+        nebula.fill(
+          Path(ellipseIn: rect(center: center, width: width, height: height)),
+          with: .color(color.opacity(opacity))
+        )
+      }
+    }
+  }
+
+  private func drawStarParticles(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval
+  ) {
+    context.blendMode = .plusLighter
+
+    let count = min(360, max(130, Int(190 * settings.amount)))
+    let speed = max(0.12, settings.speed) * 0.18
+    let sizeScale = CGFloat(max(0.45, settings.size))
+    let brightness = max(0.36, settings.brightness)
+
+    for index in 0..<count {
+      let seedA = DynamicBackgroundMath.seededUnit(index: index, salt: 12.9898)
+      let seedB = DynamicBackgroundMath.seededUnit(index: index, salt: 78.233)
+      let seedC = DynamicBackgroundMath.seededUnit(index: index, salt: 37.719)
+      let progress = DynamicBackgroundMath.unit(seedB + time * (0.006 + seedC * 0.008) * speed)
+      let x =
+        size.width * CGFloat(seedA)
+        + CGFloat(sin(time * 0.015 + seedB * 9)) * 10 * CGFloat(settings.drift)
+      let y =
+        size.height * CGFloat(1 - progress)
+        + CGFloat(cos(time * 0.012 + seedA * 8)) * 8 * CGFloat(settings.drift)
+      let twinkle = pow(max(0, sin(time * (0.48 + seedC * 0.42) + seedA * 11)), 3)
+      let side =
+        CGFloat(index.isMultiple(of: 11) ? 1.8 : 0.75)
+        * sizeScale
+        * CGFloat(0.75 + twinkle * 0.6)
+      let color =
+        index.isMultiple(of: 13)
+        ? theme.highlightColor(index: index, time: time)
+        : theme.ribbonColor(index: index, time: time)
+      let opacity =
+        (index.isMultiple(of: 11) ? 0.26 : 0.12)
+        + twinkle * 0.24
+
+      context.fill(
+        Path(
+          CGRect(
+            x: x - side / 2,
+            y: y - side / 2,
+            width: side,
+            height: side
+          )
+        ),
+        with: .color(color.opacity(opacity * brightness))
+      )
+    }
+  }
+
+  private func drawWarpStreak(
+    context: inout GraphicsContext,
+    start: CGPoint,
+    end: CGPoint,
+    color: Color,
+    opacity: Double,
+    lineWidth: CGFloat
+  ) {
+    var path = Path()
+    path.move(to: start)
+    path.addLine(to: end)
+
+    context.stroke(
+      path,
+      with: .color(color.opacity(opacity)),
+      style: StrokeStyle(
+        lineWidth: lineWidth,
+        lineCap: .round
+      )
+    )
+  }
+
+  private func vanishingPoint(size: CGSize, time: TimeInterval) -> CGPoint {
+    CGPoint(
+      x: size.width * (0.5 + CGFloat(sin(time * 0.036)) * 0.012),
+      y: size.height * (0.5 + CGFloat(cos(time * 0.031)) * 0.01)
+    )
+  }
+  private func rect(center: CGPoint, width: CGFloat, height: CGFloat) -> CGRect {
+    CGRect(
+      x: center.x - width / 2,
+      y: center.y - height / 2,
+      width: width,
+      height: height
+    )
+  }
+
+}
+
+// MARK: - SpatialRetroBackground
+
+struct SpatialRetroBackground: View {
+  let theme: DynamicBackgroundTheme
+
+  var body: some View {
+    TimelineView(.animation(minimumInterval: 1 / 30)) { timeline in
+      let time =
+        timeline.date.timeIntervalSinceReferenceDate
+        * theme.particleSettings.backgrounds.spatialRetroSpeed
+      let primary = theme.sharedColor(index: 0, time: time)
+      let secondary = theme.sharedColor(index: 1, time: time)
+      let highlight = theme.ribbonColor(index: 2, time: time)
+      let sharedGradient = theme.sharedGradientPoints(
+        from: .topLeading,
+        to: .bottomTrailing
+      )
+
+      ZStack {
+        PaletteGradientField(
+          colors: [
+            theme.paletteBackgroundColor(primary, darkness: 1),
+            theme.paletteBackgroundColor(primary, darkness: 0.78),
+            theme.paletteBackgroundColor(secondary, darkness: 0.96),
+            theme.paletteBackgroundColor(primary, darkness: 1),
+          ],
+          startPoint: sharedGradient.start,
+          endPoint: sharedGradient.end,
+          curvature: theme.sharedPaletteGradientCurvature
+        )
+
+        Circle()
+          .fill(secondary.opacity(0.24))
+          .frame(width: 720, height: 720)
+          .blur(radius: 150)
+          .offset(
+            x: CGFloat(sin(time * 0.09)) * 120,
+            y: CGFloat(cos(time * 0.07)) * 80
+          )
+
+        Canvas { context, size in
+          drawPerspectiveGrid(
+            context: &context,
+            size: size,
+            time: time,
+            color: primary
+          )
+          drawPixelDust(
+            context: &context,
+            size: size,
+            time: time,
+            color: highlight
+          )
+          drawPolyhedra(
+            context: &context,
+            size: size,
+            time: time
+          )
+        }
+
+        LinearGradient(
+          colors: [
+            theme.paletteDarkOverlay(opacity: 0.08),
+            .clear,
+            theme.paletteDarkOverlay(opacity: 0.34),
+          ],
+          startPoint: .top,
+          endPoint: .bottom
+        )
+      }
+      .ignoresSafeArea()
+    }
+  }
+
+  // Draws a moving perspective grid from the horizon to the bottom edge.
+  private func drawPerspectiveGrid(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval,
+    color: Color
+  ) {
+    let horizon = size.height * 0.57
+    let vanishingPoint = CGPoint(
+      x: size.width * 0.5 + CGFloat(sin(time * 0.08)) * 22,
+      y: horizon
+    )
+
+    for column in -10...10 {
+      var line = Path()
+      line.move(to: vanishingPoint)
+      line.addLine(
+        to: CGPoint(
+          x: size.width * 0.5 + CGFloat(column) * size.width * 0.105,
+          y: size.height
+        )
+      )
+      context.stroke(
+        line,
+        with: .color(color.opacity(0.12)),
+        lineWidth: 0.65
+      )
+    }
+
+    for row in 0..<17 {
+      let phase = (Double(row) / 17 + time * 0.055).truncatingRemainder(dividingBy: 1)
+      let progress = CGFloat(phase)
+      let depth = progress * progress
+      let y = horizon + (size.height - horizon) * depth
+      var line = Path()
+      line.move(to: CGPoint(x: 0, y: y))
+      line.addLine(to: CGPoint(x: size.width, y: y))
+      context.stroke(
+        line,
+        with: .color(color.opacity(0.08 + Double(progress) * 0.22)),
+        lineWidth: 0.6 + progress
+      )
+    }
+  }
+
+  // Draws small pixels that drift upward over the PS1-style grid.
+  private func drawPixelDust(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval,
+    color: Color
+  ) {
+    for index in 0..<76 {
+      let seed = Double(index) * 1.731
+      let x = (sin(seed * 2.17) * 0.5 + 0.5) * size.width
+      let progress = (Double(index) * 0.071 + time * (0.008 + Double(index % 4) * 0.002))
+        .truncatingRemainder(dividingBy: 1)
+      let y = (1 - progress) * size.height
+      let side = CGFloat(index.isMultiple(of: 9) ? 2.2 : 1.1)
+      context.fill(
+        Path(
+          CGRect(
+            x: x - side / 2,
+            y: y - side / 2,
+            width: side,
+            height: side
+          )
+        ),
+        with: .color(color.opacity(index.isMultiple(of: 9) ? 0.46 : 0.2))
+      )
+    }
+  }
+
+  // Draws rotating faceted shapes and colors their facets from the ribbon palette.
+  private func drawPolyhedra(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval
+  ) {
+    for shapeIndex in 0..<7 {
+      let seed = Double(shapeIndex) * 1.43
+      let center = CGPoint(
+        x: size.width
+          * CGFloat(0.12 + Double(shapeIndex % 4) * 0.25)
+          + CGFloat(sin(time * 0.07 + seed)) * 28,
+        y: size.height
+          * CGFloat(0.18 + Double(shapeIndex / 4) * 0.36)
+          + CGFloat(cos(time * 0.09 + seed)) * 34
+      )
+      let radius =
+        min(size.width, size.height)
+        * CGFloat(0.045 + Double(shapeIndex % 3) * 0.018)
+      let vertexCount = 4 + shapeIndex % 3
+      let rotation = time * (0.12 + Double(shapeIndex) * 0.008) + seed
+      let innerPoint = CGPoint(
+        x: center.x + CGFloat(cos(rotation * 0.7)) * radius * 0.17,
+        y: center.y + CGFloat(sin(rotation * 0.9)) * radius * 0.12
+      )
+
+      var vertices: [CGPoint] = []
+      for vertexIndex in 0..<vertexCount {
+        let angle =
+          rotation
+          + Double(vertexIndex) * (.pi * 2 / Double(vertexCount))
+        vertices.append(
+          CGPoint(
+            x: center.x + CGFloat(cos(angle)) * radius,
+            y: center.y + CGFloat(sin(angle)) * radius * 0.72
+          )
+        )
+      }
+
+      for vertexIndex in vertices.indices {
+        let nextIndex = (vertexIndex + 1) % vertices.count
+        var facet = Path()
+        facet.move(to: innerPoint)
+        facet.addLine(to: vertices[vertexIndex])
+        facet.addLine(to: vertices[nextIndex])
+        facet.closeSubpath()
+
+        let facetColor = theme.ribbonColor(
+          index: shapeIndex + vertexIndex,
+          time: time
+        )
+        context.fill(
+          facet,
+          with: .color(
+            facetColor.opacity(
+              0.12 + Double((vertexIndex + shapeIndex) % 3) * 0.07
+            )
+          )
+        )
+        context.stroke(
+          facet,
+          with: .color(facetColor.opacity(0.38)),
+          lineWidth: 0.75
+        )
+      }
+    }
+  }
+
+}
+
+// MARK: - TowersOrbsBackground
+
+struct TowersOrbsBackground: View {
+  let theme: DynamicBackgroundTheme
+
+  var body: some View {
+    TimelineView(.animation(minimumInterval: 1 / 24)) { timeline in
+      let time =
+        timeline.date.timeIntervalSinceReferenceDate
+        * theme.particleSettings.backgrounds.towersOrbsSpeed
+      let primaryColor = theme.sharedColor(index: 0, time: time)
+      let secondaryColor = theme.ribbonColor(index: 1, time: time)
+      let darkColor = theme.sharedColor(index: 2, time: time)
+      let sharedGradient = theme.sharedGradientPoints(
+        from: .top,
+        to: .bottom
+      )
+
+      ZStack {
+        PaletteGradientField(
+          colors: [
+            theme.paletteBackgroundColor(darkColor, darkness: 0.98),
+            theme.paletteBackgroundColor(darkColor, darkness: 0.72),
+            theme.paletteBackgroundColor(primaryColor, darkness: 0.76),
+            theme.paletteBackgroundColor(primaryColor, darkness: 1),
+          ],
+          startPoint: sharedGradient.start,
+          endPoint: sharedGradient.end,
+          curvature: theme.sharedPaletteGradientCurvature
+        )
+
+        Canvas { context, size in
+          drawOrbitingOrbs(
+            context: &context,
+            size: size,
+            time: time,
+            drawsFront: false
+          )
+          drawTowers(context: &context, size: size, time: time)
+          drawOrbitingOrbs(
+            context: &context,
+            size: size,
+            time: time,
+            drawsFront: true
+          )
+        }
+
+        RadialGradient(
+          colors: [secondaryColor.opacity(0.24), .clear],
+          center: .topTrailing,
+          startRadius: 10,
+          endRadius: 360
+        )
+      }
+      .ignoresSafeArea()
+    }
+  }
+
+  // Draws layered PS2-style towers with ribbon-colored faces and edges.
+  private func drawTowers(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval
+  ) {
+    for depth in 0..<5 {
+      for column in 0..<8 {
+        let index = depth * 8 + column
+        let towerColor = theme.ribbonColor(index: index, time: time)
+        let seed = Double(index) * 1.731
+        let spacing = size.width / 7
+        let x =
+          CGFloat(column) * spacing
+          + CGFloat(depth % 2) * spacing * 0.48
+          - spacing * 0.22
+          + CGFloat(sin(time * 0.035 + seed)) * 4
+        let bottom = size.height * (0.62 + CGFloat(depth) * 0.085)
+        let towerWidth = max(8, size.width * CGFloat(0.018 + Double(index % 4) * 0.005))
+        let towerHeight =
+          size.height
+          * CGFloat(
+            0.13 + (sin(seed * 1.21) * 0.5 + 0.5) * 0.38
+          )
+        let top = bottom - towerHeight
+        let depthOffset = towerWidth * 0.48
+        let depthRise = towerWidth * 0.28
+        let frontRect = CGRect(
+          x: x - towerWidth / 2,
+          y: top,
+          width: towerWidth,
+          height: towerHeight
+        )
+        context.fill(
+          Path(frontRect),
+          with: .linearGradient(
+            Gradient(colors: [
+              towerColor.opacity(0.34),
+              towerColor.opacity(0.08),
+            ]),
+            startPoint: CGPoint(x: x, y: top),
+            endPoint: CGPoint(x: x, y: bottom)
+          )
+        )
+        context.stroke(
+          Path(frontRect),
+          with: .color(towerColor.opacity(0.34)),
+          lineWidth: 0.7
+        )
+
+        var side = Path()
+        side.move(to: CGPoint(x: frontRect.maxX, y: frontRect.minY))
+        side.addLine(
+          to: CGPoint(
+            x: frontRect.maxX + depthOffset,
+            y: frontRect.minY - depthRise
+          )
+        )
+        side.addLine(
+          to: CGPoint(
+            x: frontRect.maxX + depthOffset,
+            y: frontRect.maxY - depthRise
+          )
+        )
+        side.addLine(to: CGPoint(x: frontRect.maxX, y: frontRect.maxY))
+        side.closeSubpath()
+        context.fill(side, with: .color(towerColor.opacity(0.1)))
+        context.stroke(
+          side,
+          with: .color(towerColor.opacity(0.24)),
+          lineWidth: 0.6
+        )
+
+        var topFace = Path()
+        topFace.move(to: CGPoint(x: frontRect.minX, y: frontRect.minY))
+        topFace.addLine(to: CGPoint(x: frontRect.maxX, y: frontRect.minY))
+        topFace.addLine(
+          to: CGPoint(
+            x: frontRect.maxX + depthOffset,
+            y: frontRect.minY - depthRise
+          )
+        )
+        topFace.addLine(
+          to: CGPoint(
+            x: frontRect.minX + depthOffset,
+            y: frontRect.minY - depthRise
+          )
+        )
+        topFace.closeSubpath()
+        context.fill(topFace, with: .color(towerColor.opacity(0.42)))
+        context.stroke(
+          topFace,
+          with: .color(.white.opacity(0.16)),
+          lineWidth: 0.5
+        )
+      }
+    }
+  }
+
+  // Draws orbital trails in back and front passes so each orb appears to wrap around.
+  private func drawOrbitingOrbs(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval,
+    drawsFront: Bool
+  ) {
+    for orbIndex in 0..<4 {
+      let orbColor = theme.ribbonColor(index: orbIndex, time: time)
+      let configuration = orbitConfiguration(index: orbIndex, size: size)
+      let currentMoment = time + configuration.startOffset
+
+      for tailIndex in 0..<13 {
+        let firstMoment = currentMoment - Double(tailIndex) * 0.12
+        let secondMoment = currentMoment - Double(tailIndex + 1) * 0.12
+        let middleDepth = orbitDepth(
+          moment: (firstMoment + secondMoment) / 2,
+          configuration: configuration
+        )
+        guard (middleDepth >= 0) == drawsFront else { continue }
+
+        let first = orbitPoint(
+          moment: firstMoment,
+          configuration: configuration
+        )
+        let second = orbitPoint(
+          moment: secondMoment,
+          configuration: configuration
+        )
+        let delta = secondMoment - firstMoment
+        let firstTangent = orbitTangent(
+          moment: firstMoment,
+          configuration: configuration
+        )
+        let secondTangent = orbitTangent(
+          moment: secondMoment,
+          configuration: configuration
+        )
+        let control1 = CGPoint(
+          x: first.x + firstTangent.width * delta / 3,
+          y: first.y + firstTangent.height * delta / 3
+        )
+        let control2 = CGPoint(
+          x: second.x - secondTangent.width * delta / 3,
+          y: second.y - secondTangent.height * delta / 3
+        )
+        var tail = Path()
+        tail.move(to: first)
+        tail.addCurve(
+          to: second,
+          control1: control1,
+          control2: control2
+        )
+
+        let fade = 1 - Double(tailIndex) / 13
+        context.stroke(
+          tail,
+          with: .color(orbColor.opacity(fade * (drawsFront ? 0.72 : 0.2))),
+          style: StrokeStyle(
+            lineWidth: CGFloat(0.6 + fade * 2.1),
+            lineCap: .round
+          )
+        )
+      }
+
+      let currentDepth = orbitDepth(
+        moment: currentMoment,
+        configuration: configuration
+      )
+      guard (currentDepth >= 0) == drawsFront else { continue }
+      let point = orbitPoint(
+        moment: currentMoment,
+        configuration: configuration
+      )
+      let depthScale = CGFloat(0.72 + (currentDepth + 1) * 0.2)
+      let diameter = CGFloat(7 + orbIndex) * depthScale
+      let rect = CGRect(
+        x: point.x - diameter / 2,
+        y: point.y - diameter / 2,
+        width: diameter,
+        height: diameter
+      )
+
+      context.drawLayer { glow in
+        glow.addFilter(.shadow(color: orbColor.opacity(0.9), radius: 8))
+        glow.fill(
+          Path(ellipseIn: rect),
+          with: .color(
+            drawsFront ? .white : orbColor.opacity(0.45)
+          )
+        )
+      }
+    }
+  }
+
+  // Creates seeded start positions and non-circular movement values for each orb.
+  private func orbitConfiguration(
+    index: Int,
+    size: CGSize
+  ) -> TowerOrbitConfiguration {
+    let seedA = DynamicBackgroundMath.seededUnit(index: index, salt: 17.129)
+    let seedB = DynamicBackgroundMath.seededUnit(index: index, salt: 31.415)
+    let seedC = DynamicBackgroundMath.seededUnit(index: index, salt: 57.721)
+    let seedD = DynamicBackgroundMath.seededUnit(index: index, salt: 83.113)
+    let seedE = DynamicBackgroundMath.seededUnit(index: index, salt: 109.37)
+    let seedF = DynamicBackgroundMath.seededUnit(index: index, salt: 139.81)
+
+    return TowerOrbitConfiguration(
+      center: CGPoint(
+        x: size.width * CGFloat(0.18 + seedA * 0.64),
+        y: size.height * CGFloat(0.32 + seedB * 0.36)
+      ),
+      radiusX: size.width * CGFloat(0.1 + seedC * 0.17),
+      radiusY: size.height * CGFloat(0.05 + seedD * 0.09),
+      wobbleX: size.width * CGFloat(0.025 + seedE * 0.065),
+      wobbleY: size.height * CGFloat(0.02 + seedF * 0.06),
+      speedX: 0.16 + seedB * 0.18,
+      speedY: 0.2 + seedC * 0.2,
+      wobbleSpeed: 0.34 + seedD * 0.32,
+      phaseX: seedE * .pi * 2,
+      phaseY: seedF * .pi * 2,
+      wobblePhase: seedA * .pi * 2,
+      depthSpeed: 0.22 + seedF * 0.18,
+      depthPhase: seedC * .pi * 2,
+      startOffset: seedD * 11
+    )
+  }
+
+  // Returns the current point on a layered, non-circular orb path.
+  private func orbitPoint(
+    moment: Double,
+    configuration: TowerOrbitConfiguration
+  ) -> CGPoint {
+    CGPoint(
+      x: configuration.center.x
+        + CGFloat(cos(moment * configuration.speedX + configuration.phaseX))
+        * configuration.radiusX
+        + CGFloat(sin(moment * configuration.wobbleSpeed + configuration.wobblePhase))
+        * configuration.wobbleX
+        + CGFloat(cos(moment * 0.11 + configuration.phaseY))
+        * configuration.radiusX
+        * 0.18,
+      y: configuration.center.y
+        + CGFloat(sin(moment * configuration.speedY + configuration.phaseY))
+        * configuration.radiusY
+        + CGFloat(cos(moment * configuration.wobbleSpeed * 0.82 + configuration.wobblePhase))
+        * configuration.wobbleY
+        + CGFloat(sin(moment * 0.13 + configuration.phaseX))
+        * configuration.radiusY
+        * 0.22
+    )
+  }
+
+  // Samples nearby points to curve the orb trail along the seeded path.
+  private func orbitTangent(
+    moment: Double,
+    configuration: TowerOrbitConfiguration
+  ) -> CGSize {
+    let delta = 0.01
+    let first = orbitPoint(
+      moment: moment - delta,
+      configuration: configuration
+    )
+    let second = orbitPoint(
+      moment: moment + delta,
+      configuration: configuration
+    )
+
+    return CGSize(
+      width: (second.x - first.x) / CGFloat(delta * 2),
+      height: (second.y - first.y) / CGFloat(delta * 2)
+    )
+  }
+
+  // Calculates whether an orb is currently behind or in front of the towers.
+  private func orbitDepth(
+    moment: Double,
+    configuration: TowerOrbitConfiguration
+  ) -> Double {
+    sin(moment * configuration.depthSpeed + configuration.depthPhase)
+  }
+}
+
+private struct TowerOrbitConfiguration {
+  let center: CGPoint
+  let radiusX: CGFloat
+  let radiusY: CGFloat
+  let wobbleX: CGFloat
+  let wobbleY: CGFloat
+  let speedX: Double
+  let speedY: Double
+  let wobbleSpeed: Double
+  let phaseX: Double
+  let phaseY: Double
+  let wobblePhase: Double
+  let depthSpeed: Double
+  let depthPhase: Double
+  let startOffset: Double
+}
+
+// MARK: - PlayStation2MenuScene
+
+enum PlayStation2MenuDepthPass {
+  case far
+  case middle
+  case near
+
+  func contains(_ depth: Double) -> Bool {
+    switch self {
+    case .far:
+      return depth < -0.25
+    case .middle:
+      return depth >= -0.25 && depth < 0.45
+    case .near:
+      return depth >= 0.45
+    }
+  }
+
+  func visibility(at depth: Double) -> Double {
+    let feather = 0.16
+    let middleEntry = DynamicBackgroundMath.smoothstep(
+      from: -0.25 - feather,
+      to: -0.25 + feather,
+      value: depth
+    )
+    let nearEntry = DynamicBackgroundMath.smoothstep(
+      from: 0.45 - feather,
+      to: 0.45 + feather,
+      value: depth
+    )
+
+    switch self {
+    case .far:
+      return 1 - middleEntry
+    case .middle:
+      return middleEntry * (1 - nearEntry)
+    case .near:
+      return middleEntry * nearEntry
+    }
+  }
+}
+
+struct PlayStation2MenuCamera {
+  let size: CGSize
+  let horizontalExtent: Double
+  let verticalExtent: Double
+
+  private let yawSine: Double
+  private let yawCosine: Double
+  private let pitchSine: Double
+  private let pitchCosine: Double
+  private let rollSine: Double
+  private let rollCosine: Double
+  private let viewportScale: Double
+  private let panX: Double
+  private let panY: Double
+
+  init(
+    size: CGSize,
+    time: TimeInterval,
+    yawSpeed: Double,
+    rollSpeed: Double,
+    orbitDegrees: Double
+  ) {
+    self.size = size
+
+    let minimumDimension = max(1, min(size.width, size.height))
+    horizontalExtent = Double(size.width / minimumDimension)
+    verticalExtent = Double(size.height / minimumDimension)
+    viewportScale = Double(minimumDimension * 0.5)
+
+    let orbitLimit = orbitDegrees * Double.pi / 180
+    let yawMotion =
+      sin(time * 0.024 * yawSpeed) * 0.055
+      + sin(time * 0.008 * yawSpeed) * 0.015
+    let yaw = yawMotion / 0.07 * orbitLimit
+    let pitch = sin(time * 0.019 + 1.2) * 0.035
+    let roll = sin(time * 0.014 * rollSpeed) * 0.012
+
+    yawSine = sin(yaw)
+    yawCosine = cos(yaw)
+    pitchSine = sin(pitch)
+    pitchCosine = cos(pitch)
+    rollSine = sin(roll)
+    rollCosine = cos(roll)
+    panX =
+      sin(time * 0.013) * Double(size.width) * 0.024
+      + sin(time * 0.005 + 1.3) * Double(size.width) * 0.008
+    panY =
+      cos(time * 0.011) * Double(size.height) * 0.018
+      + sin(time * 0.004 + 0.7) * Double(size.height) * 0.007
+  }
+
+  func project(_ world: PlayStation2MenuVector3) -> PlayStation2MenuProjection {
+    let yawX = world.x * yawCosine + world.z * yawSine
+    let yawZ = -world.x * yawSine + world.z * yawCosine
+    let pitchY = world.y * pitchCosine - yawZ * pitchSine
+    let pitchZ = world.y * pitchSine + yawZ * pitchCosine
+    let transformedX = yawX * rollCosine - pitchY * rollSine
+    let transformedY = yawX * rollSine + pitchY * rollCosine
+    let perspective = 1 / max(0.68, 1 - pitchZ * 0.17)
+
+    return PlayStation2MenuProjection(
+      point: CGPoint(
+        x: size.width * 0.5
+          + CGFloat(transformedX * viewportScale * perspective + panX),
+        y: size.height * 0.52
+          + CGFloat(transformedY * viewportScale * perspective + panY)
+          - CGFloat(pitchZ) * size.height * 0.018
+      ),
+      depth: pitchZ,
+      scale: CGFloat(perspective)
+    )
+  }
+}
+
+struct PlayStation2MenuVector3 {
+  let x: Double
+  let y: Double
+  let z: Double
+
+  static func + (
+    lhs: PlayStation2MenuVector3,
+    rhs: PlayStation2MenuVector3
+  ) -> PlayStation2MenuVector3 {
+    PlayStation2MenuVector3(
+      x: lhs.x + rhs.x,
+      y: lhs.y + rhs.y,
+      z: lhs.z + rhs.z
+    )
+  }
+
+  static func * (
+    vector: PlayStation2MenuVector3,
+    scalar: Double
+  ) -> PlayStation2MenuVector3 {
+    PlayStation2MenuVector3(
+      x: vector.x * scalar,
+      y: vector.y * scalar,
+      z: vector.z * scalar
+    )
+  }
+
+  func rotatedX(_ angle: Double) -> PlayStation2MenuVector3 {
+    PlayStation2MenuVector3(
+      x: x,
+      y: y * cos(angle) - z * sin(angle),
+      z: y * sin(angle) + z * cos(angle)
+    )
+  }
+
+  func rotatedY(_ angle: Double) -> PlayStation2MenuVector3 {
+    PlayStation2MenuVector3(
+      x: x * cos(angle) + z * sin(angle),
+      y: y,
+      z: -x * sin(angle) + z * cos(angle)
+    )
+  }
+
+  func rotatedZ(_ angle: Double) -> PlayStation2MenuVector3 {
+    PlayStation2MenuVector3(
+      x: x * cos(angle) - y * sin(angle),
+      y: x * sin(angle) + y * cos(angle),
+      z: z
+    )
+  }
+}
+
+struct PlayStation2MenuRotation {
+  let x: Double
+  let y: Double
+  let z: Double
+}
+
+struct PlayStation2MenuProjection {
+  let point: CGPoint
+  let depth: Double
+  let scale: CGFloat
+}
+
+struct PlayStation2MenuTowerConfiguration {
+  let center: PlayStation2MenuVector3
+  let size: PlayStation2MenuVector3
+  let rotation: PlayStation2MenuRotation
+  let pulseSpeed: Double
+  let pulseAmount: Double
+  let phase: Double
+  let isInner: Bool
+}
+
+struct PlayStation2MenuCrystalConfiguration {
+  let center: PlayStation2MenuVector3
+  let side: Double
+  let phase: Double
+  let rotationSpeed: Double
+  let tintIndex: Int
+}
+
+struct PlayStation2MenuCloudElement {
+  let rect: CGRect
+  let glowRect: CGRect
+  let color: Color
+  let cloudOpacity: Double
+  let glowOpacity: Double
+}
+
+struct PlayStation2MenuOrbConfiguration {
+  let center: PlayStation2MenuVector3
+  let radiusX: Double
+  let radiusY: Double
+  let bend: Double
+  let speed: Double
+  let phase: Double
+  let depthPhase: Double
+}
+
+enum PlayStation2MenuGeometry {
+  static let cubeFaces: [[Int]] = [
+    [0, 1, 2, 3],
+    [4, 7, 6, 5],
+    [0, 4, 5, 1],
+    [1, 5, 6, 2],
+    [2, 6, 7, 3],
+    [3, 7, 4, 0],
+  ]
+
+  static let crystalCrossEdges: [(Int, Int)] = [
+    (0, 6),
+    (1, 7),
+    (2, 4),
+    (3, 5),
+  ]
+}
+
+// MARK: - PlayStation2MenuBackground
+
+struct PlayStation2MenuBackground: View {
+  let theme: DynamicBackgroundTheme
+  @State private var cameraStartDate = Date()
+
+  var body: some View {
+    let framesPerSecond = max(
+      1,
+      theme.particleSettings.backgrounds.playStation2MenuFramesPerSecond
+    )
+
+    TimelineView(.animation(minimumInterval: 1 / framesPerSecond)) { timeline in
+      let motionSettings = theme.particleSettings.backgrounds
+      let time =
+        timeline.date.timeIntervalSinceReferenceDate
+        * motionSettings.playStation2MenuSceneSpeed
+      let cameraTime =
+        max(0, timeline.date.timeIntervalSince(cameraStartDate))
+        * motionSettings.playStation2MenuSceneSpeed
+      let deepColor = theme.sharedColor(index: 0, time: time)
+      let cloudColor = theme.sharedColor(index: 1, time: time)
+      let reflectedColor = theme.ribbonColor(index: 2, time: time)
+      let sharedGradient = theme.sharedGradientPoints(
+        from: .topLeading,
+        to: .bottomTrailing
+      )
+
+      ZStack {
+        theme.paletteBackgroundColor(deepColor, darkness: 1)
+
+        PaletteGradientField(
+          colors: [
+            theme.paletteBackgroundColor(deepColor, darkness: 1),
+            theme.paletteBackgroundColor(deepColor, darkness: 0.98),
+            theme.paletteBackgroundColor(deepColor, darkness: 0.89),
+            theme.paletteBackgroundColor(deepColor, darkness: 1),
+          ],
+          startPoint: sharedGradient.start,
+          endPoint: sharedGradient.end,
+          curvature: theme.sharedPaletteGradientCurvature
+        )
+
+        RadialGradient(
+          colors: [
+            cloudColor.opacity(0.2),
+            reflectedColor.opacity(0.065),
+            deepColor.opacity(0.035),
+            .clear,
+          ],
+          center: UnitPoint(
+            x: 0.53 + CGFloat(sin(time * 0.019)) * 0.035,
+            y: 0.58 + CGFloat(cos(time * 0.016)) * 0.045
+          ),
+          startRadius: 18,
+          endRadius: 700
+        )
+
+        Canvas(
+          opaque: false,
+          colorMode: .nonLinear,
+          rendersAsynchronously: true
+        ) { context, size in
+          guard size.width > 1, size.height > 1 else { return }
+
+          let camera = PlayStation2MenuCamera(
+            size: size,
+            time: cameraTime,
+            yawSpeed: motionSettings.playStation2MenuYawSpeed,
+            rollSpeed: motionSettings.playStation2MenuRollSpeed,
+            orbitDegrees: motionSettings.playStation2MenuOrbitDegrees
+          )
+          let towers = towerConfigurations(camera: camera)
+          let crystals = crystalConfigurations(camera: camera)
+
+          drawFog(
+            context: &context,
+            camera: camera,
+            time: time,
+            foreground: false
+          )
+
+          drawOrbTrails(
+            context: &context,
+            camera: camera,
+            time: time,
+            pass: .far
+          )
+          drawTowers(
+            context: &context,
+            camera: camera,
+            time: time,
+            pass: .far,
+            configurations: towers
+          )
+          drawCrystals(
+            context: &context,
+            camera: camera,
+            time: time,
+            pass: .far,
+            configurations: crystals
+          )
+
+          drawTowers(
+            context: &context,
+            camera: camera,
+            time: time,
+            pass: .middle,
+            configurations: towers
+          )
+          drawOrbTrails(
+            context: &context,
+            camera: camera,
+            time: time,
+            pass: .middle
+          )
+          drawCrystals(
+            context: &context,
+            camera: camera,
+            time: time,
+            pass: .middle,
+            configurations: crystals
+          )
+
+          drawTowers(
+            context: &context,
+            camera: camera,
+            time: time,
+            pass: .near,
+            configurations: towers
+          )
+          drawTowerBaseClouds(
+            context: &context,
+            camera: camera,
+            time: time,
+            configurations: towers
+          )
+          drawCrystals(
+            context: &context,
+            camera: camera,
+            time: time,
+            pass: .near,
+            configurations: crystals
+          )
+          drawOrbTrails(
+            context: &context,
+            camera: camera,
+            time: time,
+            pass: .near
+          )
+        }
+
+        LinearGradient(
+          colors: [
+            theme.paletteDarkOverlay(opacity: 0.5),
+            .clear,
+            theme.paletteDarkOverlay(opacity: 0.24),
+          ],
+          startPoint: .top,
+          endPoint: .bottom
+        )
+
+        RadialGradient(
+          colors: [
+            .clear,
+            theme.paletteDarkOverlay(opacity: 0.76),
+          ],
+          center: .center,
+          startRadius: 230,
+          endRadius: 840
+        )
+      }
+      .ignoresSafeArea()
+      .accessibilityHidden(true)
+    }
+  }
+}
+
+// MARK: - PlayStation2MenuRenderer
+
+extension PlayStation2MenuBackground {
+  func drawFog(
+    context: inout GraphicsContext,
+    camera: PlayStation2MenuCamera,
+    time: TimeInterval,
+    foreground: Bool
+  ) {
+    let count = foreground ? 4 : 7
+    context.drawLayer { fog in
+      fog.blendMode = .plusLighter
+      fog.addFilter(.blur(radius: foreground ? 72 : 62))
+
+      for index in 0..<count {
+        let seedA = DynamicBackgroundMath.seededUnit(index: index, salt: foreground ? 31.73 : 13.19)
+        let seedB = DynamicBackgroundMath.seededUnit(index: index, salt: foreground ? 83.41 : 57.13)
+        let seedC = DynamicBackgroundMath.seededUnit(
+          index: index, salt: foreground ? 119.17 : 97.61)
+        let depth =
+          foreground
+          ? 0.48 + seedC * 0.52
+          : -1.08 + seedC * 0.9
+        let worldCenter = PlayStation2MenuVector3(
+          x: (-0.92 + seedA * 1.84) * camera.horizontalExtent,
+          y: (-0.78 + seedB * 1.56) * camera.verticalExtent,
+          z: depth
+        )
+        let projected = camera.project(worldCenter)
+        let driftX = CGFloat(sin(time * (0.009 + seedA * 0.008) + seedB * 9)) * 34
+        let driftY = CGFloat(cos(time * (0.008 + seedC * 0.007) + seedA * 11)) * 26
+        let width = camera.size.width * CGFloat(0.2 + seedB * 0.31) * projected.scale
+        let height = camera.size.height * CGFloat(0.08 + seedC * 0.15) * projected.scale
+        let rect = CGRect(
+          x: projected.point.x + driftX - width / 2,
+          y: projected.point.y + driftY - height / 2,
+          width: width,
+          height: height
+        )
+        let color =
+          index.isMultiple(of: 3)
+          ? theme.sharedColor(index: index + 1, time: time)
+          : theme.ribbonColor(index: index + 2, time: time)
+        let opacity =
+          foreground
+          ? 0.018 + seedA * 0.012
+          : 0.018 + seedA * 0.022
+
+        fog.fill(
+          Path(ellipseIn: rect),
+          with: .color(color.opacity(opacity))
+        )
+      }
+    }
+  }
+}
+
+// MARK: - PlayStation2MenuTowerRenderer
+
+extension PlayStation2MenuBackground {
+  func drawTowers(
+    context: inout GraphicsContext,
+    camera: PlayStation2MenuCamera,
+    time: TimeInterval,
+    pass: PlayStation2MenuDepthPass,
+    configurations: [PlayStation2MenuTowerConfiguration]
+  ) {
+    let visibleConfigurations =
+      configurations
+      .enumerated()
+      .filter { pass.contains($0.element.center.z) }
+      .sorted { $0.element.center.z < $1.element.center.z }
+
+    for (index, configuration) in visibleConfigurations {
+      let pulse =
+        1
+        + sin(time * configuration.pulseSpeed + configuration.phase)
+        * configuration.pulseAmount
+      drawTower(
+        context: &context,
+        camera: camera,
+        configuration: configuration,
+        growth: pulse,
+        time: time,
+        index: index,
+        pass: pass
+      )
+    }
+  }
+
+  func drawTower(
+    context: inout GraphicsContext,
+    camera: PlayStation2MenuCamera,
+    configuration: PlayStation2MenuTowerConfiguration,
+    growth: Double,
+    time: TimeInterval,
+    index: Int,
+    pass: PlayStation2MenuDepthPass
+  ) {
+    let baseCenter = towerBaseCenter(
+      configuration: configuration,
+      growth: growth
+    )
+    let top = towerFaceCorners(
+      center: configuration.center,
+      size: configuration.size,
+      scale: 1,
+      rotation: configuration.rotation,
+      camera: camera
+    )
+    let base = towerFaceCorners(
+      center: baseCenter,
+      size: configuration.size,
+      scale: configuration.isInner ? 0.7 : 0.56,
+      rotation: configuration.rotation,
+      camera: camera
+    )
+    let sideFaces = [
+      [base[0], base[1], top[1], top[0]],
+      [base[1], base[2], top[2], top[1]],
+      [base[2], base[3], top[3], top[2]],
+      [base[3], base[0], top[0], top[3]],
+    ].enumerated().sorted { lhs, rhs in
+      averagedDepth(lhs.element) < averagedDepth(rhs.element)
+    }
+    let tint =
+      index.isMultiple(of: 7)
+      ? theme.ribbonColor(index: index, time: time)
+      : theme.sharedColor(index: index, time: time)
+    let colorsTowers =
+      theme.particleSettings.backgrounds.playStation2MenuColorsTowers
+    let materialOpacity: Double
+
+    switch pass {
+    case .far:
+      materialOpacity = 0.22
+    case .middle:
+      materialOpacity = 0.42
+    case .near:
+      materialOpacity = 0.62
+    }
+
+    let faceLight: [Double] = [0.28, 0.68, 0.42, 0.78]
+
+    for (faceIndex, face) in sideFaces {
+      let path = polygonPath(face.map { $0.point })
+      let light = faceLight[faceIndex]
+      let baseEdgeCenter = averagedPoint([face[0].point, face[1].point])
+      let topEdgeCenter = averagedPoint([face[2].point, face[3].point])
+      let depthBase: (red: Double, green: Double, blue: Double)
+
+      switch pass {
+      case .far:
+        depthBase = (0.14, 0.18, 0.26)
+      case .middle:
+        depthBase = (0.24, 0.3, 0.4)
+      case .near:
+        depthBase = (0.38, 0.46, 0.58)
+      }
+
+      let neutral = Color(
+        red: depthBase.red + light * 0.12,
+        green: depthBase.green + light * 0.11,
+        blue: depthBase.blue + light * 0.1
+      )
+      let towerSurface = colorsTowers ? tint : neutral
+
+      context.fill(
+        path,
+        with: .linearGradient(
+          Gradient(stops: [
+            .init(color: .clear, location: 0),
+            .init(
+              color: tint.opacity(
+                materialOpacity * (colorsTowers ? 0.18 : 0.025)
+              ),
+              location: 0.16
+            ),
+            .init(
+              color: towerSurface.opacity(
+                materialOpacity * (colorsTowers ? 0.38 : 0.2)
+              ),
+              location: 0.34
+            ),
+            .init(
+              color: towerSurface.opacity(materialOpacity * (0.7 + light * 0.12)),
+              location: 0.88
+            ),
+            .init(
+              color: .white.opacity(materialOpacity * light * 0.24),
+              location: 1
+            ),
+          ]),
+          startPoint: baseEdgeCenter,
+          endPoint: topEdgeCenter
+        )
+      )
+
+      context.stroke(
+        path,
+        with: .linearGradient(
+          Gradient(stops: [
+            .init(color: .clear, location: 0),
+            .init(
+              color: .white.opacity(materialOpacity * 0.035),
+              location: 0.34
+            ),
+            .init(
+              color: .white.opacity(materialOpacity * (0.08 + light * 0.05)),
+              location: 1
+            ),
+          ]),
+          startPoint: baseEdgeCenter,
+          endPoint: topEdgeCenter
+        ),
+        lineWidth: pass == .near ? 0.7 : 0.45
+      )
+    }
+
+    let topPath = polygonPath(top.map { $0.point })
+    let topBounds = topPath.boundingRect
+    let topColor: Color
+
+    switch pass {
+    case .far:
+      topColor = Color(red: 0.3, green: 0.36, blue: 0.47)
+    case .middle:
+      topColor = Color(red: 0.46, green: 0.54, blue: 0.65)
+    case .near:
+      topColor = Color(red: 0.62, green: 0.7, blue: 0.8)
+    }
+
+    context.fill(
+      topPath,
+      with: .linearGradient(
+        Gradient(colors: [
+          .white.opacity(materialOpacity * 0.24),
+          (colorsTowers ? tint : topColor).opacity(materialOpacity * 0.76),
+          tint.opacity(materialOpacity * (colorsTowers ? 0.48 : 0.14)),
+          .black.opacity(materialOpacity * 0.22),
+        ]),
+        startPoint: topBounds.origin,
+        endPoint: CGPoint(x: topBounds.maxX, y: topBounds.maxY)
+      )
+    )
+    context.stroke(
+      topPath,
+      with: .color(.white.opacity(materialOpacity * 0.13)),
+      lineWidth: pass == .near ? 0.75 : 0.5
+    )
+  }
+
+  func towerBaseCenter(
+    configuration: PlayStation2MenuTowerConfiguration,
+    growth: Double
+  ) -> PlayStation2MenuVector3 {
+    let radialDistance = max(
+      0.001,
+      hypot(configuration.center.x, configuration.center.y)
+    )
+    let inward = PlayStation2MenuVector3(
+      x: -configuration.center.x / radialDistance,
+      y: -configuration.center.y / radialDistance,
+      z: 0
+    )
+    let maximumShaftLength = radialDistance * (configuration.isInner ? 0.22 : 0.68)
+    let shaftLength = min(configuration.size.z * growth, maximumShaftLength)
+
+    return PlayStation2MenuVector3(
+      x: configuration.center.x + inward.x * shaftLength,
+      y: configuration.center.y + inward.y * shaftLength,
+      z: configuration.center.z - 0.1 - shaftLength * 0.18
+    )
+  }
+
+  func towerFaceCorners(
+    center: PlayStation2MenuVector3,
+    size: PlayStation2MenuVector3,
+    scale: Double,
+    rotation: PlayStation2MenuRotation,
+    camera: PlayStation2MenuCamera
+  ) -> [PlayStation2MenuProjection] {
+    let halfWidth = size.x * scale * 0.5
+    let halfHeight = size.y * scale * 0.5
+
+    return [
+      PlayStation2MenuVector3(x: -halfWidth, y: -halfHeight, z: 0),
+      PlayStation2MenuVector3(x: halfWidth, y: -halfHeight, z: 0),
+      PlayStation2MenuVector3(x: halfWidth, y: halfHeight, z: 0),
+      PlayStation2MenuVector3(x: -halfWidth, y: halfHeight, z: 0),
+    ].map { local in
+      camera.project(center + local.rotatedZ(rotation.z))
+    }
+  }
+
+  func averagedDepth(_ projections: [PlayStation2MenuProjection]) -> Double {
+    projections.reduce(0) { $0 + $1.depth } / Double(projections.count)
+  }
+
+  func drawTowerBaseClouds(
+    context: inout GraphicsContext,
+    camera: PlayStation2MenuCamera,
+    time: TimeInterval,
+    configurations: [PlayStation2MenuTowerConfiguration]
+  ) {
+    let bankCenter = camera.project(
+      PlayStation2MenuVector3(
+        x: -0.06 * camera.horizontalExtent,
+        y: 0.08 * camera.verticalExtent,
+        z: -0.08
+      )
+    ).point
+    let bankRect = CGRect(
+      x: bankCenter.x - camera.size.width * 0.31,
+      y: bankCenter.y - camera.size.height * 0.15,
+      width: camera.size.width * 0.62,
+      height: camera.size.height * 0.3
+    )
+
+    context.drawLayer { bank in
+      bank.addFilter(.blur(radius: 68))
+      bank.fill(
+        Path(ellipseIn: bankRect),
+        with: .color(Color(red: 0.08, green: 0.12, blue: 0.2).opacity(0.3))
+      )
+    }
+    context.drawLayer { bankGlow in
+      bankGlow.blendMode = .plusLighter
+      bankGlow.addFilter(.blur(radius: 84))
+      bankGlow.fill(
+        Path(ellipseIn: bankRect.insetBy(dx: bankRect.width * 0.08, dy: 0)),
+        with: .color(theme.sharedColor(index: 1, time: time).opacity(0.075))
+      )
+    }
+
+    let outerConfigurations =
+      configurations
+      .enumerated()
+      .filter { !$0.element.isInner }
+    let minimumDimension = min(camera.size.width, camera.size.height)
+
+    let cloudElements = outerConfigurations.map { entry in
+      let (index, configuration) = entry
+      let pulse =
+        1
+        + sin(time * configuration.pulseSpeed + configuration.phase)
+        * configuration.pulseAmount
+      let projected = camera.project(
+        towerBaseCenter(configuration: configuration, growth: pulse)
+      )
+      let seedA = DynamicBackgroundMath.seededUnit(index: index, salt: 37.11)
+      let seedB = DynamicBackgroundMath.seededUnit(index: index, salt: 79.63)
+      let drift = CGPoint(
+        x: CGFloat(sin(time * 0.012 + Double(index) * 1.7)) * 12,
+        y: CGFloat(cos(time * 0.01 + Double(index) * 1.3)) * 9
+      )
+      let width = minimumDimension * CGFloat(0.21 + seedA * 0.09)
+      let height = minimumDimension * CGFloat(0.09 + seedB * 0.055)
+      let rect = CGRect(
+        x: projected.point.x + drift.x - width / 2,
+        y: projected.point.y + drift.y - height / 2,
+        width: width,
+        height: height
+      )
+      let color =
+        index.isMultiple(of: 3)
+        ? theme.sharedColor(index: index + 1, time: time)
+        : theme.ribbonColor(index: index + 2, time: time)
+
+      return PlayStation2MenuCloudElement(
+        rect: rect,
+        glowRect: rect.insetBy(dx: width * 0.1, dy: height * 0.08),
+        color: color,
+        cloudOpacity: 0.28 + seedA * 0.12,
+        glowOpacity: 0.08 + seedB * 0.045
+      )
+    }
+
+    context.drawLayer { cloud in
+      cloud.addFilter(.blur(radius: 34))
+      for element in cloudElements {
+        cloud.fill(
+          Path(ellipseIn: element.rect),
+          with: .color(
+            Color(red: 0.16, green: 0.21, blue: 0.3)
+              .opacity(element.cloudOpacity)
+          )
+        )
+      }
+    }
+    context.drawLayer { glow in
+      glow.blendMode = .plusLighter
+      glow.addFilter(.blur(radius: 47))
+      for element in cloudElements {
+        glow.fill(
+          Path(ellipseIn: element.glowRect),
+          with: .color(element.color.opacity(element.glowOpacity))
+        )
+      }
+    }
+  }
+}
+
+// MARK: - PlayStation2MenuCrystalRenderer
+
+extension PlayStation2MenuBackground {
+  func drawCrystals(
+    context: inout GraphicsContext,
+    camera: PlayStation2MenuCamera,
+    time: TimeInterval,
+    pass: PlayStation2MenuDepthPass,
+    configurations: [PlayStation2MenuCrystalConfiguration]
+  ) {
+    for (index, configuration) in configurations.enumerated() {
+      guard pass.contains(configuration.center.z) else { continue }
+
+      drawCrystal(
+        context: &context,
+        camera: camera,
+        configuration: configuration,
+        time: time,
+        index: index,
+        pass: pass
+      )
+    }
+  }
+
+  func drawCrystal(
+    context: inout GraphicsContext,
+    camera: PlayStation2MenuCamera,
+    configuration: PlayStation2MenuCrystalConfiguration,
+    time: TimeInterval,
+    index: Int,
+    pass: PlayStation2MenuDepthPass
+  ) {
+    let rotation = PlayStation2MenuRotation(
+      x: configuration.phase + time * configuration.rotationSpeed * 0.68,
+      y: configuration.phase * 0.73 + time * configuration.rotationSpeed,
+      z: configuration.phase * 0.41 + time * configuration.rotationSpeed * 0.38
+    )
+    let half = PlayStation2MenuVector3(
+      x: configuration.side / 2,
+      y: configuration.side / 2,
+      z: configuration.side / 2
+    )
+    let projected = cuboidVertices(
+      center: configuration.center,
+      halfSize: half,
+      rotation: rotation,
+      camera: camera
+    )
+    let faces = PlayStation2MenuGeometry.cubeFaces.enumerated().sorted { lhs, rhs in
+      averageDepth(lhs.element, vertices: projected)
+        < averageDepth(rhs.element, vertices: projected)
+    }
+    let shared = theme.sharedColor(index: configuration.tintIndex, time: time)
+    let accent = theme.ribbonColor(index: configuration.tintIndex + 1, time: time)
+    let opacity: Double
+
+    switch pass {
+    case .far:
+      opacity = 0.1
+    case .middle:
+      opacity = 0.18
+    case .near:
+      opacity = 0.27
+    }
+
+    for (sortedIndex, faceEntry) in faces.enumerated() {
+      let faceIndex = faceEntry.offset
+      let face = faceEntry.element
+      let points = face.map { projected[$0].point }
+      let path = polygonPath(points)
+      let bounds = path.boundingRect
+      let depth = averageDepth(face, vertices: projected)
+      let sheen = 0.45 + max(-0.25, min(0.45, depth))
+
+      context.fill(
+        path,
+        with: .linearGradient(
+          Gradient(colors: [
+            .white.opacity(opacity * (0.24 + sheen * 0.2)),
+            shared.opacity(opacity * (0.42 + sheen * 0.18)),
+            accent.opacity(opacity * 0.5),
+            .black.opacity(opacity * 0.28),
+          ]),
+          startPoint: CGPoint(x: bounds.minX, y: bounds.minY),
+          endPoint: CGPoint(x: bounds.maxX, y: bounds.maxY)
+        )
+      )
+
+      let reflectiveFaceCount = pass == .far ? 2 : 3
+      if sortedIndex >= faces.count - reflectiveFaceCount {
+        let reflectionIdentity =
+          index * PlayStation2MenuGeometry.cubeFaces.count + faceIndex
+        drawCrystalCloudReflection(
+          context: &context,
+          clippingPath: path,
+          bounds: bounds,
+          time: time,
+          index: reflectionIdentity,
+          opacity: opacity
+        )
+        drawCrystalOrbReflections(
+          context: &context,
+          clippingPath: path,
+          bounds: bounds,
+          time: time,
+          index: reflectionIdentity,
+          reflectionCount: pass == .near ? 2 : 1,
+          opacity: opacity
+        )
+      }
+
+      if let first = points.first, points.count > 2 {
+        var facet = Path()
+        facet.move(to: first)
+        facet.addLine(to: averagedPoint(points))
+        facet.addLine(to: points[2])
+        facet.closeSubpath()
+        context.fill(
+          facet,
+          with: .color(.white.opacity(opacity * 0.055))
+        )
+      }
+
+      context.stroke(
+        path,
+        with: .color(.white.opacity(opacity * 0.7)),
+        lineWidth: pass == .near ? 1 : 0.65
+      )
+    }
+
+    context.drawLayer { facets in
+      facets.blendMode = .plusLighter
+      for edge in PlayStation2MenuGeometry.crystalCrossEdges {
+        var line = Path()
+        line.move(to: projected[edge.0].point)
+        line.addLine(to: projected[edge.1].point)
+        facets.stroke(
+          line,
+          with: .color(accent.opacity(opacity * 0.18)),
+          lineWidth: 0.55
+        )
+      }
+    }
+  }
+
+  func drawCrystalCloudReflection(
+    context: inout GraphicsContext,
+    clippingPath: Path,
+    bounds: CGRect,
+    time: TimeInterval,
+    index: Int,
+    opacity: Double
+  ) {
+    guard bounds.width > 5, bounds.height > 5 else { return }
+
+    let phase = time * (0.018 + Double(index % 4) * 0.004) + Double(index) * 1.37
+    let color = theme.sharedColor(index: index + 1, time: time)
+    let center = CGPoint(
+      x: bounds.midX + CGFloat(sin(phase)) * bounds.width * 0.31,
+      y: bounds.midY + CGFloat(cos(phase * 0.83)) * bounds.height * 0.24
+    )
+    let rect = CGRect(
+      x: center.x - bounds.width * 0.52,
+      y: center.y - bounds.height * 0.28,
+      width: bounds.width * 1.04,
+      height: bounds.height * 0.56
+    )
+
+    context.drawLayer { reflection in
+      reflection.clip(to: clippingPath)
+      reflection.blendMode = .plusLighter
+      reflection.addFilter(.blur(radius: max(7, min(28, bounds.width * 0.12))))
+      reflection.fill(
+        Path(ellipseIn: rect),
+        with: .color(color.opacity(opacity * 0.72))
+      )
+    }
+  }
+
+  func drawCrystalOrbReflections(
+    context: inout GraphicsContext,
+    clippingPath: Path,
+    bounds: CGRect,
+    time: TimeInterval,
+    index: Int,
+    reflectionCount: Int,
+    opacity: Double
+  ) {
+    guard bounds.width > 8, bounds.height > 8 else { return }
+
+    for reflectionIndex in 0..<reflectionCount {
+      let orbIndex = (index + reflectionIndex * 2) % 4
+      let color = theme.ribbonColor(index: orbIndex + 2, time: time)
+      let moment = time * (0.055 + Double(orbIndex) * 0.006) + Double(index) * 0.71
+      let yOffset = CGFloat(sin(moment + Double(reflectionIndex))) * bounds.height * 0.22
+      let start = CGPoint(
+        x: bounds.minX - bounds.width * 0.14,
+        y: bounds.midY + yOffset
+      )
+      let control = CGPoint(
+        x: bounds.midX + CGFloat(cos(moment * 0.77)) * bounds.width * 0.18,
+        y: bounds.midY - CGFloat(cos(moment)) * bounds.height * 0.42
+      )
+      let end = CGPoint(
+        x: bounds.maxX + bounds.width * 0.14,
+        y: bounds.midY - yOffset * 0.7
+      )
+      var reflectionPath = Path()
+      reflectionPath.move(to: start)
+      reflectionPath.addQuadCurve(to: end, control: control)
+
+      context.drawLayer { glow in
+        glow.clip(to: clippingPath)
+        glow.blendMode = .plusLighter
+        glow.addFilter(.blur(radius: 3.5))
+        glow.stroke(
+          reflectionPath,
+          with: .color(color.opacity(opacity * 0.95)),
+          style: StrokeStyle(lineWidth: 2.2, lineCap: .round)
+        )
+      }
+
+      context.drawLayer { reflection in
+        reflection.clip(to: clippingPath)
+        reflection.blendMode = .plusLighter
+        reflection.stroke(
+          reflectionPath,
+          with: .color(color.opacity(opacity * 1.25)),
+          style: StrokeStyle(lineWidth: 0.75, lineCap: .round)
+        )
+
+        let travelPhase =
+          time * (0.1 + Double(orbIndex) * 0.008)
+          + Double(index) * 0.43
+          + Double(reflectionIndex) * 1.4
+        let travel = 0.5 + sin(travelPhase) * 0.5
+        let orbPoint = quadraticPoint(
+          from: start,
+          control: control,
+          to: end,
+          progress: CGFloat(travel)
+        )
+        let diameter = max(2.2, min(5.5, bounds.width * 0.045))
+        reflection.fill(
+          Path(
+            ellipseIn: CGRect(
+              x: orbPoint.x - diameter / 2,
+              y: orbPoint.y - diameter / 2,
+              width: diameter,
+              height: diameter
+            )
+          ),
+          with: .color(.white.opacity(opacity * 2.1))
+        )
+      }
+    }
+  }
+}
+
+// MARK: - PlayStation2MenuOrbRenderer
+
+extension PlayStation2MenuBackground {
+  func drawOrbTrails(
+    context: inout GraphicsContext,
+    camera: PlayStation2MenuCamera,
+    time: TimeInterval,
+    pass: PlayStation2MenuDepthPass
+  ) {
+    for index in 0..<4 {
+      let configuration = orbConfiguration(index: index, camera: camera)
+      let moment = time * configuration.speed + configuration.phase
+      let headWorld = orbPoint(moment: moment, configuration: configuration)
+      let head = camera.project(headWorld)
+      let passVisibility = pass.visibility(at: head.depth)
+      guard passVisibility > 0.001 else { continue }
+
+      let samples = 42
+      let projections = (0...samples).map { sample in
+        let sampleMoment = moment - Double(samples - sample) * 0.027
+        return camera.project(
+          orbPoint(moment: sampleMoment, configuration: configuration)
+        )
+      }
+      let points = projections.map(\.point)
+      guard let tailPoint = points.first, let headPoint = points.last else {
+        continue
+      }
+      let color = theme.ribbonColor(index: index + 2, time: time)
+      var completePath = Path()
+      completePath.move(to: tailPoint)
+      let maximumTangentLength = min(camera.size.width, camera.size.height) * 0.08
+
+      for sample in 0..<(points.count - 1) {
+        let segment = OrbTrailGeometry.segment(
+          points: points,
+          index: sample,
+          maximumTangentLength: maximumTangentLength
+        )
+        completePath.addCurve(
+          to: segment.end,
+          control1: segment.control1,
+          control2: segment.control2
+        )
+      }
+
+      let normalizedDepth = max(0, min(1, (head.depth + 0.7) / 1.4))
+      let depthProgress = normalizedDepth * normalizedDepth * (3 - 2 * normalizedDepth)
+      let depthOpacity = 0.18 + depthProgress * 0.68
+      let renderedOpacity = depthOpacity * passVisibility
+      let baseWidth = 0.7 + CGFloat(depthProgress) * 0.65
+
+      context.drawLayer { glow in
+        glow.blendMode = .plusLighter
+        glow.addFilter(.blur(radius: CGFloat(4 + depthProgress * 2)))
+        glow.stroke(
+          completePath,
+          with: .linearGradient(
+            Gradient(stops: [
+              .init(color: .clear, location: 0),
+              .init(color: color.opacity(renderedOpacity * 0.04), location: 0.18),
+              .init(color: color.opacity(renderedOpacity * 0.2), location: 0.62),
+              .init(color: color.opacity(renderedOpacity * 0.46), location: 1),
+            ]),
+            startPoint: tailPoint,
+            endPoint: headPoint
+          ),
+          style: StrokeStyle(
+            lineWidth: baseWidth * 3,
+            lineCap: .round,
+            lineJoin: .round
+          )
+        )
+      }
+
+      context.drawLayer { trail in
+        trail.blendMode = .plusLighter
+        trail.stroke(
+          completePath,
+          with: .linearGradient(
+            Gradient(stops: [
+              .init(color: .clear, location: 0),
+              .init(color: color.opacity(renderedOpacity * 0.06), location: 0.16),
+              .init(color: color.opacity(renderedOpacity * 0.38), location: 0.58),
+              .init(color: color.opacity(renderedOpacity), location: 1),
+            ]),
+            startPoint: tailPoint,
+            endPoint: headPoint
+          ),
+          style: StrokeStyle(
+            lineWidth: baseWidth,
+            lineCap: .round,
+            lineJoin: .round
+          )
+        )
+      }
+
+      let diameter = (5.2 + CGFloat(depthProgress) * 2.3) * head.scale
+      let orbRect = CGRect(
+        x: head.point.x - diameter / 2,
+        y: head.point.y - diameter / 2,
+        width: diameter,
+        height: diameter
+      )
+
+      context.drawLayer { orb in
+        orb.blendMode = .plusLighter
+        orb.addFilter(
+          .shadow(color: color.opacity(renderedOpacity), radius: 10)
+        )
+        orb.fill(
+          Path(ellipseIn: orbRect),
+          with: .color(
+            .white.opacity((0.55 + depthOpacity * 0.45) * passVisibility)
+          )
+        )
+      }
+    }
+  }
+
+  func towerConfigurations(
+    camera: PlayStation2MenuCamera
+  ) -> [PlayStation2MenuTowerConfiguration] {
+    [
+      makeTower(
+        x: -0.82, y: -0.58, depth: 0.64,
+        width: 0.54, height: 0.54, shaft: 0.8,
+        angle: 0.012, phase: 0.2, camera: camera
+      ),
+      makeTower(
+        x: -0.84, y: -0.08, depth: 0.2,
+        width: 0.38, height: 0.38, shaft: 0.5,
+        angle: -0.018, phase: 1.1, camera: camera
+      ),
+      makeTower(
+        x: -0.82, y: 0.34, depth: 0.46,
+        width: 0.46, height: 0.46, shaft: 0.68,
+        angle: 0.01, phase: 2.05, camera: camera
+      ),
+      makeTower(
+        x: -0.42, y: -0.82, depth: 0.12,
+        width: 0.44, height: 0.44, shaft: 0.62,
+        angle: 0.016, phase: 4.0, camera: camera
+      ),
+      makeTower(
+        x: -0.04, y: -0.84, depth: -0.35,
+        width: 0.25, height: 0.25, shaft: 0.34,
+        angle: -0.012, phase: 4.8, camera: camera
+      ),
+      makeTower(
+        x: 0.72, y: -0.66, depth: 0.58,
+        width: 0.52, height: 0.52, shaft: 0.74,
+        angle: -0.016, phase: 5.7, camera: camera
+      ),
+      makeTower(
+        x: 0.84, y: 0.02, depth: 0.24,
+        width: 0.4, height: 0.4, shaft: 0.56,
+        angle: 0.012, phase: 6.5, camera: camera
+      ),
+      makeTower(
+        x: 0.24, y: 0.08, depth: -0.18,
+        width: 0.2, height: 0.2, shaft: 0.18,
+        angle: -0.01, phase: 7.1, camera: camera,
+        isShortTower: true
+      ),
+      makeTower(
+        x: 0.42, y: 0.34, depth: 0.06,
+        width: 0.26, height: 0.26, shaft: 0.22,
+        angle: 0.012, phase: 7.7, camera: camera,
+        isShortTower: true
+      ),
+      makeTower(
+        x: 0.58, y: 0.58, depth: 0.28,
+        width: 0.23, height: 0.23, shaft: 0.16,
+        angle: -0.014, phase: 8.3, camera: camera,
+        isShortTower: true
+      ),
+      makeTower(
+        x: 0.7, y: 0.82, depth: 0.4,
+        width: 0.29, height: 0.29, shaft: 0.24,
+        angle: 0.01, phase: 8.9, camera: camera,
+        isShortTower: true
+      ),
+      makeTower(
+        x: -0.46, y: 0.9, depth: 0.18,
+        width: 0.36, height: 0.36, shaft: 0.48,
+        angle: -0.012, phase: 8.2, camera: camera
+      ),
+      makeTower(
+        x: -0.08, y: 0.91, depth: -0.12,
+        width: 0.32, height: 0.32, shaft: 0.46,
+        angle: 0.014, phase: 9.1, camera: camera
+      ),
+    ]
+  }
+
+  func makeTower(
+    x: Double,
+    y: Double,
+    depth: Double,
+    width: Double,
+    height: Double,
+    shaft: Double,
+    angle: Double,
+    phase: Double,
+    camera: PlayStation2MenuCamera,
+    isInner: Bool = false,
+    isShortTower: Bool = false
+  ) -> PlayStation2MenuTowerConfiguration {
+    let variation = DynamicBackgroundMath.unit(abs(phase) * 0.37)
+
+    return PlayStation2MenuTowerConfiguration(
+      center: PlayStation2MenuVector3(
+        x: x * camera.horizontalExtent,
+        y: y * camera.verticalExtent,
+        z: depth
+      ),
+      size: PlayStation2MenuVector3(
+        x: width,
+        y: height,
+        z: shaft
+      ),
+      rotation: PlayStation2MenuRotation(
+        x: 0,
+        y: 0,
+        z: angle
+      ),
+      pulseSpeed: 0.04 + variation * 0.025,
+      pulseAmount: isShortTower
+        ? 0.028
+        : (isInner ? 0.025 : 0.035 + variation * 0.03),
+      phase: phase,
+      isInner: isInner
+    )
+  }
+
+  func crystalConfigurations(
+    camera: PlayStation2MenuCamera
+  ) -> [PlayStation2MenuCrystalConfiguration] {
+    let x = camera.horizontalExtent
+    let y = camera.verticalExtent
+
+    return [
+      PlayStation2MenuCrystalConfiguration(
+        center: PlayStation2MenuVector3(x: 0.08 * x, y: -0.3 * y, z: 0.16),
+        side: 0.38,
+        phase: 0.35,
+        rotationSpeed: 0.035,
+        tintIndex: 1
+      ),
+      PlayStation2MenuCrystalConfiguration(
+        center: PlayStation2MenuVector3(x: -0.62 * x, y: -0.18 * y, z: -0.18),
+        side: 0.23,
+        phase: 1.7,
+        rotationSpeed: 0.028,
+        tintIndex: 3
+      ),
+      PlayStation2MenuCrystalConfiguration(
+        center: PlayStation2MenuVector3(x: 0.68 * x, y: -0.58 * y, z: 0.28),
+        side: 0.28,
+        phase: 2.8,
+        rotationSpeed: 0.032,
+        tintIndex: 5
+      ),
+      PlayStation2MenuCrystalConfiguration(
+        center: PlayStation2MenuVector3(x: 0.76 * x, y: 0.03 * y, z: -0.34),
+        side: 0.2,
+        phase: 4.2,
+        rotationSpeed: 0.026,
+        tintIndex: 7
+      ),
+      PlayStation2MenuCrystalConfiguration(
+        center: PlayStation2MenuVector3(x: 0.82 * x, y: 0.67 * y, z: 0.72),
+        side: 0.44,
+        phase: 5.5,
+        rotationSpeed: 0.024,
+        tintIndex: 9
+      ),
+      PlayStation2MenuCrystalConfiguration(
+        center: PlayStation2MenuVector3(x: -0.8 * x, y: 0.66 * y, z: 0.58),
+        side: 0.36,
+        phase: 3.9,
+        rotationSpeed: 0.027,
+        tintIndex: 11
+      ),
+      PlayStation2MenuCrystalConfiguration(
+        center: PlayStation2MenuVector3(x: -0.73 * x, y: -0.68 * y, z: 0.42),
+        side: 0.27,
+        phase: 0.9,
+        rotationSpeed: 0.03,
+        tintIndex: 13
+      ),
+      PlayStation2MenuCrystalConfiguration(
+        center: PlayStation2MenuVector3(x: 0.18 * x, y: 0.62 * y, z: -0.62),
+        side: 0.18,
+        phase: 2.15,
+        rotationSpeed: 0.029,
+        tintIndex: 15
+      ),
+    ]
+  }
+
+  func orbConfiguration(
+    index: Int,
+    camera: PlayStation2MenuCamera
+  ) -> PlayStation2MenuOrbConfiguration {
+    let seedA = DynamicBackgroundMath.seededUnit(index: index, salt: 23.13)
+    let seedB = DynamicBackgroundMath.seededUnit(index: index, salt: 71.79)
+    let seedC = DynamicBackgroundMath.seededUnit(index: index, salt: 109.11)
+    let seedD = DynamicBackgroundMath.seededUnit(index: index, salt: 157.33)
+
+    return PlayStation2MenuOrbConfiguration(
+      center: PlayStation2MenuVector3(
+        x: (-0.22 + seedA * 0.44) * camera.horizontalExtent,
+        y: (-0.2 + seedB * 0.4) * camera.verticalExtent,
+        z: 0
+      ),
+      radiusX: camera.horizontalExtent * (0.46 + seedC * 0.36),
+      radiusY: camera.verticalExtent * (0.24 + seedD * 0.25),
+      bend: camera.verticalExtent * (0.08 + seedA * 0.13),
+      speed: 0.052 + seedB * 0.035,
+      phase: seedC * .pi * 2,
+      depthPhase: seedD * .pi * 2
+    )
+  }
+
+  func orbPoint(
+    moment: Double,
+    configuration: PlayStation2MenuOrbConfiguration
+  ) -> PlayStation2MenuVector3 {
+    PlayStation2MenuVector3(
+      x: configuration.center.x
+        + cos(moment) * configuration.radiusX
+        + sin(moment * 1.73 + configuration.depthPhase) * configuration.radiusX * 0.14,
+      y: configuration.center.y
+        + sin(moment * 0.78 + configuration.depthPhase * 0.2) * configuration.radiusY
+        + cos(moment * 0.43) * configuration.bend,
+      z: sin(moment * 0.83 + configuration.depthPhase) * 0.96
+    )
+  }
+
+  func cuboidVertices(
+    center: PlayStation2MenuVector3,
+    halfSize: PlayStation2MenuVector3,
+    rotation: PlayStation2MenuRotation,
+    camera: PlayStation2MenuCamera
+  ) -> [PlayStation2MenuProjection] {
+    [
+      PlayStation2MenuVector3(x: -halfSize.x, y: -halfSize.y, z: -halfSize.z),
+      PlayStation2MenuVector3(x: halfSize.x, y: -halfSize.y, z: -halfSize.z),
+      PlayStation2MenuVector3(x: halfSize.x, y: halfSize.y, z: -halfSize.z),
+      PlayStation2MenuVector3(x: -halfSize.x, y: halfSize.y, z: -halfSize.z),
+      PlayStation2MenuVector3(x: -halfSize.x, y: -halfSize.y, z: halfSize.z),
+      PlayStation2MenuVector3(x: halfSize.x, y: -halfSize.y, z: halfSize.z),
+      PlayStation2MenuVector3(x: halfSize.x, y: halfSize.y, z: halfSize.z),
+      PlayStation2MenuVector3(x: -halfSize.x, y: halfSize.y, z: halfSize.z),
+    ].map { local in
+      let rotated =
+        local
+        .rotatedX(rotation.x)
+        .rotatedY(rotation.y)
+        .rotatedZ(rotation.z)
+      return camera.project(center + rotated)
+    }
+  }
+
+  func averageDepth(
+    _ face: [Int],
+    vertices: [PlayStation2MenuProjection]
+  ) -> Double {
+    face.reduce(0) { $0 + vertices[$1].depth } / Double(face.count)
+  }
+
+  func polygonPath(_ points: [CGPoint]) -> Path {
+    var path = Path()
+    guard let first = points.first else { return path }
+
+    path.move(to: first)
+    for point in points.dropFirst() {
+      path.addLine(to: point)
+    }
+    path.closeSubpath()
+    return path
+  }
+
+  func averagedPoint(_ points: [CGPoint]) -> CGPoint {
+    guard !points.isEmpty else { return .zero }
+
+    let total = points.reduce(CGPoint.zero) { result, point in
+      CGPoint(x: result.x + point.x, y: result.y + point.y)
+    }
+    return CGPoint(
+      x: total.x / CGFloat(points.count),
+      y: total.y / CGFloat(points.count)
+    )
+  }
+
+  func quadraticPoint(
+    from start: CGPoint,
+    control: CGPoint,
+    to end: CGPoint,
+    progress: CGFloat
+  ) -> CGPoint {
+    let inverse = 1 - progress
+    return CGPoint(
+      x: inverse * inverse * start.x
+        + 2 * inverse * progress * control.x
+        + progress * progress * end.x,
+      y: inverse * inverse * start.y
+        + 2 * inverse * progress * control.y
+        + progress * progress * end.y
+    )
+  }
+}
+
+// MARK: - PlayStation3XMBMartGradient
+
+struct PlayStation3XMBMartGradient {
+  let startColor: Color
+  let endColor: Color
+  let angleDegrees: Double
+  let offsetX: Double
+  let offsetY: Double
+  let width: Double
+  let curvature: Double
+
+  init(
+    startColor: Color,
+    endColor: Color,
+    angleDegrees: Double,
+    offsetX: Double = 0,
+    offsetY: Double = 0,
+    width: Double = 1,
+    curvature: Double = 0
+  ) {
+    self.startColor = startColor
+    self.endColor = endColor
+    self.angleDegrees = angleDegrees
+    self.offsetX = offsetX
+    self.offsetY = offsetY
+    self.width = width
+    self.curvature = curvature
+  }
+
+  var stops: [Gradient.Stop] {
+    (0...12).map { index in
+      let progress = Double(index) / 12
+      let smoothProgress = progress * progress * (3 - 2 * progress)
+      return Gradient.Stop(
+        color: blend(startColor, endColor, amount: smoothProgress),
+        location: CGFloat(progress)
+      )
+    }
+  }
+
+  var startPoint: UnitPoint {
+    let direction = gradientDirection
+    let range = gradientRange(direction: direction)
+    let centerProjection = 0.5 * direction.x + 0.5 * direction.y
+    let offset = range.minimum - centerProjection
+    return UnitPoint(
+      x: CGFloat(0.5 + direction.x * offset),
+      y: CGFloat(0.5 + direction.y * offset)
+    )
+  }
+
+  var endPoint: UnitPoint {
+    let direction = gradientDirection
+    let range = gradientRange(direction: direction)
+    let centerProjection = 0.5 * direction.x + 0.5 * direction.y
+    let offset = range.maximum - centerProjection
+    return UnitPoint(
+      x: CGFloat(0.5 + direction.x * offset),
+      y: CGFloat(0.5 + direction.y * offset)
+    )
+  }
+
+  private var gradientDirection: (x: Double, y: Double) {
+    let radians = angleDegrees * .pi / 180
+    return (cos(radians), sin(radians))
+  }
+
+  private func gradientRange(
+    direction: (x: Double, y: Double)
+  ) -> (minimum: Double, maximum: Double) {
+    let projections = [
+      0,
+      direction.x,
+      direction.y,
+      direction.x + direction.y,
+    ]
+    return (projections.min() ?? 0, projections.max() ?? 1)
+  }
+
+  private func blend(_ first: Color, _ second: Color, amount: Double) -> Color {
+    let firstColor = UIColor(first)
+    let secondColor = UIColor(second)
+    var firstRed: CGFloat = 0
+    var firstGreen: CGFloat = 0
+    var firstBlue: CGFloat = 0
+    var firstAlpha: CGFloat = 0
+    var secondRed: CGFloat = 0
+    var secondGreen: CGFloat = 0
+    var secondBlue: CGFloat = 0
+    var secondAlpha: CGFloat = 0
+
+    guard
+      firstColor.getRed(
+        &firstRed,
+        green: &firstGreen,
+        blue: &firstBlue,
+        alpha: &firstAlpha
+      ),
+      secondColor.getRed(
+        &secondRed,
+        green: &secondGreen,
+        blue: &secondBlue,
+        alpha: &secondAlpha
+      )
+    else {
+      return amount < 0.5 ? first : second
+    }
+
+    return Color(
+      red: Double(firstRed + (secondRed - firstRed) * amount),
+      green: Double(firstGreen + (secondGreen - firstGreen) * amount),
+      blue: Double(firstBlue + (secondBlue - firstBlue) * amount),
+      opacity: Double(firstAlpha + (secondAlpha - firstAlpha) * amount)
+    )
+  }
+}
+
+struct PlayStation3XMBMartRGB {
+  let red: Double
+  let green: Double
+  let blue: Double
+
+  init(_ red: Int, _ green: Int, _ blue: Int) {
+    self.red = Double(red) / 255
+    self.green = Double(green) / 255
+    self.blue = Double(blue) / 255
+  }
+
+  var color: Color {
+    Color(red: red, green: green, blue: blue)
+  }
+}
+
+extension PlayStation3XMBGradientPreset {
+  var sourceGradient:
+    (angleDegrees: Double, start: PlayStation3XMBMartRGB, end: PlayStation3XMBMartRGB)
+  {
+    switch self {
+    case .theme, .original:
+      return (90, PlayStation3XMBMartRGB(3, 8, 24), PlayStation3XMBMartRGB(37, 89, 179))
+    case .januaryDay:
+      return (90.25, PlayStation3XMBMartRGB(197, 197, 197), PlayStation3XMBMartRGB(201, 201, 201))
+    case .januaryNight:
+      return (89.75, PlayStation3XMBMartRGB(181, 181, 181), PlayStation3XMBMartRGB(0, 0, 0))
+    case .februaryDay:
+      return (67, PlayStation3XMBMartRGB(203, 158, 13), PlayStation3XMBMartRGB(219, 214, 41))
+    case .februaryNight:
+      return (93.75, PlayStation3XMBMartRGB(198, 188, 128), PlayStation3XMBMartRGB(0, 0, 0))
+    case .marchDay:
+      return (106, PlayStation3XMBMartRGB(142, 190, 40), PlayStation3XMBMartRGB(104, 168, 22))
+    case .marchNight:
+      return (90.25, PlayStation3XMBMartRGB(152, 170, 113), PlayStation3XMBMartRGB(0, 0, 0))
+    case .aprilDay:
+      return (136.75, PlayStation3XMBMartRGB(216, 182, 182), PlayStation3XMBMartRGB(231, 66, 117))
+    case .aprilNight:
+      return (90.25, PlayStation3XMBMartRGB(212, 174, 182), PlayStation3XMBMartRGB(10, 8, 8))
+    case .mayDay:
+      return (1.5, PlayStation3XMBMartRGB(19, 108, 19), PlayStation3XMBMartRGB(24, 156, 24))
+    case .mayNight:
+      return (116, PlayStation3XMBMartRGB(48, 118, 48), PlayStation3XMBMartRGB(11, 3, 11))
+    case .juneDay:
+      return (148.75, PlayStation3XMBMartRGB(198, 120, 238), PlayStation3XMBMartRGB(103, 77, 161))
+    case .juneNight:
+      return (91, PlayStation3XMBMartRGB(209, 163, 225), PlayStation3XMBMartRGB(0, 0, 0))
+    case .julyDay:
+      return (26.5, PlayStation3XMBMartRGB(0, 167, 146), PlayStation3XMBMartRGB(10, 240, 239))
+    case .julyNight:
+      return (109.75, PlayStation3XMBMartRGB(16, 129, 124), PlayStation3XMBMartRGB(17, 0, 0))
+    case .augustDay:
+      return (62.5, PlayStation3XMBMartRGB(0, 0, 95), PlayStation3XMBMartRGB(33, 217, 255))
+    case .augustNight:
+      return (69.5, PlayStation3XMBMartRGB(20, 159, 176), PlayStation3XMBMartRGB(0, 0, 31))
+    case .septemberDay:
+      return (148.5, PlayStation3XMBMartRGB(146, 44, 155), PlayStation3XMBMartRGB(217, 98, 236))
+    case .septemberNight:
+      return (51, PlayStation3XMBMartRGB(116, 0, 153), PlayStation3XMBMartRGB(12, 0, 11))
+    case .octoberDay:
+      return (128.5, PlayStation3XMBMartRGB(227, 151, 15), PlayStation3XMBMartRGB(224, 187, 2))
+    case .octoberNight:
+      return (89.75, PlayStation3XMBMartRGB(216, 142, 0), PlayStation3XMBMartRGB(0, 0, 0))
+    case .novemberDay:
+      return (90, PlayStation3XMBMartRGB(115, 68, 20), PlayStation3XMBMartRGB(154, 118, 47))
+    case .novemberNight:
+      return (90, PlayStation3XMBMartRGB(131, 86, 32), PlayStation3XMBMartRGB(18, 20, 17))
+    case .decemberDay:
+      return (170.5, PlayStation3XMBMartRGB(236, 68, 45), PlayStation3XMBMartRGB(214, 63, 43))
+    case .decemberNight:
+      return (118.25, PlayStation3XMBMartRGB(157, 59, 44), PlayStation3XMBMartRGB(0, 0, 3))
+    }
+  }
+}
+
+// MARK: - PlayStation3XMBMartSplinePipeline
+
+// Direct Swift port of spline-reverse.js's synthetic descriptor and texture pipeline.
+final class PlayStation3XMBMartSplinePipeline {
+  private static let tableEntryCount = 0x169
+  private static let loopIterations = 8
+  private static let storesPerIteration = 8
+  static let textureWidth = 256
+  static let textureHeight = 64
+  private static let descriptorByteCount = 0x2200
+  private static let normA = [0.39584, -0.0052389996, -0.58664495, 0.189007]
+  private static let normB = [-0.003751, -0.57536095, 0.161975, 0.417137]
+  private static let registerWords = [0x00, 0x11, 0x22, 0x33]
+
+  private var cachedDescriptorSeed: Int?
+  private var descriptor = [UInt8](
+    repeating: 0,
+    count: PlayStation3XMBMartSplinePipeline.descriptorByteCount
+  )
+  private var runtimeInput = [Double](repeating: 0, count: 16)
+  private var coefficients = [Double](
+    repeating: 0,
+    count: PlayStation3XMBMartSplinePipeline.tableEntryCount * 16
+  )
+  private var table = [Double](
+    repeating: 0,
+    count: PlayStation3XMBMartSplinePipeline.tableEntryCount * 4
+  )
+  private var kernelPacked = [Double](
+    repeating: 0,
+    count: PlayStation3XMBMartSplinePipeline.loopIterations
+      * PlayStation3XMBMartSplinePipeline.storesPerIteration * 4
+  )
+  private var previousKernelPacked = [Double](
+    repeating: 0,
+    count: PlayStation3XMBMartSplinePipeline.loopIterations
+      * PlayStation3XMBMartSplinePipeline.storesPerIteration * 4
+  )
+  private var controlPoints = [Double](repeating: 0, count: 28)
+  private var displacement = [Double](
+    repeating: 0,
+    count: PlayStation3XMBMartSplinePipeline.textureWidth
+      * PlayStation3XMBMartSplinePipeline.textureHeight
+  )
+
+  func update(settings: PlayStation3XMBSettings, time: TimeInterval) {
+    buildRuntimeInputs(settings: settings)
+    buildDescriptor(settings: settings)
+    decodeCoefficients(settings: settings, time: time)
+    buildSplineTable(settings: settings)
+    runKernel(settings: settings, time: time)
+    writeDisplacementTexture(settings: settings, time: time)
+  }
+
+  func sample(u: Double, v: Double) -> Double {
+    let x = clamp(u, lower: 0, upper: 1) * Double(Self.textureWidth - 1)
+    let y = clamp(v, lower: 0, upper: 1) * Double(Self.textureHeight - 1)
+    let x0 = Int(floor(x))
+    let y0 = Int(floor(y))
+    let x1 = min(Self.textureWidth - 1, x0 + 1)
+    let y1 = min(Self.textureHeight - 1, y0 + 1)
+    let xBlend = x - floor(x)
+    let yBlend = y - floor(y)
+    let top = mix(
+      displacement[y0 * Self.textureWidth + x0],
+      displacement[y0 * Self.textureWidth + x1],
+      amount: xBlend
+    )
+    let bottom = mix(
+      displacement[y1 * Self.textureWidth + x0],
+      displacement[y1 * Self.textureWidth + x1],
+      amount: xBlend
+    )
+    return mix(top, bottom, amount: yBlend)
+  }
+
+  func copyDisplacement(into values: inout [Float]) {
+    if values.count != displacement.count {
+      values = Array(repeating: 0, count: displacement.count)
+    }
+    for index in displacement.indices {
+      values[index] = Float(displacement[index])
+    }
+  }
+
+  private func buildRuntimeInputs(settings: PlayStation3XMBSettings) {
+    runtimeInput[0] = settings.damping
+    runtimeInput[1] = settings.length
+    runtimeInput[2] = settings.tension
+    runtimeInput[3] = settings.spacing * 0.001
+    runtimeInput[4] = settings.waveCosineAmplitude
+    runtimeInput[5] = settings.waveBias
+    runtimeInput[6] = settings.timeStep
+    runtimeInput[7] = settings.perturbation
+    runtimeInput[8] = settings.perturbationScale
+    runtimeInput[9] = settings.flowSpeed
+    runtimeInput[10] = settings.ffdScale1X
+    runtimeInput[11] = settings.ffdScale2X
+    runtimeInput[12] = settings.ffdOffsetY
+    runtimeInput[13] = settings.fresnelScale
+    runtimeInput[14] = settings.waveHeightScale
+    runtimeInput[15] = 1
+  }
+
+  private func buildDescriptor(settings: PlayStation3XMBSettings) {
+    let seed = Int(settings.reverseSyntheticDescriptorSeed)
+    guard seed != cachedDescriptorSeed else { return }
+    cachedDescriptorSeed = seed
+
+    for index in descriptor.indices {
+      let fraction = Double(index) / Double(descriptor.count)
+      let wave =
+        sin((fraction * 97) * (0.3 + settings.length)) * 0.5
+        + sin((fraction * 211) * (0.15 + settings.tension * 3)) * 0.3
+        + sin((fraction * 17) * (0.2 + settings.perturbationScale * 2)) * 0.2
+      let noise = hash01(Double(index) * 13.37 + Double(seed) * 0.01) * 2 - 1
+      let value = clamp(
+        (wave * settings.reverseDescriptorStrength + noise * 0.35 + 1) * 0.5,
+        lower: 0,
+        upper: 1
+      )
+      descriptor[index] = UInt8(Int(value * 255))
+    }
+  }
+
+  private func decodeCoefficients(
+    settings: PlayStation3XMBSettings,
+    time: TimeInterval
+  ) {
+    let descriptorStride = 0x130
+    let phase =
+      time * settings.flowSpeed * settings.timeStep
+      * settings.reverseSyntheticDescriptorMotion
+
+    for entry in 0..<Self.tableEntryCount {
+      let entryBase = entry * 16
+      let descriptorBase = (entry * descriptorStride) % descriptor.count
+
+      for block in 0..<4 {
+        for lane in 0..<4 {
+          let byteIndex = (descriptorBase + block * 0x10 + lane * 4 + entry % 7) % descriptor.count
+          let byteValue = Double(descriptor[byteIndex]) / 255
+          let centered = byteValue * 2 - 1
+          let harmonic = sin(
+            Double(entry) * 0.07
+              + Double(block) * 0.91
+              + Double(lane) * 1.37
+              + phase * 0.23
+          )
+          coefficients[entryBase + block * 4 + lane] =
+            centered * 0.75 + harmonic * 0.25
+        }
+      }
+    }
+  }
+
+  private func buildSplineTable(settings: PlayStation3XMBSettings) {
+    for entry in 0..<Self.tableEntryCount {
+      let coefficientBase = entry * 16
+      let tableBase = entry * 4
+
+      for lane in 0..<4 {
+        let raw =
+          coefficients[coefficientBase + lane] * runtimeInput[0]
+          + coefficients[coefficientBase + 4 + lane] * runtimeInput[1]
+          + coefficients[coefficientBase + 8 + lane] * runtimeInput[2]
+          + coefficients[coefficientBase + 12 + lane] * runtimeInput[3]
+        let denominatorMagnitude = max(abs(Self.normB[lane]), 0.05)
+        let denominator =
+          Self.normB[lane] < 0
+          ? -denominatorMagnitude
+          : denominatorMagnitude
+        let normalized =
+          ((raw - Self.normA[lane]) / denominator)
+          * settings.reverseNormalizeGain
+        table[tableBase + lane] = tanh(normalized)
+      }
+    }
+  }
+
+  private func runKernel(
+    settings: PlayStation3XMBSettings,
+    time: TimeInterval
+  ) {
+    for iteration in 0..<Self.loopIterations {
+      let phase =
+        time * settings.reverseKernelPhaseStep
+        + Double(iteration) * 0.37
+      var indices = [Double](repeating: 0, count: 4)
+
+      for lane in 0..<4 {
+        let word = (Self.registerWords[lane] + iteration * 0x13) & 0xff
+        let baseIndex = tableIndex(from: word)
+        let offset =
+          sin(phase + Double(lane) * 0.77)
+          * settings.reverseIndexJitter * Double(Self.tableEntryCount)
+        indices[lane] = wrappedIndex(
+          Double(baseIndex) + offset,
+          length: Self.tableEntryCount
+        )
+      }
+
+      let value0 = sampleTableVector(at: indices[0])
+      let value1 = sampleTableVector(at: indices[1])
+      let value2 = sampleTableVector(at: indices[2])
+      let value3 = sampleTableVector(at: indices[3])
+      let mixA = 0.5 + 0.5 * sin(phase * 0.7)
+      let mixB = 0.5 + 0.5 * cos(phase * 0.9)
+      let mixed12 = mixVectors(value0, value1, amount: mixA)
+      let mixed13 = mixVectors(value1, value2, amount: mixB)
+      let mixed14 = mixVectors(value2, value3, amount: mixA)
+      let mixed15 = mixVectors(value3, value0, amount: mixB)
+      let delta9 = subtractVectors(value1, value0)
+      let delta4 = subtractVectors(value2, value1)
+      let delta87 = subtractVectors(value3, value2)
+      let delta89 = subtractVectors(value0, value3)
+      let stores = [
+        mixed12, mixed13, mixed14, mixed15,
+        delta9, delta4, delta87, delta89,
+      ]
+
+      for storeIndex in 0..<stores.count {
+        let packedBase = (iteration * Self.storesPerIteration + storeIndex) * 4
+        for lane in 0..<4 {
+          kernelPacked[packedBase + lane] = stores[storeIndex][lane]
+        }
+      }
+    }
+
+    let temporal = clamp(settings.reverseTemporalSmooth, lower: 0, upper: 0.999)
+    for index in kernelPacked.indices {
+      let smoothed =
+        previousKernelPacked[index] * temporal
+        + kernelPacked[index] * (1 - temporal)
+      kernelPacked[index] = smoothed
+      previousKernelPacked[index] = smoothed
+    }
+  }
+
+  private func writeDisplacementTexture(
+    settings: PlayStation3XMBSettings,
+    time: TimeInterval
+  ) {
+    let controlPointCount = controlPoints.count
+    let kernelVectorCount = Self.loopIterations * Self.storesPerIteration
+    let flow = time * settings.flowSpeed * settings.timeStep
+
+    for row in 0..<Self.textureHeight {
+      let depth = Double(row) / Double(max(1, Self.textureHeight - 1)) * 2 - 1
+      let rowBase = row * Self.textureWidth
+      let rowPhase = flow * 0.25 + depth * 1.7
+
+      for index in 0..<controlPointCount {
+        let x = Double(index) / Double(max(1, controlPointCount - 1))
+        let kernelPosition = Double(row) * 0.93 + Double(index) * 0.61 + flow * 0.35
+        let lowerVector = positiveModulo(
+          Int(floor(kernelPosition)),
+          kernelVectorCount
+        )
+        let upperVector = (lowerVector + 1) % kernelVectorCount
+        let vectorBlend = kernelPosition - floor(kernelPosition)
+        let lowerBase = lowerVector * 4
+        let upperBase = upperVector * 4
+        let kernelX = mix(
+          kernelPacked[lowerBase],
+          kernelPacked[upperBase],
+          amount: vectorBlend
+        )
+        let kernelY = mix(
+          kernelPacked[lowerBase + 1],
+          kernelPacked[upperBase + 1],
+          amount: vectorBlend
+        )
+        let kernelZ = mix(
+          kernelPacked[lowerBase + 2],
+          kernelPacked[upperBase + 2],
+          amount: vectorBlend
+        )
+        let kernelW = mix(
+          kernelPacked[lowerBase + 3],
+          kernelPacked[upperBase + 3],
+          amount: vectorBlend
+        )
+
+        let reverseCore =
+          (kernelX * 0.45
+            + kernelY * 0.25
+            + kernelZ * 0.2
+            + kernelW * 0.1) * settings.reverseKernelGain
+          + sin(rowPhase + x * 6.2) * settings.bandAmplitude
+          + cos(
+            depth * settings.bandSecondaryFrequency
+              + x * 4.8
+              + flow * 0.09
+          ) * settings.bandSecondaryAmplitude
+        let legacy =
+          sin(x * .pi * 1.3 + depth * 0.8 - flow * settings.travelSpeed1)
+          * settings.travelAmplitude1 * settings.tension
+          + sin(x * .pi * 2.8 - depth * 1.2 + flow * settings.travelSpeed2)
+          * settings.travelAmplitude2
+          + settings.perturbation * settings.perturbationScale
+          * sin(
+            (x * (4 + settings.length * 2) + depth * 4 - flow * 0.6)
+              * (settings.spacing * 0.01)
+          )
+        controlPoints[index] =
+          reverseCore * settings.reversePipelineBlend
+          + legacy * (1 - settings.reversePipelineBlend)
+      }
+
+      for xIndex in 0..<Self.textureWidth {
+        displacement[rowBase + xIndex] = evaluateSpline(
+          controlPoints: controlPoints,
+          position: Double(xIndex) / Double(max(1, Self.textureWidth - 1))
+        )
+      }
+    }
+  }
+
+  private func evaluateSpline(
+    controlPoints: [Double],
+    position: Double
+  ) -> Double {
+    let segmentCount = controlPoints.count - 3
+    guard segmentCount >= 1 else { return 0 }
+    let scaled = max(
+      0,
+      min(position * Double(segmentCount), Double(segmentCount) - 0.000_001)
+    )
+    let segment = Int(floor(scaled))
+    let local = scaled - Double(segment)
+    let squared = local * local
+    let cubed = squared * local
+    let basis = [
+      (1 - 3 * local + 3 * squared - cubed) / 6,
+      (4 - 6 * squared + 3 * cubed) / 6,
+      (1 + 3 * local + 3 * squared - 3 * cubed) / 6,
+      cubed / 6,
+    ]
+    return basis[0] * controlPoints[segment]
+      + basis[1] * controlPoints[segment + 1]
+      + basis[2] * controlPoints[segment + 2]
+      + basis[3] * controlPoints[segment + 3]
+  }
+
+  private func tableIndex(from word: Int) -> Int {
+    let high = (word >> 4) & 0xff
+    let low = word & 0xf
+    return (19 * high + low) % Self.tableEntryCount
+  }
+
+  private func wrappedIndex(_ value: Double, length: Int) -> Double {
+    var result = value.truncatingRemainder(dividingBy: Double(length))
+    if result < 0 {
+      result += Double(length)
+    }
+    return result
+  }
+
+  private func sampleTableVector(at index: Double) -> [Double] {
+    let lower = Int(floor(index)) % Self.tableEntryCount
+    let upper = (lower + 1) % Self.tableEntryCount
+    let blend = index - floor(index)
+    let lowerBase = lower * 4
+    let upperBase = upper * 4
+    return (0..<4).map { lane in
+      mix(
+        table[lowerBase + lane],
+        table[upperBase + lane],
+        amount: blend
+      )
+    }
+  }
+
+  private func mixVectors(
+    _ first: [Double],
+    _ second: [Double],
+    amount: Double
+  ) -> [Double] {
+    (0..<4).map { lane in
+      mix(first[lane], second[lane], amount: amount)
+    }
+  }
+
+  private func subtractVectors(
+    _ first: [Double],
+    _ second: [Double]
+  ) -> [Double] {
+    (0..<4).map { lane in first[lane] - second[lane] }
+  }
+
+  private func positiveModulo(_ value: Int, _ divisor: Int) -> Int {
+    ((value % divisor) + divisor) % divisor
+  }
+
+  private func hash01(_ value: Double) -> Double {
+    DynamicBackgroundMath.unit(sin(value) * 43_758.5453123)
+  }
+  private func mix(_ first: Double, _ second: Double, amount: Double) -> Double {
+    first + (second - first) * amount
+  }
+
+  private func clamp(_ value: Double, lower: Double, upper: Double) -> Double {
+    min(upper, max(lower, value))
+  }
+}
+
+// MARK: - PlayStation3XMBByMartMetalRenderer
+
+private struct XMBBackgroundUniforms {
+  var startColor: SIMD4<Float>
+  var endColor: SIMD4<Float>
+  var directionRange: SIMD4<Float>
+  var geometry: SIMD4<Float>
+}
+
+private struct XMBWaveUniforms {
+  var timing: SIMD4<Float>
+  var geometry: SIMD4<Float>
+  var shaping: SIMD4<Float>
+  var detail: SIMD4<Float>
+  var ffdScale1: SIMD4<Float>
+  var ffdScale2: SIMD4<Float>
+  var ffdOffset: SIMD4<Float>
+  var material: SIMD4<Float>
+  var color: SIMD4<Float>
+}
+
+private struct XMBParticleUniforms {
+  var timing: SIMD4<Float>
+  var sizing: SIMD4<Float>
+  var color: SIMD4<Float>
+  var distribution: SIMD4<Float>
+  var waveFollowing: SIMD4<Float>
+}
+
+private final class PlayStation3XMBMartMetalRenderer: NSObject, MTKViewDelegate {
+  private let renderMode: PlayStation3XMBMartRenderMode
+  private let commandQueue: MTLCommandQueue
+  private let backgroundPipeline: MTLRenderPipelineState
+  private let wavePipeline: MTLRenderPipelineState
+  private let particlePipeline: MTLRenderPipelineState
+  private let waveVertexBuffer: MTLBuffer
+  private let waveIndexBuffer: MTLBuffer
+  private let waveIndexCount: Int
+  private let splineTexture: MTLTexture
+  private let splinePipeline = PlayStation3XMBMartSplinePipeline()
+
+  private var settings = PlayStation3XMBSettings()
+  private var theme: DynamicBackgroundTheme?
+  private var particleControls = PlayStation3XMBMartParticleControls()
+  private var backgroundUniforms = XMBBackgroundUniforms(
+    startColor: SIMD4(0, 0, 0, 1),
+    endColor: SIMD4(0.1, 0.3, 0.7, 1),
+    directionRange: SIMD4(0, 1, 0, 1),
+    geometry: SIMD4(0, 0, 1, 0)
+  )
+  private var waveColor = SIMD4<Float>(1, 1, 1, 1)
+  private var particleBuffer: MTLBuffer?
+  private var particleCount = 0
+  private var displacementValues = [Float](
+    repeating: 0,
+    count: PlayStation3XMBMartSplinePipeline.textureWidth
+      * PlayStation3XMBMartSplinePipeline.textureHeight
+  )
+  private var splineTime: TimeInterval = 0
+  private var particleTime = Double.random(in: 0..<1000)
+  private var previousFrameTime: CFTimeInterval?
+
+  @MainActor
+  init?(view: MTKView, renderMode: PlayStation3XMBMartRenderMode) {
+    guard let device = view.device,
+      let commandQueue = device.makeCommandQueue(),
+      let library = PlayStation3XMBByMartShaderLibrary.makeLibrary(device: device),
+      let backgroundVertex = library.makeFunction(name: "xmbBackgroundVertex"),
+      let backgroundFragment = library.makeFunction(name: "xmbBackgroundFragment"),
+      let waveVertex = library.makeFunction(name: "xmbWaveVertex"),
+      let waveFragment = library.makeFunction(name: "xmbWaveFragment"),
+      let particleVertex = library.makeFunction(name: "xmbParticleVertex"),
+      let particleFragment = library.makeFunction(name: "xmbParticleFragment")
+    else {
+      return nil
+    }
+
+    let backgroundDescriptor = MTLRenderPipelineDescriptor()
+    backgroundDescriptor.vertexFunction = backgroundVertex
+    backgroundDescriptor.fragmentFunction = backgroundFragment
+    backgroundDescriptor.colorAttachments[0].pixelFormat = view.colorPixelFormat
+
+    let waveDescriptor = MTLRenderPipelineDescriptor()
+    waveDescriptor.vertexFunction = waveVertex
+    waveDescriptor.fragmentFunction = waveFragment
+    waveDescriptor.colorAttachments[0].pixelFormat = view.colorPixelFormat
+    waveDescriptor.colorAttachments[0].isBlendingEnabled = true
+    waveDescriptor.colorAttachments[0].sourceRGBBlendFactor = .sourceAlpha
+    waveDescriptor.colorAttachments[0].destinationRGBBlendFactor = .oneMinusSourceAlpha
+    waveDescriptor.colorAttachments[0].sourceAlphaBlendFactor = .one
+    waveDescriptor.colorAttachments[0].destinationAlphaBlendFactor = .oneMinusSourceAlpha
+
+    let particleDescriptor = MTLRenderPipelineDescriptor()
+    particleDescriptor.vertexFunction = particleVertex
+    particleDescriptor.fragmentFunction = particleFragment
+    particleDescriptor.colorAttachments[0].pixelFormat = view.colorPixelFormat
+    particleDescriptor.colorAttachments[0].isBlendingEnabled = true
+    particleDescriptor.colorAttachments[0].sourceRGBBlendFactor = .one
+    particleDescriptor.colorAttachments[0].destinationRGBBlendFactor = .one
+    particleDescriptor.colorAttachments[0].sourceAlphaBlendFactor = .one
+    particleDescriptor.colorAttachments[0].destinationAlphaBlendFactor = .one
+
+    guard
+      let backgroundPipeline = try? device.makeRenderPipelineState(
+        descriptor: backgroundDescriptor
+      ),
+      let wavePipeline = try? device.makeRenderPipelineState(
+        descriptor: waveDescriptor
+      ),
+      let particlePipeline = try? device.makeRenderPipelineState(
+        descriptor: particleDescriptor
+      )
+    else {
+      return nil
+    }
+
+    let grid = Self.makeWaveGrid(resolution: 100)
+    guard
+      let waveVertexBuffer = device.makeBuffer(
+        bytes: grid.vertices,
+        length: MemoryLayout<SIMD2<Float>>.stride * grid.vertices.count,
+        options: .storageModeShared
+      ),
+      let waveIndexBuffer = device.makeBuffer(
+        bytes: grid.indices,
+        length: MemoryLayout<UInt16>.stride * grid.indices.count,
+        options: .storageModeShared
+      )
+    else {
+      return nil
+    }
+
+    let textureDescriptor = MTLTextureDescriptor.texture2DDescriptor(
+      pixelFormat: .r32Float,
+      width: PlayStation3XMBMartSplinePipeline.textureWidth,
+      height: PlayStation3XMBMartSplinePipeline.textureHeight,
+      mipmapped: false
+    )
+    textureDescriptor.usage = .shaderRead
+    textureDescriptor.storageMode = .shared
+    guard let splineTexture = device.makeTexture(descriptor: textureDescriptor) else {
+      return nil
+    }
+
+    self.renderMode = renderMode
+    self.commandQueue = commandQueue
+    self.backgroundPipeline = backgroundPipeline
+    self.wavePipeline = wavePipeline
+    self.particlePipeline = particlePipeline
+    self.waveVertexBuffer = waveVertexBuffer
+    self.waveIndexBuffer = waveIndexBuffer
+    self.waveIndexCount = grid.indices.count
+    self.splineTexture = splineTexture
+    super.init()
+
+    rebuildParticles(device: device, count: Int(settings.particleCount))
+  }
+
+  func update(
+    settings: PlayStation3XMBSettings,
+    theme: DynamicBackgroundTheme,
+    particleControls: PlayStation3XMBMartParticleControls
+  ) {
+    self.settings = settings
+    self.theme = theme
+    self.particleControls = particleControls
+
+    let density =
+      renderMode == .particlesOnly
+      ? particleControls.amount
+      : settings.particleVerticalDensity
+    let desiredCount = Int(
+      min(
+        4000,
+        max(10, (settings.particleCount * density).rounded())
+      )
+    )
+    if desiredCount != particleCount {
+      rebuildParticles(device: commandQueue.device, count: desiredCount)
+    }
+  }
+
+  func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {}
+
+  func draw(in view: MTKView) {
+    let frameTime = CACurrentMediaTime()
+    if let previousFrameTime {
+      let delta = max(0, frameTime - previousFrameTime)
+      splineTime += delta
+      particleTime += delta
+    }
+    previousFrameTime = frameTime
+
+    if let theme {
+      let paletteTime = CFAbsoluteTimeGetCurrent()
+      if renderMode == .fullBackground {
+        let gradient = PlayStation3XMBMartThemeResolver.backgroundGradient(
+          theme: theme,
+          settings: settings,
+          time: paletteTime
+        )
+        backgroundUniforms = makeBackgroundUniforms(gradient: gradient)
+      }
+      waveColor = colorComponents(
+        theme.highlightColor(index: 0, time: paletteTime)
+      )
+    }
+
+    if renderMode != .particlesOnly {
+      splinePipeline.update(settings: settings, time: splineTime)
+      splinePipeline.copyDisplacement(into: &displacementValues)
+      displacementValues.withUnsafeBytes { bytes in
+        guard let baseAddress = bytes.baseAddress else { return }
+        splineTexture.replace(
+          region: MTLRegionMake2D(
+            0,
+            0,
+            PlayStation3XMBMartSplinePipeline.textureWidth,
+            PlayStation3XMBMartSplinePipeline.textureHeight
+          ),
+          mipmapLevel: 0,
+          withBytes: baseAddress,
+          bytesPerRow: MemoryLayout<Float>.stride
+            * PlayStation3XMBMartSplinePipeline.textureWidth
+        )
+      }
+    }
+
+    guard let descriptor = view.currentRenderPassDescriptor,
+      let drawable = view.currentDrawable,
+      let commandBuffer = commandQueue.makeCommandBuffer(),
+      let encoder = commandBuffer.makeRenderCommandEncoder(descriptor: descriptor)
+    else {
+      return
+    }
+
+    if renderMode == .fullBackground {
+      encodeBackground(encoder: encoder)
+    }
+    if renderMode != .particlesOnly {
+      encodeWave(encoder: encoder)
+    }
+    encodeParticles(encoder: encoder, drawableSize: view.drawableSize)
+    encoder.endEncoding()
+    commandBuffer.present(drawable)
+    commandBuffer.commit()
+  }
+
+  private func encodeBackground(encoder: MTLRenderCommandEncoder) {
+    var uniforms = backgroundUniforms
+    encoder.setRenderPipelineState(backgroundPipeline)
+    encoder.setFragmentBytes(
+      &uniforms,
+      length: MemoryLayout<XMBBackgroundUniforms>.stride,
+      index: 0
+    )
+    encoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
+  }
+
+  private func encodeWave(encoder: MTLRenderCommandEncoder) {
+    var uniforms = makeWaveUniforms()
+
+    encoder.setRenderPipelineState(wavePipeline)
+    encoder.setCullMode(.none)
+    encoder.setVertexBuffer(waveVertexBuffer, offset: 0, index: 0)
+    encoder.setVertexBytes(
+      &uniforms,
+      length: MemoryLayout<XMBWaveUniforms>.stride,
+      index: 1
+    )
+    encoder.setFragmentBytes(
+      &uniforms,
+      length: MemoryLayout<XMBWaveUniforms>.stride,
+      index: 1
+    )
+    encoder.setVertexTexture(splineTexture, index: 0)
+    encoder.drawIndexedPrimitives(
+      type: .triangleStrip,
+      indexCount: waveIndexCount,
+      indexType: .uint16,
+      indexBuffer: waveIndexBuffer,
+      indexBufferOffset: 0
+    )
+  }
+
+  private func encodeParticles(
+    encoder: MTLRenderCommandEncoder,
+    drawableSize: CGSize
+  ) {
+    guard particleCount > 0, let particleBuffer else { return }
+    let rendersParticleOverlay = renderMode == .particlesOnly
+    let aspect = Float(drawableSize.width / max(1, drawableSize.height))
+    let ratio = max(1, min(aspect, 2)) * 0.375
+    var particleColor = waveColor
+    particleColor.w =
+      rendersParticleOverlay
+      ? Float(particleControls.depthVariation)
+      : Float(settings.particleDepthVariation)
+    var uniforms = XMBParticleUniforms(
+      timing: SIMD4(
+        Float(particleTime),
+        Float(settings.particleFlowSpeed * particleControls.speed),
+        ratio,
+        Float(
+          settings.particleOpacity
+            * particleControls.brightness
+            * particleControls.opacity
+        )
+      ),
+      sizing: SIMD4(
+        Float(settings.particleSizeBase),
+        Float(settings.particleSizeVariance),
+        rendersParticleOverlay ? Float(1.5 * particleControls.size) : 1,
+        rendersParticleOverlay
+          ? Float(1 - particleControls.verticalLevel * 2)
+          : 0
+      ),
+      color: particleColor,
+      distribution: SIMD4(
+        rendersParticleOverlay
+          ? Float(particleControls.direction * 2)
+          : 0,
+        rendersParticleOverlay
+          ? Float(particleControls.dispersion * particleControls.verticalSpread)
+          : Float(settings.particleVerticalSpread),
+        rendersParticleOverlay ? 1 : 0,
+        rendersParticleOverlay
+          ? Float(particleControls.outerDispersion)
+          : Float(settings.particleOuterDispersion)
+      ),
+      waveFollowing: SIMD4(
+        !rendersParticleOverlay && settings.particlesFollowWaveY ? 1 : 0,
+        renderMode == .foregroundOnly ? 1 : 0,
+        0,
+        0
+      )
+    )
+    var waveUniforms = makeWaveUniforms()
+
+    encoder.setRenderPipelineState(particlePipeline)
+    encoder.setVertexBuffer(particleBuffer, offset: 0, index: 0)
+    encoder.setVertexBytes(
+      &uniforms,
+      length: MemoryLayout<XMBParticleUniforms>.stride,
+      index: 1
+    )
+    encoder.setVertexBytes(
+      &waveUniforms,
+      length: MemoryLayout<XMBWaveUniforms>.stride,
+      index: 2
+    )
+    encoder.setVertexTexture(splineTexture, index: 0)
+    encoder.setFragmentBytes(
+      &uniforms,
+      length: MemoryLayout<XMBParticleUniforms>.stride,
+      index: 1
+    )
+    encoder.drawPrimitives(
+      type: .point,
+      vertexStart: 0,
+      vertexCount: particleCount
+    )
+  }
+
+  private func makeWaveUniforms() -> XMBWaveUniforms {
+    XMBWaveUniforms(
+      timing: SIMD4(
+        Float(splineTime),
+        Float(settings.flowSpeed),
+        Float(settings.tension),
+        Float(settings.damping)
+      ),
+      geometry: SIMD4(
+        Float(settings.length),
+        Float(settings.spacing),
+        Float(settings.perturbation),
+        Float(settings.perturbationScale)
+      ),
+      shaping: SIMD4(
+        Float(settings.timeStep),
+        Float(settings.waveCosineAmplitude),
+        Float(settings.waveBias),
+        Float(settings.waveHeightScale)
+      ),
+      detail: SIMD4(
+        Float(settings.waveSoftClip),
+        Float(settings.ffdYAmplitude),
+        Float(settings.ffdZAmplitude),
+        Float(settings.zDetailScale)
+      ),
+      ffdScale1: SIMD4(
+        Float(settings.ffdScale1X),
+        Float(settings.ffdScale1Y),
+        Float(settings.ffdScale1Z),
+        0
+      ),
+      ffdScale2: SIMD4(
+        Float(settings.ffdScale2X),
+        Float(settings.ffdScale2Y),
+        Float(settings.ffdScale2Z),
+        0
+      ),
+      ffdOffset: SIMD4(
+        Float(settings.ffdOffsetX),
+        Float(settings.ffdOffsetY),
+        Float(settings.ffdOffsetZ),
+        0
+      ),
+      material: SIMD4(
+        Float(settings.opacity),
+        Float(settings.brightness),
+        Float(settings.fresnelPower),
+        Float(settings.fresnelScale)
+      ),
+      color: waveColor
+    )
+  }
+
+  private func rebuildParticles(device: MTLDevice, count: Int) {
+    var generator = SystemRandomNumberGenerator()
+    let seeds = (0..<count).map { _ in
+      SIMD3<Float>(
+        Float.random(in: 0..<1, using: &generator),
+        Float.random(in: 0..<1, using: &generator),
+        pow(Float.random(in: 0..<1, using: &generator), 8) + 0.1
+      )
+    }
+    particleBuffer = device.makeBuffer(
+      bytes: seeds,
+      length: MemoryLayout<SIMD3<Float>>.stride * seeds.count,
+      options: .storageModeShared
+    )
+    particleCount = count
+  }
+
+  private func makeBackgroundUniforms(
+    gradient: PlayStation3XMBMartGradient
+  ) -> XMBBackgroundUniforms {
+    let radians = Float(gradient.angleDegrees * .pi / 180)
+    let direction = SIMD2<Float>(cos(radians), sin(radians))
+    let projections: [Float] = [
+      0,
+      direction.x,
+      direction.y,
+      direction.x + direction.y,
+    ]
+    let minimum = projections.min() ?? 0
+    let maximum = projections.max() ?? 1
+    return XMBBackgroundUniforms(
+      startColor: colorComponents(gradient.startColor),
+      endColor: colorComponents(gradient.endColor),
+      directionRange: SIMD4(
+        direction.x,
+        direction.y,
+        minimum,
+        max(0.000_001, maximum - minimum)
+      ),
+      geometry: SIMD4(
+        Float(gradient.offsetX),
+        Float(gradient.offsetY),
+        Float(max(0.05, gradient.width)),
+        Float(min(1, max(-1, gradient.curvature)))
+      )
+    )
+  }
+
+  private func colorComponents(_ color: Color) -> SIMD4<Float> {
+    let uiColor = UIColor(color)
+    var red: CGFloat = 0
+    var green: CGFloat = 0
+    var blue: CGFloat = 0
+    var alpha: CGFloat = 0
+    guard uiColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
+      return SIMD4(1, 1, 1, 1)
+    }
+    return SIMD4(Float(red), Float(green), Float(blue), Float(alpha))
+  }
+
+  private static func makeWaveGrid(
+    resolution: Int
+  ) -> (vertices: [SIMD2<Float>], indices: [UInt16]) {
+    let strips = resolution - 1
+    let verticesPerStrip = resolution * 2
+    var vertices: [SIMD2<Float>] = []
+    vertices.reserveCapacity(strips * verticesPerStrip)
+
+    for y in 0..<strips {
+      for x in 0..<resolution {
+        let horizontal = Float(x) / Float(resolution - 1) * 2 - 1
+        vertices.append(
+          SIMD2(
+            horizontal,
+            Float(y + 1) / Float(resolution - 1) * 2 - 1
+          )
+        )
+        vertices.append(
+          SIMD2(
+            horizontal,
+            Float(y) / Float(resolution - 1) * 2 - 1
+          )
+        )
+      }
+    }
+
+    var indices: [UInt16] = []
+    indices.reserveCapacity(strips * (verticesPerStrip + 2) - 2)
+    var base = 0
+    for strip in 0..<strips {
+      if strip > 0 {
+        indices.append(UInt16(base - 1))
+        indices.append(UInt16(base))
+      }
+      for index in 0..<verticesPerStrip {
+        indices.append(UInt16(base + index))
+      }
+      base += verticesPerStrip
+    }
+    return (vertices, indices)
+  }
+}
+
+// MARK: - PlayStation3XMBMartMetalSurface
+
+enum PlayStation3XMBMartRenderMode: Equatable {
+  case fullBackground
+  case foregroundOnly
+  case particlesOnly
+}
+
+struct PlayStation3XMBMartParticleControls {
+  var amount = 1.0
+  var speed = 1.0
+  var direction = 0.0
+  var dispersion = 1.0
+  var verticalSpread = 1.0
+  var outerDispersion = 0.0
+  var verticalLevel = 0.5
+  var size = 1.0
+  var brightness = 1.0
+  var opacity = 1.0
+  var depthVariation = 0.0
+}
+
+struct PlayStation3XMBMartMetalSurface: UIViewRepresentable {
+  let settings: PlayStation3XMBSettings
+  let theme: DynamicBackgroundTheme
+  var renderMode: PlayStation3XMBMartRenderMode = .fullBackground
+  var particleControls = PlayStation3XMBMartParticleControls()
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(renderMode: renderMode)
+  }
+
+  func makeUIView(context: Context) -> MTKView {
+    let view = MTKView(frame: .zero, device: MTLCreateSystemDefaultDevice())
+    view.colorPixelFormat = .bgra8Unorm
+    let rendersTransparentSurface = renderMode != .fullBackground
+    view.clearColor = MTLClearColor(
+      red: 0,
+      green: 0,
+      blue: 0,
+      alpha: rendersTransparentSurface ? 0 : 1
+    )
+    view.framebufferOnly = true
+    view.autoResizeDrawable = true
+    view.preferredFramesPerSecond = 30
+    view.enableSetNeedsDisplay = false
+    view.isPaused = false
+    view.isOpaque = !rendersTransparentSurface
+    view.layer.isOpaque = !rendersTransparentSurface
+    view.backgroundColor = .clear
+    context.coordinator.attach(to: view)
+    context.coordinator.renderer?.update(
+      settings: settings,
+      theme: theme,
+      particleControls: particleControls
+    )
+    return view
+  }
+
+  func updateUIView(_ view: MTKView, context: Context) {
+    context.coordinator.renderer?.update(
+      settings: settings,
+      theme: theme,
+      particleControls: particleControls
+    )
+  }
+
+  static func dismantleUIView(_ view: MTKView, coordinator: Coordinator) {
+    view.delegate = nil
+    view.isPaused = true
+    view.enableSetNeedsDisplay = true
+    view.releaseDrawables()
+    coordinator.detach()
+    view.device = nil
+  }
+
+  final class Coordinator {
+    fileprivate var renderer: PlayStation3XMBMartMetalRenderer?
+    private let renderMode: PlayStation3XMBMartRenderMode
+    private var retainsShaderLibrary = false
+
+    init(renderMode: PlayStation3XMBMartRenderMode) {
+      self.renderMode = renderMode
+    }
+
+    @MainActor
+    func attach(to view: MTKView) {
+      guard renderer == nil else { return }
+      guard let renderer = PlayStation3XMBMartMetalRenderer(view: view, renderMode: renderMode) else {
+        PlayStation3XMBByMartShaderLibrary.releaseIfUnused()
+        return
+      }
+      self.renderer = renderer
+      PlayStation3XMBByMartShaderLibrary.retainForRenderer()
+      retainsShaderLibrary = true
+      view.delegate = renderer
+    }
+
+    @MainActor
+    func detach() {
+      renderer = nil
+      guard retainsShaderLibrary else {
+        PlayStation3XMBByMartShaderLibrary.releaseIfUnused()
+        return
+      }
+      retainsShaderLibrary = false
+      PlayStation3XMBByMartShaderLibrary.releaseForRenderer()
+    }
+  }
+}
+
+// MARK: - PlayStation3XMBByMartBackground
+
+// Native SwiftUI adaptation of Mart's MIT-licensed PlayStation 3 XMB recreation.
+struct PlayStation3XMBByMartBackground: View {
+  let theme: DynamicBackgroundTheme
+
+  @ViewBuilder
+  var body: some View {
+    if usesPlayStation4PaletteBackdrop {
+      ZStack {
+        PlayStation4WavesBackground(theme: theme, showsWaves: false)
+
+        PlayStation3XMBMartMetalSurface(
+          settings: settings,
+          theme: theme,
+          renderMode: .foregroundOnly
+        )
+      }
+      .ignoresSafeArea()
+      .accessibilityHidden(true)
+    } else {
+      PlayStation3XMBMartMetalSurface(
+        settings: settings,
+        theme: theme
+      )
+      .ignoresSafeArea()
+      .accessibilityHidden(true)
+    }
+  }
+
+  private var settings: PlayStation3XMBSettings {
+    theme.particleSettings.playStation3XMB
+  }
+
+  private var usesPlayStation4PaletteBackdrop: Bool {
+    settings.gradientPreset == .theme && theme.usesDynamicSharedPalette
+  }
+}
+
+private enum PlayStation3XMBMartThemeResolver {
+  static func backgroundGradient(
+    theme: DynamicBackgroundTheme,
+    settings: PlayStation3XMBSettings,
+    time: TimeInterval
+  ) -> PlayStation3XMBMartGradient {
+    if settings.gradientPreset == .theme {
+      return PlayStation3XMBMartGradient(
+        startColor: themedGradientColor(
+          theme.sharedColor(index: 0, time: time),
+          theme: theme,
+          multiplier: settings.gradientTopMul,
+          blueMultiplier: 1.2
+        ),
+        endColor: themedGradientColor(
+          theme.sharedColor(index: 2, time: time),
+          theme: theme,
+          multiplier: settings.gradientBotMul
+        ),
+        angleDegrees: 90 + theme.sharedPaletteGradientTilt,
+        offsetX: theme.particleSettings.sharedPaletteGradientOffsetX,
+        offsetY: theme.particleSettings.sharedPaletteGradientOffsetY,
+        width: theme.particleSettings.sharedPaletteGradientWidth,
+        curvature: theme.sharedPaletteGradientCurvature
+      )
+    }
+
+    if settings.gradientPreset == .original {
+      let original = Color(
+        red: settings.colorR / 255,
+        green: settings.colorG / 255,
+        blue: settings.colorB / 255
+      )
+      return PlayStation3XMBMartGradient(
+        startColor: scaledColor(
+          original,
+          multiplier: settings.gradientTopMul,
+          blueMultiplier: 1.2
+        ),
+        endColor: scaledColor(original, multiplier: settings.gradientBotMul),
+        angleDegrees: 90 + theme.sharedPaletteGradientTilt,
+        offsetX: theme.particleSettings.sharedPaletteGradientOffsetX,
+        offsetY: theme.particleSettings.sharedPaletteGradientOffsetY,
+        width: theme.particleSettings.sharedPaletteGradientWidth,
+        curvature: theme.sharedPaletteGradientCurvature
+      )
+    }
+
+    let preset = settings.gradientPreset.sourceGradient
+    return PlayStation3XMBMartGradient(
+      startColor: preset.start.color,
+      endColor: preset.end.color,
+      angleDegrees: preset.angleDegrees + theme.sharedPaletteGradientTilt,
+      offsetX: theme.particleSettings.sharedPaletteGradientOffsetX,
+      offsetY: theme.particleSettings.sharedPaletteGradientOffsetY,
+      width: theme.particleSettings.sharedPaletteGradientWidth,
+      curvature: theme.sharedPaletteGradientCurvature
+    )
+  }
+
+  private static func themedGradientColor(
+    _ color: Color,
+    theme: DynamicBackgroundTheme,
+    multiplier: Double,
+    blueMultiplier: Double = 1
+  ) -> Color {
+    let brightenedColor = scaledColor(
+      color,
+      multiplier: max(1, multiplier),
+      blueMultiplier: blueMultiplier
+    )
+    return theme.paletteBackgroundColor(
+      brightenedColor,
+      darkness: max(0, 1 - multiplier)
+    )
+  }
+
+  private static func scaledColor(
+    _ color: Color,
+    multiplier: Double,
+    blueMultiplier: Double = 1
+  ) -> Color {
+    let uiColor = UIColor(color)
+    var red: CGFloat = 0
+    var green: CGFloat = 0
+    var blue: CGFloat = 0
+    var alpha: CGFloat = 0
+
+    guard uiColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
+      return color.opacity(DynamicBackgroundMath.clamp(multiplier, to: 0...1))
+    }
+
+    return Color(
+      red: DynamicBackgroundMath.clamp(Double(red) * multiplier, to: 0...1),
+      green: DynamicBackgroundMath.clamp(Double(green) * multiplier, to: 0...1),
+      blue: DynamicBackgroundMath.clamp(
+        Double(blue) * multiplier * blueMultiplier,
+        to: 0...1
+      ),
+      opacity: Double(alpha)
+    )
+  }
+
+}
+
+// MARK: - FaceButtonsBackground
+
+struct FaceButtonsBackground: View {
+  let theme: DynamicBackgroundTheme
+  var showsBackdrop = true
+  var showsLightBands = true
+
+  var body: some View {
+    TimelineView(.animation(minimumInterval: 1 / 30)) { timeline in
+      let time = timeline.date.timeIntervalSinceReferenceDate
+      let motionTime =
+        time
+        * settings.faceButtonSpeed
+        * settings.backgrounds.faceButtonsSpeed
+      let deepColor = theme.sharedColor(index: 0, time: time)
+      let midColor = theme.sharedColor(index: 1, time: time)
+      let lightColor = theme.sharedColor(index: 2, time: time)
+      let sharedGradient = theme.sharedGradientPoints(
+        from: .topLeading,
+        to: .bottomTrailing
+      )
+
+      ZStack {
+        if showsBackdrop {
+          PaletteGradientField(
+            colors: [
+              theme.paletteBackgroundColor(deepColor, darkness: 0.96),
+              theme.paletteBackgroundColor(deepColor, darkness: 0.54),
+              theme.paletteBackgroundColor(midColor, darkness: 0.66),
+              theme.paletteBackgroundColor(midColor, darkness: 0.94),
+            ],
+            startPoint: sharedGradient.start,
+            endPoint: sharedGradient.end,
+            curvature: theme.sharedPaletteGradientCurvature
+          )
+
+          Circle()
+            .fill(lightColor.opacity(0.18))
+            .frame(width: 780, height: 780)
+            .blur(radius: 160)
+            .offset(
+              x: CGFloat(sin(motionTime * 0.24)) * 90,
+              y: CGFloat(cos(motionTime * 0.18)) * 70
+            )
+        }
+
+        Canvas { context, size in
+          if showsLightBands && settings.backgrounds.faceButtonsShowsLightBands {
+            drawWeavingLightBands(
+              context: &context,
+              size: size,
+              motionTime: motionTime,
+              colorTime: time
+            )
+          }
+          drawFaceButtonField(
+            context: &context,
+            size: size,
+            motionTime: motionTime,
+            colorTime: time
+          )
+        }
+
+        if showsBackdrop {
+          LinearGradient(
+            colors: [
+              theme.paletteDarkOverlay(opacity: 0.18),
+              .clear,
+              theme.paletteDarkOverlay(opacity: 0.38),
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+          )
+        }
+      }
+      .ignoresSafeArea()
+    }
+  }
+
+  private var settings: DynamicParticleSettings {
+    theme.particleSettings
+  }
+
+  // Draws soft sine-wave paths that the face symbols appear to weave through.
+  private func drawWeavingLightBands(
+    context: inout GraphicsContext,
+    size: CGSize,
+    motionTime: TimeInterval,
+    colorTime: TimeInterval
+  ) {
+    for bandIndex in 0..<5 {
+      var path = Path()
+      let steps = 52
+      let baseY = size.height * CGFloat(0.2 + Double(bandIndex) * 0.14)
+      let amplitude = size.height * CGFloat(0.035 + Double(bandIndex % 2) * 0.018)
+      let phase =
+        motionTime * (0.18 + Double(bandIndex) * 0.025)
+        + Double(bandIndex) * 1.24
+
+      for step in 0...steps {
+        let progress = CGFloat(step) / CGFloat(steps)
+        let x = size.width * progress
+        let y =
+          baseY
+          + sin(Double(progress) * .pi * 3.4 + phase) * amplitude
+          + cos(Double(progress) * .pi * 1.6 - phase * 0.7) * amplitude * 0.45
+        let point = CGPoint(x: x, y: y)
+
+        if step == 0 {
+          path.move(to: point)
+        } else {
+          path.addLine(to: point)
+        }
+      }
+
+      let color = theme.ribbonColor(index: bandIndex, time: colorTime)
+      context.drawLayer { glow in
+        glow.addFilter(.blur(radius: 16))
+        glow.stroke(
+          path,
+          with: .color(color.opacity(0.12)),
+          style: StrokeStyle(lineWidth: 14, lineCap: .round, lineJoin: .round)
+        )
+      }
+      context.stroke(
+        path,
+        with: .color(color.opacity(0.3)),
+        style: StrokeStyle(lineWidth: 0.9, lineCap: .round, lineJoin: .round)
+      )
+    }
+  }
+
+  // Draws face-button symbols with falling, weaving, looping, and drifting motion.
+  private func drawFaceButtonField(
+    context: inout GraphicsContext,
+    size: CGSize,
+    motionTime: TimeInterval,
+    colorTime: TimeInterval
+  ) {
+    context.blendMode = .plusLighter
+
+    let symbolCount = min(180, max(0, Int(72 * settings.faceButtonAmount)))
+    for index in 0..<symbolCount {
+      let color =
+        index.isMultiple(of: 6)
+        ? theme.highlightColor(index: index, time: colorTime)
+        : theme.ribbonColor(index: index, time: colorTime)
+      let center = symbolCenter(index: index, size: size, time: motionTime)
+      let side = symbolSide(index: index, size: size, time: motionTime)
+      let rotation = symbolRotation(index: index, time: motionTime)
+      let opacity = (index.isMultiple(of: 5) ? 0.78 : 0.46) * settings.faceButtonOpacity
+
+      drawFaceButtonSymbol(
+        context: &context,
+        kind: symbolKind(for: index),
+        center: center,
+        side: side,
+        rotation: rotation,
+        color: color,
+        opacity: opacity
+      )
+    }
+  }
+
+  // Draws one PlayStation face-button outline with glow and a faint inner fill.
+  private func drawFaceButtonSymbol(
+    context: inout GraphicsContext,
+    kind: FaceButtonSymbol,
+    center: CGPoint,
+    side: CGFloat,
+    rotation: Double,
+    color: Color,
+    opacity: Double
+  ) {
+    let lineWidth = max(1.2, side * 0.07)
+    let path: Path
+
+    switch kind {
+    case .square:
+      path = polygonPath(
+        sides: 4, center: center, radius: side * 0.56, rotation: rotation + .pi / 4)
+    case .cross:
+      path = crossPath(center: center, radius: side * 0.52, rotation: rotation)
+    case .circle:
+      path = Path(
+        ellipseIn: CGRect(
+          x: center.x - side * 0.45,
+          y: center.y - side * 0.45,
+          width: side * 0.9,
+          height: side * 0.9
+        )
+      )
+    case .triangle:
+      path = polygonPath(sides: 3, center: center, radius: side * 0.6, rotation: rotation - .pi / 2)
+    }
+
+    if kind != .cross {
+      context.fill(path, with: .color(color.opacity(opacity * 0.08)))
+    }
+
+    context.drawLayer { glow in
+      glow.addFilter(.shadow(color: color.opacity(0.78), radius: 8))
+      glow.stroke(
+        path,
+        with: .color(color.opacity(opacity)),
+        style: StrokeStyle(lineWidth: lineWidth, lineCap: .round, lineJoin: .round)
+      )
+    }
+
+    context.stroke(
+      path,
+      with: .color(.white.opacity(opacity * 0.24)),
+      style: StrokeStyle(lineWidth: max(0.6, lineWidth * 0.42), lineCap: .round, lineJoin: .round)
+    )
+  }
+
+  private func symbolKind(for index: Int) -> FaceButtonSymbol {
+    switch index % 4 {
+    case 0:
+      return .square
+    case 1:
+      return .cross
+    case 2:
+      return .circle
+    default:
+      return .triangle
+    }
+  }
+
+  // Chooses one of several deterministic motion styles for each symbol.
+  private func symbolCenter(index: Int, size: CGSize, time: TimeInterval) -> CGPoint {
+    let seedA = DynamicBackgroundMath.seededUnit(index: index, salt: 12.9898)
+    let seedB = DynamicBackgroundMath.seededUnit(index: index, salt: 78.233)
+    let seedC = DynamicBackgroundMath.seededUnit(index: index, salt: 37.719)
+    let spread = settings.faceButtonDispersion
+    let width = Double(size.width)
+    let height = Double(size.height)
+
+    switch index % 5 {
+    case 0:
+      let progress = DynamicBackgroundMath.unit(seedC + time * (0.025 + seedA * 0.03))
+      let x =
+        width * (0.08 + seedA * 0.84)
+        + sin(time * 1.05 + seedB * 12) * width * 0.075 * spread
+      let y = -height * 0.12 + progress * height * 1.24
+      return CGPoint(x: CGFloat(x), y: CGFloat(y))
+    case 1:
+      let progress = DynamicBackgroundMath.unit(seedA + time * (0.012 + seedC * 0.016))
+      let x =
+        -width * 0.08
+        + progress * width * 1.16
+        + cos(time * 0.34 + seedB * 10) * width * 0.055 * spread
+      let y =
+        height * (0.18 + seedB * 0.64)
+        + sin(progress * .pi * 3.2 + seedC * 8) * height * 0.08 * spread
+      return CGPoint(x: CGFloat(x), y: CGFloat(y))
+    case 2:
+      let progress = DynamicBackgroundMath.unit(seedB + time * (0.018 + seedA * 0.014))
+      let x = width * progress
+      let y =
+        height * (0.18 + seedC * 0.62)
+        + sin(time * 0.9 + progress * .pi * 4 + seedA * 8) * height * 0.08 * spread
+      return CGPoint(x: CGFloat(x), y: CGFloat(y))
+    case 3:
+      let radiusX = width * (0.14 + seedA * 0.22) * spread
+      let radiusY = height * (0.11 + seedB * 0.18) * spread
+      let x = width * 0.5 + sin(time * (0.22 + seedC * 0.16) + seedA * .pi * 2) * radiusX
+      let y = height * 0.48 + cos(time * (0.28 + seedA * 0.16) + seedB * .pi * 2) * radiusY
+      return CGPoint(x: CGFloat(x), y: CGFloat(y))
+    default:
+      let progress = DynamicBackgroundMath.unit(seedA - time * (0.02 + seedB * 0.018))
+      let x =
+        width * (0.12 + seedC * 0.76)
+        + cos(time * 0.72 + seedA * 16) * width * 0.1 * spread
+      let y = -height * 0.1 + progress * height * 1.22
+      return CGPoint(x: CGFloat(x), y: CGFloat(y))
+    }
+  }
+
+  private func symbolSide(index: Int, size: CGSize, time: TimeInterval) -> CGFloat {
+    let seed = DynamicBackgroundMath.seededUnit(index: index, salt: 19.119)
+    let base =
+      min(size.width, size.height)
+      * CGFloat(0.032 + seed * 0.042)
+      * 0.5
+      * CGFloat(settings.faceButtonSize)
+    let pulse =
+      1
+      + CGFloat(sin(time * (0.65 + seed) + seed * 9))
+      * 0.08
+      * CGFloat(settings.faceButtonPulse)
+    return min(58, max(8, base * pulse))
+  }
+
+  private func symbolRotation(index: Int, time: TimeInterval) -> Double {
+    let seed = DynamicBackgroundMath.seededUnit(index: index, salt: 91.733)
+    let direction = index.isMultiple(of: 2) ? 1.0 : -1.0
+    return seed * .pi * 2 + time * (0.28 + seed * 0.46) * direction * settings.faceButtonRotation
+  }
+
+  private func polygonPath(
+    sides: Int,
+    center: CGPoint,
+    radius: CGFloat,
+    rotation: Double
+  ) -> Path {
+    var path = Path()
+
+    for vertexIndex in 0..<sides {
+      let angle = rotation + Double(vertexIndex) * (.pi * 2 / Double(sides))
+      let point = CGPoint(
+        x: center.x + CGFloat(cos(angle)) * radius,
+        y: center.y + CGFloat(sin(angle)) * radius
+      )
+
+      if vertexIndex == 0 {
+        path.move(to: point)
+      } else {
+        path.addLine(to: point)
+      }
+    }
+
+    path.closeSubpath()
+    return path
+  }
+
+  private func crossPath(
+    center: CGPoint,
+    radius: CGFloat,
+    rotation: Double
+  ) -> Path {
+    var path = Path()
+    let points = [
+      (CGPoint(x: -radius, y: -radius), CGPoint(x: radius, y: radius)),
+      (CGPoint(x: radius, y: -radius), CGPoint(x: -radius, y: radius)),
+    ]
+
+    for segment in points {
+      path.move(to: rotatedPoint(segment.0, around: center, rotation: rotation))
+      path.addLine(to: rotatedPoint(segment.1, around: center, rotation: rotation))
+    }
+
+    return path
+  }
+
+  private func rotatedPoint(
+    _ offset: CGPoint,
+    around center: CGPoint,
+    rotation: Double
+  ) -> CGPoint {
+    CGPoint(
+      x: center.x + offset.x * CGFloat(cos(rotation)) - offset.y * CGFloat(sin(rotation)),
+      y: center.y + offset.x * CGFloat(sin(rotation)) + offset.y * CGFloat(cos(rotation))
+    )
+  }
+}
+
+private enum FaceButtonSymbol: Equatable {
+  case square
+  case cross
+  case circle
+  case triangle
+}
+
+// MARK: - PlayStationPortableBlurBackground
+
+struct PlayStationPortableBlurBackground: View {
+  let theme: DynamicBackgroundTheme
+
+  var body: some View {
+    TimelineView(.animation(minimumInterval: 1 / 30)) { timeline in
+      let time =
+        timeline.date.timeIntervalSinceReferenceDate
+        * theme.particleSettings.backgrounds.playStationPortableBlurSpeed
+      let settings = theme.particleSettings.backgrounds.playStationPortableBlur
+      let base = theme.sharedColor(index: 1, time: time)
+      let accent = theme.ribbonColor(index: 1, time: time)
+      let shadow = theme.sharedColor(index: 0, time: time)
+      let glow = theme.sharedColor(index: 2, time: time)
+      let sharedGradient = theme.sharedGradientPoints(
+        from: .topLeading,
+        to: .bottomTrailing
+      )
+
+      ZStack {
+        PaletteGradientField(
+          colors: [
+            theme.paletteBackgroundColor(
+              shadow,
+              darkness: 1 - min(1, settings.backgroundIntensity)
+            ),
+            theme.paletteBackgroundColor(
+              base,
+              darkness: 1 - min(1, settings.backgroundIntensity)
+            ),
+            theme.paletteBackgroundColor(
+              accent,
+              darkness: 1 - min(1, 0.74 * settings.backgroundIntensity)
+            ),
+            theme.paletteBackgroundColor(
+              glow,
+              darkness: 1 - min(1, 0.82 * settings.backgroundIntensity)
+            ),
+          ],
+          startPoint: sharedGradient.start,
+          endPoint: sharedGradient.end,
+          curvature: theme.sharedPaletteGradientCurvature
+        )
+
+        RadialGradient(
+          colors: [
+            theme.highlightColor(index: 4, time: time)
+              .opacity(0.34 * settings.ambientGlowIntensity),
+            .clear,
+          ],
+          center: .center,
+          startRadius: 10,
+          endRadius: 430 * settings.ambientGlowScale
+        )
+
+        if settings.showsRibbons {
+          Canvas { context, size in
+            let ribbonCount = max(1, Int(settings.ribbonCount.rounded()))
+            for index in 0..<ribbonCount {
+              drawRibbon(
+                context: &context,
+                size: size,
+                time: time,
+                index: index
+              )
+            }
+          }
+        }
+
+        LinearGradient(
+          colors: [
+            theme.paletteDarkOverlay(
+              opacity: 0.12 * settings.vignetteIntensity
+            ),
+            .clear,
+            theme.paletteDarkOverlay(
+              opacity: 0.18 * settings.vignetteIntensity
+            ),
+          ],
+          startPoint: .top,
+          endPoint: .bottom
+        )
+      }
+      .ignoresSafeArea()
+    }
+  }
+
+  // Draws one XMB ribbon with a blurred glow and a thin bright core.
+  private func drawRibbon(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval,
+    index: Int
+  ) {
+    let path = ribbonPath(size: size, time: time, index: index)
+    let broadWidth = CGFloat(14 + (index % 4) * 7) * CGFloat(settings.broadWidth)
+    let brightness = 0.14 + Double(index % 3) * 0.045
+    let ribbonColor =
+      index.isMultiple(of: 3)
+      ? theme.ribbonColor(index: index, time: time)
+      : theme.highlightColor(index: index, time: time)
+    let coreColor = theme.highlightColor(index: index + 4, time: time)
+
+    if settings.showsGlow {
+      context.drawLayer { glow in
+        glow.blendMode = .plusLighter
+        glow.addFilter(
+          .blur(
+            radius: (9 + CGFloat(index % 3) * 4) * CGFloat(settings.glowBlur)
+          )
+        )
+        glow.stroke(
+          path,
+          with: .color(ribbonColor.opacity(brightness * settings.glowOpacity)),
+          style: StrokeStyle(
+            lineWidth: broadWidth,
+            lineCap: .round,
+            lineJoin: .round
+          )
+        )
+      }
+    }
+
+    if settings.showsCores {
+      context.drawLayer { core in
+        core.blendMode = .plusLighter
+        core.addFilter(
+          .blur(
+            radius: (2.4 + CGFloat(index % 2)) * CGFloat(settings.coreBlur)
+          )
+        )
+        core.stroke(
+          path,
+          with: .color(
+            coreColor.opacity(
+              (0.16 + Double(index % 3) * 0.035) * settings.coreOpacity
+            )
+          ),
+          style: StrokeStyle(
+            lineWidth: (2.2 + CGFloat(index % 3) * 0.7)
+              * CGFloat(settings.coreWidth),
+            lineCap: .round,
+            lineJoin: .round
+          )
+        )
+      }
+    }
+  }
+
+  // Builds a smooth multi-point XMB wave path across the screen.
+  private func ribbonPath(
+    size: CGSize,
+    time: TimeInterval,
+    index: Int
+  ) -> Path {
+    let basePositions: [CGFloat] = [
+      0.58, 0.62, 0.67, 0.7, 0.73, 0.76, 0.64,
+    ]
+    let amplitudes: [CGFloat] = [
+      0.12, 0.095, 0.07, 0.045, 0.035, 0.055, 0.085,
+    ]
+    let profileIndex = index % basePositions.count
+    let direction = settings.alternatesDirection && !index.isMultiple(of: 2) ? -1.0 : 1.0
+    let phase =
+      time * (0.12 + Double(index) * 0.011) * direction
+      + Double(index) * 0.63 * settings.phaseSpread
+
+    let points = (0...28).map { step in
+      let progress = CGFloat(step) / 28
+      let progressValue = Double(progress)
+      let longWave = sin(progressValue * 2.15 + phase)
+      let secondaryWave = sin(
+        progressValue * 4.4 - phase * 0.52 + Double(index) * 0.37
+      )
+      let y =
+        size.height * (basePositions[profileIndex] + CGFloat(settings.verticalOffset))
+        + size.height * amplitudes[profileIndex] * CGFloat(settings.waveAmplitude)
+        * CGFloat(longWave)
+        + size.height * 0.018 * CGFloat(settings.detailAmplitude)
+        * CGFloat(secondaryWave)
+
+      return CGPoint(
+        x: -size.width * 0.08 + progress * size.width * 1.16,
+        y: y
+      )
+    }
+
+    return DynamicBackgroundGeometry.smoothCurve(through: points)
+  }
+
+  private var settings: PlayStationPortableBlurSettings {
+    theme.particleSettings.backgrounds.playStationPortableBlur
+  }
+}
+
+// MARK: - PlayStation3SplinesBackground
+
+enum PlayStationRibbonSizing {
+  case playStation3
+  case playStation4
+}
+
+struct PlayStation3SplinesBackground: View {
+  let theme: DynamicBackgroundTheme
+  let ribbonSizing: PlayStationRibbonSizing
+
+  var body: some View {
+    TimelineView(.animation(minimumInterval: 1 / 30)) { timeline in
+      let time =
+        timeline.date.timeIntervalSinceReferenceDate
+        * theme.particleSettings.backgrounds.playStation3SplinesSpeed
+      let settings = theme.particleSettings.backgrounds.playStation3Splines
+      let dark = theme.sharedColor(index: 0, time: time)
+      let primary = theme.sharedColor(index: 1, time: time)
+      let ribbonPrimary = theme.ribbonColor(index: 1, time: time)
+      let highlight = theme.ribbonColor(index: 2, time: time)
+      let sharedGradient = theme.sharedGradientPoints(
+        from: .topLeading,
+        to: .bottomTrailing
+      )
+
+      ZStack {
+        PaletteGradientField(
+          colors: [
+            theme.paletteBackgroundColor(
+              dark,
+              darkness: 1 - min(1, 0.58 * settings.backgroundIntensity)
+            ),
+            theme.paletteBackgroundColor(
+              primary,
+              darkness: 1 - min(1, 0.7 * settings.backgroundIntensity)
+            ),
+            theme.paletteBackgroundColor(
+              primary,
+              darkness: 1 - min(1, 0.46 * settings.backgroundIntensity)
+            ),
+            theme.paletteBackgroundColor(
+              highlight,
+              darkness: 1 - min(1, 0.24 * settings.backgroundIntensity)
+            ),
+          ],
+          startPoint: sharedGradient.start,
+          endPoint: sharedGradient.end,
+          curvature: theme.sharedPaletteGradientCurvature
+        )
+
+        RadialGradient(
+          colors: [
+            highlight.opacity(0.16 * settings.backgroundIntensity),
+            primary.opacity(0.08 * settings.backgroundIntensity),
+            .clear,
+          ],
+          center: .bottomTrailing,
+          startRadius: 8,
+          endRadius: 520
+        )
+
+        Canvas { context, size in
+          if settings.showsParticles {
+            drawParticles(
+              context: &context,
+              size: size,
+              time: time,
+              color: highlight
+            )
+          }
+          if settings.showsSplines {
+            drawSplineBundle(
+              context: &context,
+              size: size,
+              time: time,
+              primary: ribbonPrimary,
+              highlight: highlight
+            )
+          }
+        }
+
+        LinearGradient(
+          colors: [
+            theme.paletteDarkOverlay(
+              opacity: 0.12 * settings.vignetteIntensity
+            ),
+            .clear,
+            theme.paletteDarkOverlay(
+              opacity: 0.18 * settings.vignetteIntensity
+            ),
+          ],
+          startPoint: .top,
+          endPoint: .bottom
+        )
+      }
+      .ignoresSafeArea()
+    }
+  }
+
+  // Draws the XMB3 ribbon bundle; XMB4 reuses it with PS4-sized stroke widths.
+  private func drawSplineBundle(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval,
+    primary: Color,
+    highlight: Color
+  ) {
+    let strandCount = max(1, Int(settings.strandCount.rounded()))
+
+    for index in 0..<strandCount {
+      let path = splinePath(size: size, time: time, index: index)
+      let fade = 1 - Double(index) / Double(strandCount + 4)
+      let color = index.isMultiple(of: 4) ? highlight : primary
+      let widths = ribbonStrokeWidths(index: index)
+
+      context.drawLayer { glow in
+        glow.blendMode = .plusLighter
+        glow.addFilter(
+          .blur(radius: ribbonGlowBlur(index: index) * CGFloat(settings.glowBlur))
+        )
+        glow.stroke(
+          path,
+          with: .color(color.opacity(fade * 0.075 * settings.glowOpacity)),
+          style: StrokeStyle(
+            lineWidth: widths.glow * CGFloat(settings.glowWidth),
+            lineCap: .round,
+            lineJoin: .round
+          )
+        )
+      }
+
+      context.drawLayer { strand in
+        strand.blendMode = .plusLighter
+        strand.stroke(
+          path,
+          with: .color(
+            index.isMultiple(of: 5)
+              ? theme.highlightColor(index: index + 8, time: time)
+                .opacity(fade * 0.58 * settings.coreOpacity)
+              : color.opacity(fade * 0.3 * settings.coreOpacity)
+          ),
+          style: StrokeStyle(
+            lineWidth: widths.core * CGFloat(settings.coreWidth),
+            lineCap: .round,
+            lineJoin: .round
+          )
+        )
+      }
+    }
+  }
+
+  // Draws small twinkling particles around the spline bundle.
+  private func drawParticles(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval,
+    color: Color
+  ) {
+    context.blendMode = .plusLighter
+
+    let particleCount = max(0, Int(settings.particleCount.rounded()))
+    let particleTime = time * settings.particleSpeed
+
+    for index in 0..<particleCount {
+      let seed = DynamicBackgroundMath.unit(sin(Double(index + 1) * 12.9898) * 43_758.5453)
+      let secondarySeed = DynamicBackgroundMath.unit(
+        sin(Double(index + 7) * 78.233) * 9_631.417
+      )
+      let speed = 0.006 + Double(index % 7) * 0.0011
+      let progress = DynamicBackgroundMath.unit(seed + particleTime * speed)
+      let x = CGFloat(progress) * size.width
+      let waveCenter =
+        size.height
+        * (CGFloat(settings.verticalPosition) + 0.02
+          + 0.095
+          * CGFloat(
+            sin(progress * .pi * 2.1 - particleTime * 0.11 + seed * 5)
+          ))
+      let spread =
+        (CGFloat(secondarySeed) - 0.5)
+        * size.height
+        * (0.18 + CGFloat(seed) * 0.2)
+        * CGFloat(settings.particleSpread)
+      let y =
+        waveCenter + spread
+        + CGFloat(sin(particleTime * 0.24 + seed * 18)) * 7
+        * CGFloat(settings.particleSpread)
+      let twinkle = pow(
+        max(
+          0,
+          sin(particleTime * settings.particleTwinkle * (0.9 + seed) + secondarySeed * 14)
+        ),
+        3
+      )
+      let diameter =
+        (CGFloat(0.7 + Double(index % 5) * 0.34)
+          + CGFloat(twinkle) * 1.35) * CGFloat(settings.particleSize)
+      let rect = CGRect(
+        x: x - diameter / 2,
+        y: y - diameter / 2,
+        width: diameter,
+        height: diameter
+      )
+
+      context.fill(
+        Path(ellipseIn: rect),
+        with: .color(
+          index.isMultiple(of: 8)
+            ? .white.opacity((0.35 + twinkle * 0.5) * settings.particleOpacity)
+            : color.opacity((0.12 + twinkle * 0.28) * settings.particleOpacity)
+        )
+      )
+    }
+  }
+
+  // Builds one animated XMB3 spline from sampled sine waves.
+  private func splinePath(
+    size: CGSize,
+    time: TimeInterval,
+    index: Int
+  ) -> Path {
+    let strand = Double(index)
+    let direction = index.isMultiple(of: 3) ? -1.0 : 1.0
+    let phase =
+      time * (0.1 + strand * 0.0025) * direction
+      + strand * 0.24 * settings.phaseSpread
+    let centeredIndex =
+      CGFloat(index) - CGFloat(max(0, Int(settings.strandCount.rounded()) - 1)) / 2
+    let baseY =
+      size.height
+      * (CGFloat(settings.verticalPosition)
+        + centeredIndex * 0.0095 * CGFloat(settings.strandSpacing))
+    let amplitude =
+      size.height
+      * (0.09 + CGFloat(index % 4) * 0.008)
+      * CGFloat(settings.waveAmplitude)
+
+    let points = (0...32).map { step in
+      let progress = CGFloat(step) / 32
+      let progressValue = Double(progress)
+      let primaryWave = sin(progressValue * .pi * 2.05 + phase)
+      let detailWave = sin(
+        progressValue * .pi * 4.1 - phase * 0.44 + strand * 0.33
+      )
+      let y =
+        baseY
+        + amplitude * CGFloat(primaryWave)
+        + size.height * 0.018 * CGFloat(settings.detailAmplitude) * CGFloat(detailWave)
+
+      return CGPoint(
+        x: -size.width * 0.08 + progress * size.width * 1.16,
+        y: y
+      )
+    }
+
+    return DynamicBackgroundGeometry.smoothCurve(through: points)
+  }
+
+  // Chooses the glow and core widths for XMB3 or the wider XMB4 variant.
+  private func ribbonStrokeWidths(index: Int) -> (glow: CGFloat, core: CGFloat) {
+    switch ribbonSizing {
+    case .playStation3:
+      return (
+        glow: 11 + CGFloat(index % 5) * 2.8,
+        core: 0.55 + CGFloat(index % 4) * 0.34
+      )
+    case .playStation4:
+      let waveIndex = index % 8
+      return (
+        glow: CGFloat(20 - waveIndex),
+        core: CGFloat(0.7 + Double(7 - waveIndex) * 0.4)
+      )
+    }
+  }
+
+  // Matches the blur radius to the selected ribbon size profile.
+  private func ribbonGlowBlur(index: Int) -> CGFloat {
+    switch ribbonSizing {
+    case .playStation3:
+      return 10 + CGFloat(index % 4) * 2.5
+    case .playStation4:
+      return 18
+    }
+  }
+
+  // Converts any floating value into a stable 0...1 seed.
+  private var settings: PlayStation3SplinesSettings {
+    theme.particleSettings.backgrounds.playStation3Splines
+  }
+}
+
+// MARK: - PlayStation4ParticlesBackground
+
+struct PlayStation4ParticlesBackground: View {
+  let theme: DynamicBackgroundTheme
+
+  var body: some View {
+    TimelineView(.animation(minimumInterval: 1 / 30)) { timeline in
+      let time =
+        timeline.date.timeIntervalSinceReferenceDate
+        * theme.particleSettings.backgrounds.playStation4ParticlesSpeed
+      let settings = theme.particleSettings.backgrounds.playStation4Particles
+      let dark = theme.sharedColor(index: 0, time: time)
+      let primary = theme.sharedColor(index: 1, time: time)
+      let ribbonPrimary = theme.ribbonColor(index: 1, time: time)
+      let highlight = theme.ribbonColor(index: 2, time: time)
+      let sharedGradient = theme.sharedGradientPoints(
+        from: .topLeading,
+        to: .bottomTrailing
+      )
+
+      ZStack {
+        PaletteGradientField(
+          colors: [
+            theme.paletteBackgroundColor(
+              dark,
+              darkness: 1 - min(1, 0.58 * settings.backgroundIntensity)
+            ),
+            theme.paletteBackgroundColor(
+              primary,
+              darkness: 1 - min(1, 0.7 * settings.backgroundIntensity)
+            ),
+            theme.paletteBackgroundColor(
+              primary,
+              darkness: 1 - min(1, 0.46 * settings.backgroundIntensity)
+            ),
+            theme.paletteBackgroundColor(
+              highlight,
+              darkness: 1 - min(1, 0.24 * settings.backgroundIntensity)
+            ),
+          ],
+          startPoint: sharedGradient.start,
+          endPoint: sharedGradient.end,
+          curvature: theme.sharedPaletteGradientCurvature
+        )
+
+        RadialGradient(
+          colors: [
+            highlight.opacity(0.16 * settings.backgroundIntensity),
+            primary.opacity(0.08 * settings.backgroundIntensity),
+            .clear,
+          ],
+          center: .bottomTrailing,
+          startRadius: 8,
+          endRadius: 520
+        )
+
+        Canvas { context, size in
+          if settings.showsParticles {
+            drawParticles(
+              context: &context,
+              size: size,
+              time: time,
+              color: highlight
+            )
+          }
+          if settings.showsWaves {
+            drawPlayStationWaves(
+              context: &context,
+              size: size,
+              time: time,
+              primary: ribbonPrimary,
+              highlight: highlight
+            )
+          }
+        }
+
+        LinearGradient(
+          colors: [
+            theme.paletteDarkOverlay(
+              opacity: 0.12 * settings.vignetteIntensity
+            ),
+            .clear,
+            theme.paletteDarkOverlay(
+              opacity: 0.18 * settings.vignetteIntensity
+            ),
+          ],
+          startPoint: .top,
+          endPoint: .bottom
+        )
+      }
+      .ignoresSafeArea()
+    }
+  }
+
+  // Draws the original XMB3 particles centered on the PS4 wave band.
+  private func drawParticles(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval,
+    color: Color
+  ) {
+    context.blendMode = .plusLighter
+
+    let particleCount = max(0, Int(settings.particleCount.rounded()))
+    let particleTime = time * settings.particleSpeed
+
+    for index in 0..<particleCount {
+      let seed = DynamicBackgroundMath.unit(sin(Double(index + 1) * 12.9898) * 43_758.5453)
+      let secondarySeed = DynamicBackgroundMath.unit(sin(Double(index + 7) * 78.233) * 9_631.417)
+      let speed = 0.006 + Double(index % 7) * 0.0011
+      let progress = DynamicBackgroundMath.unit(seed + particleTime * speed)
+      let x = CGFloat(progress) * size.width
+      let waveCenter =
+        size.height
+        * (CGFloat(settings.particleVerticalPosition)
+          + 0.08
+          * CGFloat(
+            sin(progress * .pi * 2.1 - particleTime * 0.11 + seed * 5)
+          ))
+      let spread =
+        (CGFloat(secondarySeed) - 0.5)
+        * size.height
+        * (0.12 + CGFloat(seed) * 0.16)
+        * CGFloat(settings.particleSpread)
+      let y =
+        waveCenter + spread
+        + CGFloat(sin(particleTime * 0.24 + seed * 18)) * 7
+        * CGFloat(settings.particleSpread)
+      let twinkle = pow(
+        max(
+          0,
+          sin(particleTime * settings.particleTwinkle * (0.9 + seed) + secondarySeed * 14)
+        ),
+        3
+      )
+      let diameter =
+        (CGFloat(0.7 + Double(index % 5) * 0.34)
+          + CGFloat(twinkle) * 1.35) * CGFloat(settings.particleSize)
+      let rect = CGRect(
+        x: x - diameter / 2,
+        y: y - diameter / 2,
+        width: diameter,
+        height: diameter
+      )
+
+      context.fill(
+        Path(ellipseIn: rect),
+        with: .color(
+          index.isMultiple(of: 8)
+            ? .white.opacity((0.35 + twinkle * 0.5) * settings.particleOpacity)
+            : color.opacity((0.12 + twinkle * 0.28) * settings.particleOpacity)
+        )
+      )
+    }
+  }
+
+  // Draws PS4 wave paths on top of the XMB3 background.
+  private func drawPlayStationWaves(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval,
+    primary: Color,
+    highlight: Color
+  ) {
+    let waveCount = max(1, Int(settings.waveCount.rounded()))
+
+    for index in 0..<waveCount {
+      let path = playStationWavePath(size: size, time: time, index: index)
+      let fade = 1 - Double(index) / Double(waveCount + 2)
+
+      if settings.showsWaveGlow {
+        context.drawLayer { glow in
+          glow.blendMode = .plusLighter
+          glow.addFilter(.blur(radius: CGFloat(settings.glowBlur)))
+          glow.stroke(
+            path,
+            with: .color(
+              index.isMultiple(of: 2)
+                ? primary.opacity(fade * 0.38 * settings.glowOpacity)
+                : theme.ribbonColor(index: index + 1, time: time)
+                  .opacity(fade * 0.32 * settings.glowOpacity)
+            ),
+            style: StrokeStyle(
+              lineWidth: CGFloat(max(2, 20 - index)) * CGFloat(settings.glowWidth),
+              lineCap: .round
+            )
+          )
+        }
+      }
+
+      if settings.showsWaveCores {
+        context.stroke(
+          path,
+          with: .color(
+            index.isMultiple(of: 3)
+              ? highlight.opacity(fade * 0.7 * settings.coreOpacity)
+              : theme.ribbonColor(index: index + 2, time: time)
+                .opacity(fade * 0.78 * settings.coreOpacity)
+          ),
+          style: StrokeStyle(
+            lineWidth: CGFloat(0.7 + Double(waveCount - 1 - index) * 0.4)
+              * CGFloat(settings.coreWidth),
+            lineCap: .round
+          )
+        )
+      }
+    }
+  }
+
+  // Builds the same two-curve wave shape used by PS4 Waves.
+  private func playStationWavePath(size: CGSize, time: TimeInterval, index: Int) -> Path {
+    let layer = Double(index)
+    let waveCount = max(1, Int(settings.waveCount.rounded()))
+    let phase =
+      time * (0.18 + layer * 0.012)
+      + layer * 0.74 * settings.phaseSpread
+    let centerIndex = CGFloat(max(0, waveCount - 2)) / 2
+    let centerY =
+      size.height
+      * (CGFloat(settings.waveVerticalPosition)
+        + (CGFloat(index) - centerIndex) * 0.033 * CGFloat(settings.waveSpacing))
+    let amplitude =
+      size.height * (0.055 + CGFloat(index % 3) * 0.014)
+      * CGFloat(settings.waveAmplitude)
+    let start = CGPoint(
+      x: -size.width * 0.12,
+      y: centerY + sin(phase) * amplitude
+    )
+    let midpoint = CGPoint(
+      x: size.width * 0.5,
+      y: centerY - cos(phase * 0.83) * amplitude
+    )
+    let end = CGPoint(
+      x: size.width * 1.12,
+      y: centerY + sin(phase * 0.71 + 1.4) * amplitude
+    )
+    let midpointTangentY = cos(phase * 0.68 + 0.35) * amplitude * 0.62
+
+    var path = Path()
+    path.move(to: start)
+    path.addCurve(
+      to: midpoint,
+      control1: CGPoint(
+        x: size.width * 0.08,
+        y: centerY - cos(phase + 0.6) * amplitude * 1.5
+          * CGFloat(settings.waveCurvature)
+      ),
+      control2: CGPoint(
+        x: midpoint.x - size.width * 0.17,
+        y: midpoint.y - midpointTangentY * CGFloat(settings.waveCurvature)
+      )
+    )
+    path.addCurve(
+      to: end,
+      control1: CGPoint(
+        x: midpoint.x + size.width * 0.17,
+        y: midpoint.y + midpointTangentY * CGFloat(settings.waveCurvature)
+      ),
+      control2: CGPoint(
+        x: size.width * 0.91,
+        y: centerY + cos(phase + 0.2) * amplitude * 1.4
+          * CGFloat(settings.waveCurvature)
+      )
+    )
+    return path
+  }
+  private var settings: PlayStation4ParticlesSettings {
+    theme.particleSettings.backgrounds.playStation4Particles
+  }
+}
+
+// MARK: - PlayStation4WavesBackground
+
+struct PlayStation4WavesBackground: View {
+  let theme: DynamicBackgroundTheme
+  var showsWaves = true
+
+  var body: some View {
+    TimelineView(.animation(minimumInterval: 1 / 30)) { timeline in
+      let time =
+        timeline.date.timeIntervalSinceReferenceDate
+        * theme.particleSettings.backgrounds.playStation4WavesSpeed
+      let settings = theme.particleSettings.backgrounds.playStation4Waves
+      let backgroundDark = theme.playStation4BaseColor(index: 0, time: time)
+      let backgroundMiddle = theme.playStation4BaseColor(index: 1, time: time)
+      let backgroundBright = theme.playStation4BaseColor(index: 2, time: time)
+      let highlight = theme.highlightColor(index: 9, time: time)
+      let sharedGradient = theme.sharedGradientPoints(
+        from: .topLeading,
+        to: .bottomTrailing
+      )
+
+      ZStack {
+        PaletteGradientField(
+          colors: [
+            backgroundDark,
+            backgroundMiddle,
+            theme.paletteBackgroundColor(backgroundBright, darkness: 0.54),
+            theme.paletteBackgroundColor(backgroundDark, darkness: 0.22),
+          ],
+          startPoint: sharedGradient.start,
+          endPoint: sharedGradient.end,
+          curvature: theme.sharedPaletteGradientCurvature
+        )
+
+        if settings.showsAmbientGlows {
+          Ellipse()
+            .fill(
+              theme.ribbonColor(index: 0, time: time)
+                .opacity(0.3 * settings.ambientGlowIntensity)
+            )
+            .frame(
+              width: 520 * settings.ambientGlowScale,
+              height: 240 * settings.ambientGlowScale
+            )
+            .blur(radius: 90 * settings.ambientGlowScale)
+            .offset(
+              x: CGFloat(sin(time * 0.09)) * 180,
+              y: CGFloat(cos(time * 0.07)) * 130 - 80
+            )
+
+          Circle()
+            .fill(highlight.opacity(0.13 * settings.ambientGlowIntensity))
+            .frame(
+              width: 230 * settings.ambientGlowScale,
+              height: 230 * settings.ambientGlowScale
+            )
+            .blur(radius: 78 * settings.ambientGlowScale)
+            .offset(
+              x: CGFloat(cos(time * 0.11)) * 220 + 120,
+              y: CGFloat(sin(time * 0.08)) * 170
+            )
+        }
+
+        if settings.showsParticles {
+          Canvas { context, size in
+            drawParticles(
+              context: &context,
+              size: size,
+              time: time,
+              highlight: highlight
+            )
+          }
+        }
+
+        if showsWaves && settings.showsWaves {
+          Canvas { context, size in
+            drawWaves(
+              context: &context,
+              size: size,
+              time: time,
+              highlight: highlight
+            )
+          }
+        }
+
+        LinearGradient(
+          colors: [
+            theme.paletteDarkOverlay(
+              opacity: 0.18 * settings.vignetteIntensity
+            ),
+            .clear,
+            theme.paletteDarkOverlay(
+              opacity: 0.3 * settings.vignetteIntensity
+            ),
+          ],
+          startPoint: .top,
+          endPoint: .bottom
+        )
+      }
+      .ignoresSafeArea()
+    }
+  }
+
+  // Draws slow background particles colored by the ribbon palette.
+  private func drawParticles(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval,
+    highlight: Color
+  ) {
+    let particleCount = max(0, Int(settings.particleCount.rounded()))
+    let particleTime = time * settings.particleSpeed
+
+    for index in 0..<particleCount {
+      let seed = Double(index) * 1.618
+      let x =
+        (sin(particleTime * 0.035 + seed) * 0.5 + 0.5)
+        * size.width
+      let normalizedY =
+        cos(particleTime * 0.026 + seed * 1.37) * 0.5
+        * settings.particleSpread + 0.5
+      let y = normalizedY * size.height
+      let diameter =
+        CGFloat(1.2 + Double(index % 4) * 0.55)
+        * CGFloat(settings.particleSize)
+      let particle = CGRect(
+        x: x - diameter / 2,
+        y: y - diameter / 2,
+        width: diameter,
+        height: diameter
+      )
+      context.fill(
+        Path(ellipseIn: particle),
+        with: .color(
+          index.isMultiple(of: 5)
+            ? highlight.opacity(0.5 * settings.particleOpacity)
+            : theme.ribbonColor(index: index, time: time)
+              .opacity(0.32 * settings.particleOpacity)
+        )
+      )
+    }
+  }
+
+  // Draws the PS4 wave ribbons with a blurred glow and a sharp front stroke.
+  private func drawWaves(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval,
+    highlight: Color
+  ) {
+    let waveCount = max(1, Int(settings.waveCount.rounded()))
+
+    for index in 0..<waveCount {
+      let path = wavePath(size: size, time: time, index: index)
+      let fade = 1 - Double(index) / Double(waveCount + 2)
+
+      if settings.showsWaveGlow {
+        context.drawLayer { glow in
+          glow.addFilter(.blur(radius: CGFloat(settings.glowBlur)))
+          glow.stroke(
+            path,
+            with: .color(
+              index.isMultiple(of: 2)
+                ? theme.ribbonColor(index: index, time: time)
+                  .opacity(fade * 0.38 * settings.glowOpacity)
+                : theme.ribbonColor(index: index + 1, time: time)
+                  .opacity(fade * 0.32 * settings.glowOpacity)
+            ),
+            style: StrokeStyle(
+              lineWidth: CGFloat(max(2, 20 - index)) * CGFloat(settings.glowWidth),
+              lineCap: .round
+            )
+          )
+        }
+      }
+
+      if settings.showsWaveCores {
+        context.stroke(
+          path,
+          with: .color(
+            index.isMultiple(of: 3)
+              ? highlight.opacity(fade * 0.7 * settings.coreOpacity)
+              : theme.ribbonColor(index: index + 2, time: time)
+                .opacity(fade * 0.78 * settings.coreOpacity)
+          ),
+          style: StrokeStyle(
+            lineWidth: CGFloat(0.7 + Double(waveCount - 1 - index) * 0.4)
+              * CGFloat(settings.coreWidth),
+            lineCap: .round
+          )
+        )
+      }
+    }
+  }
+
+  // Builds one horizontal PS4 wave path from two cubic curves.
+  private func wavePath(size: CGSize, time: TimeInterval, index: Int) -> Path {
+    let layer = Double(index)
+    let waveCount = max(1, Int(settings.waveCount.rounded()))
+    let phase =
+      time * (0.18 + layer * 0.012)
+      + layer * 0.74 * settings.phaseSpread
+    let centerIndex = CGFloat(max(0, waveCount - 2)) / 2
+    let centerY =
+      size.height
+      * (CGFloat(settings.waveVerticalPosition)
+        + (CGFloat(index) - centerIndex) * 0.033 * CGFloat(settings.waveSpacing))
+    let amplitude =
+      size.height * (0.055 + CGFloat(index % 3) * 0.014)
+      * CGFloat(settings.waveAmplitude)
+    let start = CGPoint(
+      x: -size.width * 0.12,
+      y: centerY + sin(phase) * amplitude
+    )
+    let midpoint = CGPoint(
+      x: size.width * 0.5,
+      y: centerY - cos(phase * 0.83) * amplitude
+    )
+    let end = CGPoint(
+      x: size.width * 1.12,
+      y: centerY + sin(phase * 0.71 + 1.4) * amplitude
+    )
+    let midpointTangentY = cos(phase * 0.68 + 0.35) * amplitude * 0.62
+
+    var path = Path()
+    path.move(to: start)
+    path.addCurve(
+      to: midpoint,
+      control1: CGPoint(
+        x: size.width * 0.08,
+        y: centerY - cos(phase + 0.6) * amplitude * 1.5
+          * CGFloat(settings.waveCurvature)
+      ),
+      control2: CGPoint(
+        x: midpoint.x - size.width * 0.17,
+        y: midpoint.y - midpointTangentY * CGFloat(settings.waveCurvature)
+      )
+    )
+    path.addCurve(
+      to: end,
+      control1: CGPoint(
+        x: midpoint.x + size.width * 0.17,
+        y: midpoint.y + midpointTangentY * CGFloat(settings.waveCurvature)
+      ),
+      control2: CGPoint(
+        x: size.width * 0.91,
+        y: centerY + cos(phase + 0.2) * amplitude * 1.4
+          * CGFloat(settings.waveCurvature)
+      )
+    )
+    return path
+  }
+
+  private var settings: PlayStation4WavesSettings {
+    theme.particleSettings.backgrounds.playStation4Waves
+  }
+}
+
+// MARK: - PlayStationRibbonsBackground
+
+struct PlayStationRibbonsBackground: View {
+  let theme: DynamicBackgroundTheme
+
+  var body: some View {
+    TimelineView(.animation(minimumInterval: 1 / 30)) { timeline in
+      let time =
+        timeline.date.timeIntervalSinceReferenceDate
+        * theme.particleSettings.backgrounds.playStationRibbonsSpeed
+      let settings = theme.particleSettings.backgrounds.playStationRibbons
+      let dark = theme.sharedColor(index: 0, time: time)
+      let primary = theme.sharedColor(index: 1, time: time)
+      let highlight = theme.ribbonColor(index: 2, time: time)
+      let sharedGradient = theme.sharedGradientPoints(
+        from: .topLeading,
+        to: .bottomTrailing
+      )
+
+      ZStack {
+        PaletteGradientField(
+          colors: [
+            theme.paletteBackgroundColor(dark, darkness: 0.96),
+            theme.paletteBackgroundColor(dark, darkness: 0.54),
+            theme.paletteBackgroundColor(primary, darkness: 0.76),
+            theme.paletteBackgroundColor(primary, darkness: 1),
+          ],
+          startPoint: sharedGradient.start,
+          endPoint: sharedGradient.end,
+          curvature: theme.sharedPaletteGradientCurvature
+        )
+
+        Circle()
+          .fill(primary.opacity(0.22 * settings.ambientGlowIntensity))
+          .frame(
+            width: 430 * settings.ambientGlowScale,
+            height: 430 * settings.ambientGlowScale
+          )
+          .blur(radius: 110 * settings.ambientGlowScale)
+          .offset(
+            x: CGFloat(cos(time * 0.08)) * 170 + 90,
+            y: CGFloat(sin(time * 0.06)) * 120 - 120
+          )
+
+        Canvas { context, size in
+          if settings.showsPanels {
+            drawLuminousPanels(
+              context: &context,
+              size: size,
+              time: time
+            )
+          }
+          if settings.showsParticles {
+            drawFloatingLight(
+              context: &context,
+              size: size,
+              time: time,
+              color: highlight
+            )
+          }
+        }
+
+        LinearGradient(
+          colors: [
+            .white.opacity(0.035 * settings.vignetteIntensity),
+            .clear,
+            theme.paletteDarkOverlay(
+              opacity: 0.28 * settings.vignetteIntensity
+            ),
+          ],
+          startPoint: .top,
+          endPoint: .bottom
+        )
+      }
+      .ignoresSafeArea()
+    }
+  }
+}
+
+extension PlayStationRibbonsBackground {
+  // Draws broad luminous panels whose fill color comes from the ribbon palette.
+  private func drawLuminousPanels(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval
+  ) {
+    let panelCount = max(1, Int(settings.panelCount.rounded()))
+
+    for index in 0..<panelCount {
+      let panel = panelPath(size: size, time: time, index: index)
+      let edge = panelEdgePath(size: size, time: time, index: index)
+      let color = theme.ribbonColor(index: index + 1, time: time)
+      let fade = 1 - Double(index) / Double(panelCount + 2)
+      if settings.showsPanelGlow {
+        context.drawLayer { glow in
+          glow.addFilter(
+            .blur(
+              radius: (22 + CGFloat(index) * 3) * CGFloat(settings.panelGlowBlur)
+            )
+          )
+          glow.fill(
+            panel,
+            with: .color(
+              color.opacity(0.13 * fade * settings.panelGlowOpacity)
+            )
+          )
+        }
+      }
+
+      context.fill(
+        panel,
+        with: .linearGradient(
+          Gradient(colors: [
+            .white.opacity(0.025 * settings.panelFillOpacity),
+            color.opacity(0.2 * fade * settings.panelFillOpacity),
+            .white.opacity(0.085 * fade * settings.panelFillOpacity),
+          ]),
+          startPoint: CGPoint(x: 0, y: size.height * 0.3),
+          endPoint: CGPoint(x: size.width, y: size.height * 0.7)
+        )
+      )
+      if settings.showsPanelEdges {
+        context.stroke(
+          edge,
+          with: .color(
+            .white.opacity(0.28 * fade * settings.panelEdgeOpacity)
+          ),
+          style: StrokeStyle(
+            lineWidth: 0.8 * CGFloat(settings.panelEdgeWidth),
+            lineCap: .round
+          )
+        )
+      }
+    }
+  }
+
+  // Draws slow floating points over the PS5 panels.
+  private func drawFloatingLight(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval,
+    color: Color
+  ) {
+    let particleCount = max(0, Int(settings.particleCount.rounded()))
+    let particleTime = time * settings.particleSpeed
+
+    for index in 0..<particleCount {
+      let seed = Double(index) * 1.618
+      let progress =
+        (Double(index) * 0.047
+        + particleTime * (0.006 + Double(index % 5) * 0.0015))
+        .truncatingRemainder(dividingBy: 1)
+      let x =
+        progress * size.width
+        + CGFloat(sin(particleTime * 0.16 + seed)) * 24
+        * CGFloat(settings.particleDrift)
+      let normalizedY =
+        cos(seed * 1.37) * 0.5
+        * settings.particleVerticalSpread + 0.5
+      let y =
+        CGFloat(normalizedY) * size.height
+        + CGFloat(sin(particleTime * 0.1 + seed)) * 38
+        * CGFloat(settings.particleDrift)
+      let diameter =
+        CGFloat(0.8 + Double(index % 4) * 0.52)
+        * CGFloat(settings.particleSize)
+      let rect = CGRect(
+        x: x - diameter / 2,
+        y: y - diameter / 2,
+        width: diameter,
+        height: diameter
+      )
+      context.fill(
+        Path(ellipseIn: rect),
+        with: .color(
+          index.isMultiple(of: 7)
+            ? .white.opacity(0.5 * settings.particleOpacity)
+            : color.opacity(0.25 * settings.particleOpacity)
+        )
+      )
+    }
+  }
+
+  // Builds a thick curved panel from paired top and bottom edges.
+  private func panelPath(
+    size: CGSize,
+    time: TimeInterval,
+    index: Int
+  ) -> Path {
+    let phase =
+      time * (0.12 + Double(index) * 0.006)
+      + Double(index) * 0.72 * settings.phaseSpread
+    let baseY =
+      size.height
+      * (CGFloat(settings.panelVerticalPosition)
+        + CGFloat(index) * 0.135 * CGFloat(settings.panelSpacing))
+    let amplitude =
+      size.height * (0.055 + CGFloat(index % 2) * 0.018)
+      * CGFloat(settings.panelAmplitude)
+    let thickness =
+      size.height * (0.04 + CGFloat(index % 3) * 0.012)
+      * CGFloat(settings.panelThickness)
+    let curvature = CGFloat(settings.panelCurvature)
+    let startTop = CGPoint(
+      x: -size.width * 0.18,
+      y: baseY + CGFloat(sin(phase)) * amplitude
+    )
+    let endTop = CGPoint(
+      x: size.width * 1.18,
+      y: baseY + CGFloat(cos(phase * 0.79)) * amplitude
+    )
+    let startBottom = CGPoint(
+      x: startTop.x,
+      y: startTop.y + thickness
+    )
+    let endBottom = CGPoint(
+      x: endTop.x,
+      y: endTop.y + thickness * 0.7
+    )
+
+    var path = Path()
+    path.move(to: startTop)
+    path.addCurve(
+      to: endTop,
+      control1: CGPoint(
+        x: size.width * 0.23,
+        y: baseY - CGFloat(cos(phase + 0.4)) * amplitude * 1.8 * curvature
+      ),
+      control2: CGPoint(
+        x: size.width * 0.76,
+        y: baseY + CGFloat(sin(phase * 0.83 + 1.1)) * amplitude * 1.7 * curvature
+      )
+    )
+    path.addLine(to: endBottom)
+    path.addCurve(
+      to: startBottom,
+      control1: CGPoint(
+        x: size.width * 0.76,
+        y: baseY + thickness
+          + CGFloat(sin(phase * 0.83 + 1.1)) * amplitude * 1.4
+          * curvature
+      ),
+      control2: CGPoint(
+        x: size.width * 0.23,
+        y: baseY + thickness
+          - CGFloat(cos(phase + 0.4)) * amplitude * 1.5
+          * curvature
+      )
+    )
+    path.closeSubpath()
+    return path
+  }
+
+  // Builds the bright top edge that outlines a curved panel.
+  private func panelEdgePath(
+    size: CGSize,
+    time: TimeInterval,
+    index: Int
+  ) -> Path {
+    let phase =
+      time * (0.12 + Double(index) * 0.006)
+      + Double(index) * 0.72 * settings.phaseSpread
+    let baseY =
+      size.height
+      * (CGFloat(settings.panelVerticalPosition)
+        + CGFloat(index) * 0.135 * CGFloat(settings.panelSpacing))
+    let amplitude =
+      size.height * (0.055 + CGFloat(index % 2) * 0.018)
+      * CGFloat(settings.panelAmplitude)
+    let curvature = CGFloat(settings.panelCurvature)
+    let start = CGPoint(
+      x: -size.width * 0.18,
+      y: baseY + CGFloat(sin(phase)) * amplitude
+    )
+    let end = CGPoint(
+      x: size.width * 1.18,
+      y: baseY + CGFloat(cos(phase * 0.79)) * amplitude
+    )
+
+    var path = Path()
+    path.move(to: start)
+    path.addCurve(
+      to: end,
+      control1: CGPoint(
+        x: size.width * 0.23,
+        y: baseY - CGFloat(cos(phase + 0.4)) * amplitude * 1.8 * curvature
+      ),
+      control2: CGPoint(
+        x: size.width * 0.76,
+        y: baseY + CGFloat(sin(phase * 0.83 + 1.1)) * amplitude * 1.7 * curvature
+      )
+    )
+    return path
+  }
+
+  private var settings: PlayStationRibbonsSettings {
+    theme.particleSettings.backgrounds.playStationRibbons
+  }
+}

--- a/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicColours.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicColours.swift
@@ -1,0 +1,1790 @@
+// DynamicColours.swift — Dynamic background colour and effects editor
+// SPDX-License-Identifier: GPL-3.0+
+
+import SwiftUI
+import UIKit
+
+// MARK: - PaletteGradientField
+
+struct PaletteGradientField: View {
+  let colors: [Color]
+  let startPoint: UnitPoint
+  let endPoint: UnitPoint
+  let curvature: Double
+
+  var body: some View {
+    if abs(curvature) < 0.001 {
+      LinearGradient(
+        colors: colors,
+        startPoint: startPoint,
+        endPoint: endPoint
+      )
+    } else {
+      Canvas(opaque: false, colorMode: .linear) { context, size in
+        drawCurvedGradient(context: &context, size: size)
+      }
+    }
+  }
+
+  private func drawCurvedGradient(
+    context: inout GraphicsContext,
+    size: CGSize
+  ) {
+    guard size.width > 0, size.height > 0, let firstColor = colors.first else {
+      return
+    }
+
+    let resolvedColors = colors.map(PaletteGradientColor.init)
+    let start = CGPoint(
+      x: startPoint.x * size.width,
+      y: startPoint.y * size.height
+    )
+    let end = CGPoint(
+      x: endPoint.x * size.width,
+      y: endPoint.y * size.height
+    )
+    let vector = CGVector(dx: end.x - start.x, dy: end.y - start.y)
+    let length = max(1, hypot(vector.dx, vector.dy))
+    let direction = CGVector(dx: vector.dx / length, dy: vector.dy / length)
+    let perpendicular = CGVector(dx: -direction.dy, dy: direction.dx)
+    let center = CGPoint(x: (start.x + end.x) * 0.5, y: (start.y + end.y) * 0.5)
+    let diagonal = hypot(size.width, size.height)
+    let clampedCurvature = CGFloat(min(1, max(-1, curvature)))
+    let sampleCount = 28
+    let bandCount = 144
+
+    context.fill(
+      Path(CGRect(origin: .zero, size: size)),
+      with: .color(firstColor)
+    )
+
+    func boundary(_ progress: CGFloat) -> [CGPoint] {
+      (0...sampleCount).map { sample in
+        let crossProgress = CGFloat(sample) / CGFloat(sampleCount)
+        let crossDistance = (crossProgress * 2 - 1) * diagonal
+        let normalizedCrossDistance = crossDistance / diagonal
+        let bend =
+          clampedCurvature
+          * normalizedCrossDistance * normalizedCrossDistance
+          * length * 0.78
+        let alongDistance = (progress - 0.5) * length - bend
+        return CGPoint(
+          x: center.x
+            + direction.dx * alongDistance
+            + perpendicular.dx * crossDistance,
+          y: center.y
+            + direction.dy * alongDistance
+            + perpendicular.dy * crossDistance
+        )
+      }
+    }
+
+    let lastBoundary = boundary(1)
+    var terminalPath = Path()
+    if let first = lastBoundary.first {
+      terminalPath.move(to: first)
+      for point in lastBoundary.dropFirst() {
+        terminalPath.addLine(to: point)
+      }
+      for point in lastBoundary.reversed() {
+        terminalPath.addLine(
+          to: CGPoint(
+            x: point.x + direction.dx * diagonal * 4,
+            y: point.y + direction.dy * diagonal * 4
+          )
+        )
+      }
+      terminalPath.closeSubpath()
+      context.fill(
+        terminalPath,
+        with: .color(colors.last ?? firstColor)
+      )
+    }
+
+    for band in 0..<bandCount {
+      let lowerProgress = CGFloat(band) / CGFloat(bandCount)
+      let upperProgress = CGFloat(band + 1) / CGFloat(bandCount)
+      let lowerBoundary = boundary(lowerProgress)
+      let upperBoundary = boundary(upperProgress + 0.001)
+      guard let first = lowerBoundary.first else { continue }
+
+      var bandPath = Path()
+      bandPath.move(to: first)
+      for point in lowerBoundary.dropFirst() {
+        bandPath.addLine(to: point)
+      }
+      for point in upperBoundary.reversed() {
+        bandPath.addLine(to: point)
+      }
+      bandPath.closeSubpath()
+
+      let progress = Double(lowerProgress + upperProgress) * 0.5
+      context.fill(
+        bandPath,
+        with: .color(
+          PaletteGradientColor.interpolated(
+            colors: resolvedColors,
+            progress: progress
+          ).color
+        )
+      )
+    }
+  }
+}
+
+private struct PaletteGradientColor {
+  let red: CGFloat
+  let green: CGFloat
+  let blue: CGFloat
+  let alpha: CGFloat
+
+  init(_ color: Color) {
+    let uiColor = UIColor(color)
+    var red: CGFloat = 0
+    var green: CGFloat = 0
+    var blue: CGFloat = 0
+    var alpha: CGFloat = 0
+    if uiColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha) {
+      self.red = red
+      self.green = green
+      self.blue = blue
+      self.alpha = alpha
+    } else {
+      self.red = 0
+      self.green = 0
+      self.blue = 0
+      self.alpha = 0
+    }
+  }
+
+  private init(red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
+    self.red = red
+    self.green = green
+    self.blue = blue
+    self.alpha = alpha
+  }
+
+  var color: Color {
+    Color(red: red, green: green, blue: blue, opacity: alpha)
+  }
+
+  static func interpolated(
+    colors: [PaletteGradientColor],
+    progress: Double
+  ) -> PaletteGradientColor {
+    guard let first = colors.first else {
+      return PaletteGradientColor(red: 0, green: 0, blue: 0, alpha: 0)
+    }
+    guard colors.count > 1 else { return first }
+
+    let position = min(1, max(0, progress)) * Double(colors.count - 1)
+    let lowerIndex = min(colors.count - 1, Int(floor(position)))
+    let upperIndex = min(colors.count - 1, lowerIndex + 1)
+    let amount = CGFloat(position - Double(lowerIndex))
+    let lower = colors[lowerIndex]
+    let upper = colors[upperIndex]
+    return PaletteGradientColor(
+      red: lower.red + (upper.red - lower.red) * amount,
+      green: lower.green + (upper.green - lower.green) * amount,
+      blue: lower.blue + (upper.blue - lower.blue) * amount,
+      alpha: lower.alpha + (upper.alpha - lower.alpha) * amount
+    )
+  }
+}
+
+private struct PaletteGradientEditor: View {
+  let title: String
+  @Binding var colors: [Color]
+  var isEnabled: Binding<Bool>?
+
+  private let minimumStopCount = 2
+  private let maximumStopCount = 8
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      HStack(spacing: 10) {
+        Text(title)
+          .font(.subheadline.weight(.semibold))
+
+        Spacer()
+
+        if let isEnabled {
+          Button {
+            isEnabled.wrappedValue.toggle()
+          } label: {
+            Image(
+              systemName: isEnabled.wrappedValue ? "eye.fill" : "eye.slash"
+            )
+          }
+          .accessibilityLabel(
+            isEnabled.wrappedValue ? "Disable \(title)" : "Enable \(title)"
+          )
+        }
+
+        Button {
+          resampleColors(to: colors.count - 1)
+        } label: {
+          Image(systemName: "minus")
+        }
+        .disabled(colors.count <= minimumStopCount)
+        .accessibilityLabel("Remove \(title) gradient stop")
+
+        Button {
+          resampleColors(to: colors.count + 1)
+        } label: {
+          Image(systemName: "plus")
+        }
+        .disabled(colors.count >= maximumStopCount)
+        .accessibilityLabel("Add \(title) gradient stop")
+      }
+      .buttonStyle(.borderless)
+
+      GeometryReader { proxy in
+        let handleDiameter: CGFloat = 40
+        let trackWidth = max(0, proxy.size.width - handleDiameter)
+
+        ZStack {
+          RoundedRectangle(cornerRadius: 16, style: .continuous)
+            .fill(
+              LinearGradient(
+                colors: colors,
+                startPoint: .leading,
+                endPoint: .trailing
+              )
+            )
+            .frame(height: 32)
+            .padding(.horizontal, handleDiameter / 2)
+
+          ForEach(colors.indices, id: \.self) { index in
+            ColorPicker(
+              "\(title) stop \(index + 1)",
+              selection: colorBinding(at: index),
+              supportsOpacity: false
+            )
+            .labelsHidden()
+            .frame(width: handleDiameter, height: handleDiameter)
+            .background(Circle().fill(colors[index]))
+            .overlay {
+              Circle()
+                .stroke(.black.opacity(0.85), lineWidth: 3)
+                .allowsHitTesting(false)
+            }
+            .clipShape(Circle())
+            .position(
+              x: handleDiameter / 2
+                + trackWidth * CGFloat(index) / CGFloat(colors.count - 1),
+              y: proxy.size.height / 2
+            )
+          }
+        }
+        .opacity(isEnabled?.wrappedValue == false ? 0.35 : 1)
+        .allowsHitTesting(isEnabled?.wrappedValue != false)
+      }
+      .frame(height: 46)
+    }
+    .padding(12)
+    .glassSurface(tint: .white.opacity(0.06), cornerRadius: 14)
+  }
+
+  private func colorBinding(at index: Int) -> Binding<Color> {
+    Binding(
+      get: { colors[index] },
+      set: { colors[index] = $0 }
+    )
+  }
+
+  private func resampleColors(to count: Int) {
+    guard minimumStopCount...maximumStopCount ~= count else { return }
+    let resolvedColors = colors.map(PaletteGradientColor.init)
+    colors = (0..<count).map { index in
+      PaletteGradientColor.interpolated(
+        colors: resolvedColors,
+        progress: Double(index) / Double(count - 1)
+      ).color
+    }
+  }
+}
+
+// MARK: - ThemePaletteControls
+
+struct ThemePaletteControls: View {
+  @Binding var target: ThemePaletteTarget
+  @Binding var sharedPalette: ThemePalette
+  @Binding var sharedCustomColor: SavedPaletteColor?
+  @Binding var sharedMultiColor: ThemeMultiColorSelection
+  @Binding var ribbonPalette: ThemePalette
+  @Binding var ribbonCustomColor: SavedPaletteColor?
+  @Binding var ribbonMultiColor: ThemeMultiColorSelection
+  @Binding var particleSettings: DynamicParticleSettings
+  @Binding var isPlayStation3XMBPresetExplicit: Bool
+  @Binding var savedColorsJSON: String
+  let dynamicBackground: DynamicBackgroundStyle
+  let onSaveAppearance: () -> Void
+
+  private let columns = Array(
+    repeating: GridItem(.flexible(), spacing: 10),
+    count: 4
+  )
+
+  @State private var draftColor = Color(red: 0.95, green: 0.2, blue: 0.82)
+  @State private var draftPaletteColors = [
+    Color(red: 0.08, green: 0.42, blue: 1),
+    Color(red: 0.16, green: 0.88, blue: 0.92),
+    Color(red: 0.74, green: 0.2, blue: 0.94),
+  ]
+  @State private var draftDarkEffectColors = [Color.black, Color.black]
+  @State private var isDraftDarkEffectEnabled = true
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 20) {
+      paletteSection
+      customColorSection
+      customPaletteSection
+      multiColorControls
+      paletteEffectsSection
+    }
+  }
+
+  private var paletteSection: some View {
+    let usesMultiColor = activeMultiColorSelection.wrappedValue.isEnabled
+
+    return VStack(alignment: .leading, spacing: 10) {
+      Label("Dynamic Palettes", systemImage: "sparkles")
+        .font(.headline)
+
+      paletteGrid(
+        ThemePalette.primaryPalettes,
+        usesMultiColor: usesMultiColor
+      )
+
+      Label("Plain Palettes", systemImage: "paintpalette.fill")
+        .font(.headline)
+        .padding(.top, 8)
+
+      paletteGrid(
+        ThemePalette.morePalettes,
+        usesMultiColor: usesMultiColor
+      )
+    }
+  }
+
+  private func paletteGrid(
+    _ palettes: [ThemePalette],
+    usesMultiColor: Bool
+  ) -> some View {
+    LazyVGrid(columns: columns, spacing: 12) {
+      ForEach(palettes) { palette in
+        Button {
+          if usesMultiColor {
+            toggleMultiColorPalette(palette)
+          } else {
+            apply(palette)
+          }
+        } label: {
+          VStack(spacing: 6) {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+              .fill(
+                LinearGradient(
+                  colors: palettePreviewColors(for: palette),
+                  startPoint: palettePreviewGradientPoints.start,
+                  endPoint: palettePreviewGradientPoints.end
+                )
+              )
+              .frame(height: 54)
+              .overlay {
+                paletteSelectionOverlay(
+                  for: palette,
+                  usesMultiColor: usesMultiColor
+                )
+              }
+
+            Text(palette.title)
+              .font(.caption2.weight(.semibold))
+              .foregroundStyle(.white.opacity(0.86))
+              .lineLimit(1)
+              .minimumScaleFactor(0.7)
+          }
+        }
+        .buttonStyle(.plain)
+      }
+    }
+  }
+
+  private var multiColorControls: some View {
+    let selection = activeMultiColorSelection
+
+    return VStack(alignment: .leading, spacing: 10) {
+      Toggle("Multi-Color", isOn: multiColorEnabledBinding)
+
+      Toggle("Animate", isOn: selection.animates)
+        .disabled(!selection.wrappedValue.isEnabled)
+        .opacity(selection.wrappedValue.isEnabled ? 1 : 0.48)
+    }
+    .font(.subheadline.weight(.semibold))
+    .padding(12)
+    .glassSurface(tint: .white.opacity(0.06), cornerRadius: 14)
+  }
+
+  @ViewBuilder
+  private func paletteSelectionOverlay(
+    for palette: ThemePalette,
+    usesMultiColor: Bool
+  ) -> some View {
+    if usesMultiColor {
+      if let number = multiColorNumber(for: palette) {
+        Text("\(number)")
+          .font(.caption.weight(.black))
+          .foregroundStyle(.black)
+          .frame(width: 24, height: 24)
+          .background(Circle().fill(.white.opacity(0.94)))
+          .shadow(radius: 4)
+      }
+    } else if isSelected(palette) {
+      Image(systemName: "checkmark.circle.fill")
+        .font(.title3)
+        .foregroundStyle(.white)
+        .shadow(radius: 4)
+    }
+  }
+
+  private var customColorSection: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Custom colours")
+        .font(.headline)
+
+      HStack(spacing: 12) {
+        ColorPicker(
+          "Choose a new colour",
+          selection: $draftColor,
+          supportsOpacity: false
+        )
+
+        Button {
+          saveDraftColor()
+        } label: {
+          Label("Save", systemImage: "plus")
+            .font(.subheadline.weight(.bold))
+            .padding(.horizontal, 14)
+            .frame(height: 36)
+            .glassSurface(
+              tint: draftColor.opacity(0.2),
+              interactive: true,
+              cornerRadius: 18
+            )
+        }
+        .buttonStyle(.plain)
+      }
+
+      if !savedSolidColors.isEmpty {
+        LazyVGrid(columns: columns, spacing: 10) {
+          ForEach(savedSolidColors) { savedColor in
+            Button {
+              apply(savedColor)
+            } label: {
+              RoundedRectangle(cornerRadius: 11, style: .continuous)
+                .fill(
+                  LinearGradient(
+                    colors: palettePreviewColors(for: savedColor),
+                    startPoint: customColorPreviewGradientPoints.start,
+                    endPoint: customColorPreviewGradientPoints.end
+                  )
+                )
+                .frame(height: 52)
+                .overlay {
+                  if isSelected(savedColor) {
+                    Image(systemName: "checkmark.circle.fill")
+                      .foregroundStyle(.white)
+                  }
+                }
+            }
+            .buttonStyle(.plain)
+            .contextMenu {
+              Button(role: .destructive) {
+                delete(savedColor)
+              } label: {
+                Label("Delete", systemImage: "trash")
+              }
+            }
+            .accessibilityLabel("Saved colour \(savedColor.hex)")
+            .accessibilityAction(named: "Delete") {
+              delete(savedColor)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private var customPaletteSection: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Custom palette")
+        .font(.headline)
+
+      PaletteGradientEditor(
+        title: "Palette gradient",
+        colors: $draftPaletteColors
+      )
+
+      PaletteGradientEditor(
+        title: "Dark effect",
+        colors: $draftDarkEffectColors,
+        isEnabled: $isDraftDarkEffectEnabled
+      )
+
+      HStack {
+        Spacer()
+        Button {
+          saveDraftPalette()
+        } label: {
+          Label("Save palette", systemImage: "plus")
+            .font(.subheadline.weight(.bold))
+            .padding(.horizontal, 14)
+            .frame(height: 36)
+            .glassSurface(
+              tint: draftPaletteColors[draftPaletteColors.count / 2].opacity(0.18),
+              interactive: true,
+              cornerRadius: 18
+            )
+        }
+        .buttonStyle(.plain)
+      }
+
+      if !savedCustomPalettes.isEmpty {
+        LazyVGrid(columns: columns, spacing: 10) {
+          ForEach(savedCustomPalettes) { palette in
+            Button {
+              apply(palette)
+            } label: {
+              RoundedRectangle(cornerRadius: 11, style: .continuous)
+                .fill(
+                  LinearGradient(
+                    colors: palettePreviewColors(for: palette),
+                    startPoint: palettePreviewGradientPoints.start,
+                    endPoint: palettePreviewGradientPoints.end
+                  )
+                )
+                .frame(height: 52)
+                .overlay {
+                  if isSelected(palette) {
+                    Image(systemName: "checkmark.circle.fill")
+                      .foregroundStyle(.white)
+                      .shadow(radius: 4)
+                  }
+                }
+            }
+            .buttonStyle(.plain)
+            .contextMenu {
+              Button(role: .destructive) {
+                delete(palette)
+              } label: {
+                Label("Delete", systemImage: "trash")
+              }
+            }
+            .accessibilityLabel("Saved custom palette")
+            .accessibilityAction(named: "Delete") {
+              delete(palette)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private var paletteEffectsSection: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Toggle(
+        "Disable dark effects on palettes",
+        isOn: $particleSettings.disablesDarkPaletteEffects
+      )
+      .font(.subheadline.weight(.semibold))
+
+      particleSlider(
+        "Dark gradient strength",
+        value: $particleSettings.paletteDarkEffectIntensity,
+        range: 0...2,
+        formattedValue: "\(Int(particleSettings.paletteDarkEffectIntensity * 100))%",
+        resetValue: 1
+      )
+      .disabled(particleSettings.disablesDarkPaletteEffects)
+      .opacity(particleSettings.disablesDarkPaletteEffects ? 0.45 : 1)
+
+      if target == .shared {
+        particleSlider(
+          "Palette tilt gradient",
+          value: $particleSettings.sharedPaletteGradientTilt,
+          range: -180...180,
+          formattedValue: gradientTiltDescription(
+            particleSettings.sharedPaletteGradientTilt
+          ),
+          resetValue: 0
+        )
+
+        particleSlider(
+          "Y-Axis gradient",
+          value: $particleSettings.sharedPaletteGradientOffsetY,
+          range: -1...1,
+          formattedValue: gradientOffsetDescription(
+            particleSettings.sharedPaletteGradientOffsetY
+          ),
+          resetValue: 0
+        )
+
+        particleSlider(
+          "X-Axis gradient",
+          value: $particleSettings.sharedPaletteGradientOffsetX,
+          range: -1...1,
+          formattedValue: gradientOffsetDescription(
+            particleSettings.sharedPaletteGradientOffsetX
+          ),
+          resetValue: 0
+        )
+
+        particleSlider(
+          "Gradient width",
+          value: $particleSettings.sharedPaletteGradientWidth,
+          range: 0.25...3,
+          formattedValue: String(
+            format: "%.2fx",
+            particleSettings.sharedPaletteGradientWidth
+          ),
+          resetValue: 1
+        )
+
+        particleSlider(
+          "Gradient curvature",
+          value: $particleSettings.sharedPaletteGradientCurvature,
+          range: -1...1,
+          formattedValue: gradientOffsetDescription(
+            particleSettings.sharedPaletteGradientCurvature
+          ),
+          resetValue: 0
+        )
+      }
+    }
+    .padding(12)
+    .glassSurface(tint: .white.opacity(0.06), cornerRadius: 14)
+  }
+
+  private func palettePreviewColors(for palette: ThemePalette) -> [Color] {
+    palette.colors
+  }
+
+  private func palettePreviewColors(for palette: SavedPaletteColor) -> [Color] {
+    palette.gradientColors
+  }
+
+  private var activePaletteGradientTilt: Double {
+    target == .shared ? particleSettings.sharedPaletteGradientTilt : 0
+  }
+
+  private var palettePreviewGradientPoints: (start: UnitPoint, end: UnitPoint) {
+    rotatedPreviewGradientPoints(
+      from: .topLeading,
+      to: .bottomTrailing,
+      degrees: activePaletteGradientTilt
+    )
+  }
+
+  private var customColorPreviewGradientPoints: (start: UnitPoint, end: UnitPoint) {
+    rotatedPreviewGradientPoints(
+      from: .bottomLeading,
+      to: .topTrailing,
+      degrees: activePaletteGradientTilt
+    )
+  }
+
+  private func gradientTiltDescription(_ degrees: Double) -> String {
+    String(format: "%+.0f°", degrees)
+  }
+
+  private func gradientOffsetDescription(_ value: Double) -> String {
+    String(format: "%+.0f%%", value * 100)
+  }
+
+  private func rotatedPreviewGradientPoints(
+    from startPoint: UnitPoint,
+    to endPoint: UnitPoint,
+    degrees: Double
+  ) -> (start: UnitPoint, end: UnitPoint) {
+    let radians = degrees * .pi / 180
+    let cosine = CGFloat(cos(radians))
+    let sine = CGFloat(sin(radians))
+    let appliesSharedGeometry = target == .shared
+    let width =
+      appliesSharedGeometry
+      ? CGFloat(max(0.05, particleSettings.sharedPaletteGradientWidth))
+      : 1
+    let center = CGPoint(
+      x: (startPoint.x + endPoint.x) * 0.5
+        + (appliesSharedGeometry
+          ? CGFloat(particleSettings.sharedPaletteGradientOffsetX) : 0),
+      y: (startPoint.y + endPoint.y) * 0.5
+        + (appliesSharedGeometry
+          ? CGFloat(particleSettings.sharedPaletteGradientOffsetY) : 0)
+    )
+
+    func rotate(_ point: UnitPoint) -> UnitPoint {
+      let sourceCenter = CGPoint(
+        x: (startPoint.x + endPoint.x) * 0.5,
+        y: (startPoint.y + endPoint.y) * 0.5
+      )
+      let x = (point.x - sourceCenter.x) * width
+      let y = (point.y - sourceCenter.y) * width
+      return UnitPoint(
+        x: center.x + x * cosine - y * sine,
+        y: center.y + x * sine + y * cosine
+      )
+    }
+
+    return (rotate(startPoint), rotate(endPoint))
+  }
+
+  private func particleSlider(
+    _ title: String,
+    value: Binding<Double>,
+    range: ClosedRange<Double>,
+    formattedValue: String,
+    resetValue: Double
+  ) -> some View {
+    DynamicSettingsValueSlider(
+      title: title,
+      value: value,
+      range: range,
+      step: nil,
+      formattedValue: formattedValue,
+      resetValue: resetValue
+    )
+  }
+
+  // Decodes the saved custom colors each time the editor reads AppStorage.
+  private var savedColors: [SavedPaletteColor] {
+    DynamicBackgroundCoding.decode([SavedPaletteColor].self, from: savedColorsJSON) ?? []
+  }
+
+  private var savedSolidColors: [SavedPaletteColor] {
+    savedColors.filter { !$0.isGradient }
+  }
+
+  private var savedCustomPalettes: [SavedPaletteColor] {
+    savedColors.filter(\.isGradient)
+  }
+
+  private var activeMultiColorSelection: Binding<ThemeMultiColorSelection> {
+    Binding(
+      get: {
+        switch target {
+        case .shared:
+          return sharedMultiColor
+        case .ribbons:
+          return ribbonMultiColor
+        case .particles:
+          return ThemeMultiColorSelection()
+        }
+      },
+      set: { selection in
+        switch target {
+        case .shared:
+          sharedMultiColor = selection
+        case .ribbons:
+          ribbonMultiColor = selection
+        case .particles:
+          break
+        }
+      }
+    )
+  }
+
+  private var multiColorEnabledBinding: Binding<Bool> {
+    Binding(
+      get: {
+        activeMultiColorSelection.wrappedValue.isEnabled
+      },
+      set: { enabled in
+        setMultiColorEnabled(enabled)
+      }
+    )
+  }
+
+  private var isMultiColorEnabled: Bool {
+    activeMultiColorSelection.wrappedValue.isEnabled
+  }
+
+  // Enables or disables multi-color mode for the active color target.
+  private func setMultiColorEnabled(_ enabled: Bool) {
+    switch target {
+    case .shared:
+      sharedMultiColor.setEnabled(enabled, fallback: sharedPalette)
+      if enabled {
+        sharedCustomColor = nil
+        synchronizeRibbonPaletteAfterSharedSelection(sharedPalette)
+      }
+      useSharedThemeForXMBMart()
+    case .ribbons:
+      ribbonMultiColor.setEnabled(enabled, fallback: ribbonPalette)
+      if enabled {
+        ribbonCustomColor = nil
+      }
+      useSharedThemeForXMBMart()
+    case .particles:
+      break
+    }
+  }
+
+  // Toggles a built-in palette in the active multi-color selection.
+  private func toggleMultiColorPalette(_ palette: ThemePalette) {
+    switch target {
+    case .shared:
+      sharedCustomColor = nil
+      sharedMultiColor.toggle(palette, fallback: sharedPalette)
+      synchronizeRibbonPaletteAfterSharedSelection(palette)
+      useSharedThemeForXMBMart()
+    case .ribbons:
+      ribbonCustomColor = nil
+      ribbonMultiColor.toggle(palette, fallback: ribbonPalette)
+      useSharedThemeForXMBMart()
+    case .particles:
+      break
+    }
+  }
+
+  // Returns the number displayed on selected multi-color palettes.
+  private func multiColorNumber(for palette: ThemePalette) -> Int? {
+    switch target {
+    case .shared:
+      return sharedMultiColor.selectionNumber(for: palette)
+    case .ribbons:
+      return ribbonMultiColor.selectionNumber(for: palette)
+    case .particles:
+      return nil
+    }
+  }
+
+  // Applies a built-in palette to the currently selected target.
+  private func apply(_ palette: ThemePalette) {
+    switch target {
+    case .shared:
+      sharedMultiColor.isEnabled = false
+      sharedPalette = palette
+      sharedCustomColor = nil
+      synchronizeRibbonPaletteAfterSharedSelection(palette)
+      useSharedThemeForXMBMart()
+    case .ribbons:
+      ribbonMultiColor.isEnabled = false
+      ribbonPalette = palette
+      ribbonCustomColor = nil
+      useSharedThemeForXMBMart()
+    case .particles:
+      break
+    }
+  }
+
+  private func synchronizeRibbonPalette(with palette: ThemePalette) {
+    ribbonMultiColor.isEnabled = false
+    ribbonPalette = palette
+    ribbonCustomColor = nil
+  }
+
+  private func synchronizeRibbonPaletteAfterSharedSelection(
+    _ palette: ThemePalette
+  ) {
+    if dynamicBackground == .playStation3XMBByMart {
+      synchronizeRibbonPalette(
+        with: palette.isMorePalette ? palette.lightRibbonPaletteForMart : .cyan
+      )
+    } else if palette.isMorePalette {
+      synchronizeRibbonPalette(with: palette)
+    }
+  }
+
+  // Applies a saved custom color to the currently selected target.
+  private func apply(_ color: SavedPaletteColor) {
+    switch target {
+    case .shared:
+      sharedMultiColor.isEnabled = false
+      sharedCustomColor = color
+      if dynamicBackground == .playStation3XMBByMart, color.isGradient {
+        synchronizeRibbonPalette(with: .cyan)
+      }
+      useSharedThemeForXMBMart()
+    case .ribbons:
+      ribbonMultiColor.isEnabled = false
+      ribbonCustomColor = color
+      useSharedThemeForXMBMart()
+    case .particles:
+      break
+    }
+  }
+
+  private func useSharedThemeForXMBMart() {
+    guard !isPlayStation3XMBPresetExplicit else { return }
+    particleSettings.playStation3XMB.gradientPreset = .theme
+  }
+
+  // Checks whether a built-in palette is active for the selected target.
+  private func isSelected(_ palette: ThemePalette) -> Bool {
+    guard !isMultiColorEnabled else { return false }
+
+    switch target {
+    case .shared:
+      return sharedCustomColor == nil && sharedPalette == palette
+    case .ribbons:
+      return ribbonCustomColor == nil && ribbonPalette == palette
+    case .particles:
+      return false
+    }
+  }
+
+  // Checks whether a saved custom color is active for the selected target.
+  private func isSelected(_ color: SavedPaletteColor) -> Bool {
+    guard !isMultiColorEnabled else { return false }
+
+    switch target {
+    case .shared:
+      return sharedCustomColor == color
+    case .ribbons:
+      return ribbonCustomColor == color
+    case .particles:
+      return false
+    }
+  }
+
+  // Saves the draft color once and applies it immediately to the active target.
+  private func saveDraftColor() {
+    guard let color = SavedPaletteColor(color: draftColor) else { return }
+    save(color)
+    apply(color)
+    onSaveAppearance()
+  }
+
+  private func saveDraftPalette() {
+    guard
+      let palette = SavedPaletteColor(
+        colors: draftPaletteColors,
+        darkEffectColors: isDraftDarkEffectEnabled ? draftDarkEffectColors : nil,
+        darkEffectEnabled: isDraftDarkEffectEnabled
+      )
+    else {
+      return
+    }
+    save(palette)
+    apply(palette)
+    onSaveAppearance()
+  }
+
+  private func save(_ color: SavedPaletteColor) {
+    var colors = savedColors
+    guard !colors.contains(color) else { return }
+    colors.append(color)
+    persistSavedColors(colors)
+  }
+
+  private func delete(_ color: SavedPaletteColor) {
+    let colors = savedColors.filter { $0 != color }
+    guard colors.count != savedColors.count else { return }
+
+    if sharedCustomColor == color {
+      sharedCustomColor = nil
+    }
+    if ribbonCustomColor == color {
+      ribbonCustomColor = nil
+    }
+
+    persistSavedColors(colors)
+  }
+
+  private func persistSavedColors(_ colors: [SavedPaletteColor]) {
+    guard let json = DynamicBackgroundCoding.encodeJSONString(colors) else { return }
+    savedColorsJSON = json
+  }
+}
+
+// MARK: - ThemePaletteEditorComponents
+
+struct ThemePaletteEditorSnapshot: Equatable {
+  let sharedPalette: ThemePalette
+  let sharedCustomColor: SavedPaletteColor?
+  let sharedMultiColor: ThemeMultiColorSelection
+  let ribbonPalette: ThemePalette
+  let ribbonCustomColor: SavedPaletteColor?
+  let ribbonMultiColor: ThemeMultiColorSelection
+  let particleSettings: DynamicParticleSettings
+  let isPlayStation3XMBPresetExplicit: Bool
+  let savedColorsJSON: String
+
+  var visualState: ThemePaletteEditorVisualState {
+    ThemePaletteEditorVisualState(
+      sharedPalette: sharedPalette,
+      sharedCustomColor: sharedCustomColor,
+      sharedMultiColor: sharedMultiColor,
+      ribbonPalette: ribbonPalette,
+      ribbonCustomColor: ribbonCustomColor,
+      ribbonMultiColor: ribbonMultiColor,
+      particleSettings: particleSettings
+    )
+  }
+}
+
+struct ThemePaletteEditorVisualState: Equatable {
+  let sharedPalette: ThemePalette
+  let sharedCustomColor: SavedPaletteColor?
+  let sharedMultiColor: ThemeMultiColorSelection
+  let ribbonPalette: ThemePalette
+  let ribbonCustomColor: SavedPaletteColor?
+  let ribbonMultiColor: ThemeMultiColorSelection
+  let particleSettings: DynamicParticleSettings
+}
+
+struct ThemePaletteEditorHeader: View {
+  let canUndo: Bool
+  let canRedo: Bool
+  let cancel: () -> Void
+  let undo: () -> Void
+  let redo: () -> Void
+  let apply: () -> Void
+
+  var body: some View {
+    HStack(spacing: 10) {
+      Text("Colours")
+        .font(.title2.weight(.bold))
+
+      Spacer(minLength: 8)
+
+      HStack(spacing: 2) {
+        Button("Cancel", action: cancel)
+          .padding(.horizontal, 7)
+
+        Button(action: undo) {
+          Image(systemName: "arrow.uturn.backward")
+            .frame(width: 28, height: 32)
+        }
+        .disabled(!canUndo)
+        .accessibilityLabel("Undo")
+        .help("Undo")
+
+        Button(action: redo) {
+          Image(systemName: "arrow.uturn.forward")
+            .frame(width: 28, height: 32)
+        }
+        .disabled(!canRedo)
+        .accessibilityLabel("Redo")
+        .help("Redo")
+
+        Button("Apply", action: apply)
+          .fontWeight(.semibold)
+          .padding(.horizontal, 7)
+      }
+      .font(.subheadline.weight(.medium))
+      .padding(.horizontal, 5)
+      .frame(height: 42)
+      .glassSurface(interactive: true, cornerRadius: 21)
+      .buttonStyle(.plain)
+    }
+  }
+}
+
+struct ThemePaletteEditorSliderReadout: View {
+  let title: String
+  let value: String
+
+  var body: some View {
+    VStack {
+      HStack {
+        Spacer()
+        HStack(spacing: 8) {
+          Text(title)
+            .foregroundStyle(.white.opacity(0.72))
+          Text(value)
+            .foregroundStyle(.white)
+            .monospacedDigit()
+        }
+        .font(.caption.weight(.semibold))
+        .lineLimit(1)
+        .padding(.horizontal, 14)
+        .frame(height: 36)
+        .glassSurface(cornerRadius: 18)
+      }
+      Spacer()
+    }
+    .padding(18)
+    .allowsHitTesting(false)
+    .accessibilityElement(children: .combine)
+  }
+}
+
+// MARK: - DynamicSettingsEditor
+
+struct ThemePaletteEditor: View {
+  @Environment(\.dismiss) private var dismiss
+
+  @Binding var target: ThemePaletteTarget
+  @Binding var sharedPalette: ThemePalette
+  @Binding var sharedCustomColor: SavedPaletteColor?
+  @Binding var sharedMultiColor: ThemeMultiColorSelection
+  @Binding var ribbonPalette: ThemePalette
+  @Binding var ribbonCustomColor: SavedPaletteColor?
+  @Binding var ribbonMultiColor: ThemeMultiColorSelection
+  @Binding var particleSettings: DynamicParticleSettings
+  @Binding var isShowingBackgroundOnly: Bool
+  @Binding var isPlayStation3XMBPresetExplicit: Bool
+  let dynamicBackground: DynamicBackgroundStyle
+  let onSaveAppearance: () -> Void
+
+  @AppStorage("ARMSX2iOSDynamicSavedPaletteColors") private var savedColorsJSON = "[]"
+  @State private var previewDebounceTask: Task<Void, Never>?
+  @State private var backgroundPreviewTask: Task<Void, Never>?
+  @State private var previewFadeTask: Task<Void, Never>?
+  @State private var backgroundPreviewOpacity = 0.0
+  @State private var lastThemeSnapshot: DynamicBackgroundTheme?
+  @State private var pendingOriginalTheme: DynamicBackgroundTheme?
+  @State private var pendingUpdatedTheme: DynamicBackgroundTheme?
+  @State private var activeUpdatedTheme: DynamicBackgroundTheme?
+  @State private var previewThemeSnapshot: DynamicBackgroundTheme?
+  @State private var previewShowsUpdatedTheme = false
+  @State private var activeSliderTitle: String?
+  @State private var activeSliderValue: String?
+  @State private var lastSliderInteractionEnd = Date.distantPast
+  @State private var tabTransitionMovesForward = true
+  @State private var scrollToTopRequest = 0
+  @State private var undoSnapshots: [ThemePaletteEditorSnapshot] = []
+  @State private var redoSnapshots: [ThemePaletteEditorSnapshot] = []
+  @State private var initialEditorSnapshot: ThemePaletteEditorSnapshot?
+  @State private var lastEditorSnapshot: ThemePaletteEditorSnapshot?
+  @State private var pendingUndoSnapshot: ThemePaletteEditorSnapshot?
+  @State private var historyCommitTask: Task<Void, Never>?
+  @State private var isClosingEditor = false
+
+  init(
+    target: Binding<ThemePaletteTarget>,
+    preferences: Binding<DynamicAppearancePreferences>,
+    isShowingBackgroundOnly: Binding<Bool>,
+    dynamicBackground: DynamicBackgroundStyle,
+    onSaveAppearance: @escaping () -> Void
+  ) {
+    _target = target
+    _sharedPalette = preferences.sharedPalette
+    _sharedCustomColor = preferences.sharedCustomColor
+    _sharedMultiColor = preferences.sharedMultiColor
+    _ribbonPalette = preferences.ribbonPalette
+    _ribbonCustomColor = preferences.ribbonCustomColor
+    _ribbonMultiColor = preferences.ribbonMultiColor
+    _particleSettings = preferences.particleSettings
+    _isShowingBackgroundOnly = isShowingBackgroundOnly
+    _isPlayStation3XMBPresetExplicit = preferences.isPlayStation3XMBPresetExplicit
+    self.dynamicBackground = dynamicBackground
+    self.onSaveAppearance = onSaveAppearance
+  }
+
+  var body: some View {
+    editorSurface
+      .preferredColorScheme(.dark)
+      .presentationBackground(.clear)
+      .presentationDragIndicator(isShowingBackgroundOnly ? .hidden : .visible)
+      .onAppear(perform: prepareEditor)
+      .onChange(of: currentEditorSnapshot) { oldSnapshot, newSnapshot in
+        handleEditorSnapshotChange(from: oldSnapshot, to: newSnapshot)
+      }
+      .onDisappear(perform: tearDownEditor)
+  }
+
+  // The explicit erasure keeps the release runtime from decoding the entire sheet's
+  // deeply nested SwiftUI type when the presentation bridge creates its host.
+  private var editorSurface: AnyView {
+    AnyView(
+      editorNavigation
+        .overlay {
+          if isShowingBackgroundOnly {
+            backgroundPreview
+              .opacity(backgroundPreviewOpacity)
+          }
+        }
+        .overlay {
+          if isShowingBackgroundOnly {
+            if let activeSliderTitle,
+              let activeSliderValue
+            {
+              ThemePaletteEditorSliderReadout(
+                title: activeSliderTitle,
+                value: activeSliderValue
+              )
+              .opacity(backgroundPreviewOpacity)
+            }
+          }
+        }
+    )
+  }
+
+  private var editorNavigation: AnyView {
+    AnyView(
+      NavigationStack {
+        editorScroll
+      }
+      .simultaneousGesture(tabSwipeGesture)
+      .opacity(1 - backgroundPreviewOpacity)
+      .allowsHitTesting(!isShowingBackgroundOnly || activeSliderTitle != nil)
+      .environment(
+        \.dynamicSettingsSliderActivity,
+        DynamicSettingsSliderActivity(update: updateSliderActivity)
+      )
+    )
+  }
+
+  private var editorScroll: AnyView {
+    AnyView(
+      ScrollViewReader { proxy in
+        ScrollView {
+          editorSections
+        }
+        .onChange(of: scrollToTopRequest) { _, _ in
+          var transaction = Transaction(animation: nil)
+          transaction.disablesAnimations = true
+          withTransaction(transaction) {
+            proxy.scrollTo("colours-editor-top", anchor: .top)
+          }
+        }
+      }
+      .background(
+        Color.clear
+          .glassSurface(cornerRadius: 0)
+          .ignoresSafeArea()
+      )
+    )
+  }
+
+  private var editorSections: AnyView {
+    AnyView(
+      VStack(alignment: .leading, spacing: 20) {
+        ThemePaletteEditorHeader(
+          canUndo: canRevert,
+          canRedo: !redoSnapshots.isEmpty,
+          cancel: cancelChanges,
+          undo: revertLastChange,
+          redo: redoLastChange,
+          apply: applyChanges
+        )
+        .id("colours-editor-top")
+
+        Picker("Color target", selection: $target) {
+          ForEach(ThemePaletteTarget.allCases) { target in
+            Text(target.title).tag(target)
+          }
+        }
+        .pickerStyle(.segmented)
+
+        selectedTabSections
+          .id(target)
+          .transition(tabTransition)
+      }
+      .padding(18)
+      .clipped()
+    )
+  }
+
+  @ViewBuilder
+  private var selectedTabSections: some View {
+    if target == .particles {
+      DynamicParticleSettingsControls(
+        particleSettings: $particleSettings,
+        isPlayStation3XMBPresetExplicit: $isPlayStation3XMBPresetExplicit,
+        dynamicBackground: dynamicBackground,
+        resetAllSettingsAndPalettes: resetDynamicBackgroundSettingsAndPalettes
+      )
+    } else {
+      ThemePaletteControls(
+        target: $target,
+        sharedPalette: $sharedPalette,
+        sharedCustomColor: $sharedCustomColor,
+        sharedMultiColor: $sharedMultiColor,
+        ribbonPalette: $ribbonPalette,
+        ribbonCustomColor: $ribbonCustomColor,
+        ribbonMultiColor: $ribbonMultiColor,
+        particleSettings: $particleSettings,
+        isPlayStation3XMBPresetExplicit: $isPlayStation3XMBPresetExplicit,
+        savedColorsJSON: $savedColorsJSON,
+        dynamicBackground: dynamicBackground,
+        onSaveAppearance: onSaveAppearance
+      )
+    }
+  }
+
+  private var tabTransition: AnyTransition {
+    let insertionEdge: Edge = tabTransitionMovesForward ? .trailing : .leading
+    let removalEdge: Edge = tabTransitionMovesForward ? .leading : .trailing
+    return .asymmetric(
+      insertion: .move(edge: insertionEdge).combined(with: .opacity),
+      removal: .move(edge: removalEdge).combined(with: .opacity)
+    )
+  }
+
+  private var tabSwipeGesture: some Gesture {
+    DragGesture(minimumDistance: 28)
+      .onEnded(handleTabSwipe)
+  }
+
+  private func prepareEditor() {
+    initialEditorSnapshot = currentEditorSnapshot
+    lastThemeSnapshot = currentTheme
+    lastEditorSnapshot = currentEditorSnapshot
+  }
+
+  private func handleTabSwipe(_ value: DragGesture.Value) {
+    guard
+      !isShowingBackgroundOnly,
+      activeSliderTitle == nil,
+      Date().timeIntervalSince(lastSliderInteractionEnd) > 0.2
+    else {
+      return
+    }
+
+    let horizontalDistance = value.translation.width
+    let verticalDistance = value.translation.height
+    guard
+      abs(horizontalDistance) >= 64,
+      abs(horizontalDistance) > abs(verticalDistance) * 1.25
+    else {
+      return
+    }
+
+    moveToAdjacentTab(forward: horizontalDistance < 0)
+  }
+
+  private func moveToAdjacentTab(forward: Bool) {
+    let tabs = ThemePaletteTarget.allCases
+    guard let currentIndex = tabs.firstIndex(of: target) else { return }
+    let nextIndex = currentIndex + (forward ? 1 : -1)
+    guard tabs.indices.contains(nextIndex) else { return }
+
+    tabTransitionMovesForward = forward
+    withAnimation(.easeInOut(duration: 0.28)) {
+      target = tabs[nextIndex]
+      scrollToTopRequest += 1
+    }
+  }
+
+  private var backgroundPreview: AnyView {
+    AnyView(
+      ZStack {
+        previewBackgroundLayer
+        previewDismissLayer
+      }
+    )
+  }
+
+  private var previewBackgroundLayer: AnyView {
+    AnyView(
+      DynamicBackgroundContentView(
+        style: dynamicBackground,
+        theme: previewTheme
+      )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .ignoresSafeArea()
+        .clipped()
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    )
+  }
+
+  private var previewDismissLayer: AnyView {
+    AnyView(
+      Color.clear
+        .contentShape(Rectangle())
+        .ignoresSafeArea()
+        .allowsHitTesting(activeSliderTitle == nil)
+        .onTapGesture(perform: endBackgroundPreview)
+        .accessibilityLabel("Show controls")
+    )
+  }
+
+  private var currentTheme: DynamicBackgroundTheme {
+    DynamicBackgroundTheme(
+      sharedPalette: sharedPalette,
+      sharedCustomColor: sharedCustomColor,
+      sharedMultiColor: sharedMultiColor,
+      ribbonPalette: ribbonPalette,
+      ribbonCustomColor: ribbonCustomColor,
+      ribbonMultiColor: ribbonMultiColor,
+      particleSettings: particleSettings
+    )
+  }
+
+  private var previewTheme: DynamicBackgroundTheme {
+    previewThemeSnapshot ?? currentTheme
+  }
+
+  private func scheduleBackgroundPreview() {
+    previewDebounceTask?.cancel()
+
+    let beforeDuration = particleSettings.backgroundPreviewBeforeApplyingDuration
+    let afterDuration = particleSettings.backgroundPreviewAfterApplyingDuration
+    guard beforeDuration > 0 || afterDuration > 0 else {
+      endBackgroundPreview()
+      lastThemeSnapshot = currentTheme
+      return
+    }
+
+    let updatedTheme = currentTheme
+    let previousTheme = lastThemeSnapshot ?? updatedTheme
+    lastThemeSnapshot = updatedTheme
+
+    if isShowingBackgroundOnly {
+      previewFadeTask?.cancel()
+      activeUpdatedTheme = updatedTheme
+      pendingUpdatedTheme = updatedTheme
+
+      if backgroundPreviewOpacity < 1 {
+        withAnimation(.easeInOut(duration: 0.1)) {
+          backgroundPreviewOpacity = 1
+        }
+      }
+
+      if previewShowsUpdatedTheme {
+        var themeTransaction = Transaction(animation: nil)
+        themeTransaction.disablesAnimations = true
+        withTransaction(themeTransaction) {
+          previewThemeSnapshot = updatedTheme
+        }
+        restartBackgroundPreviewHold(afterDuration: afterDuration)
+      }
+      return
+    }
+
+    backgroundPreviewTask?.cancel()
+    if pendingOriginalTheme == nil {
+      pendingOriginalTheme = previousTheme
+    }
+    pendingUpdatedTheme = updatedTheme
+
+    previewDebounceTask = Task { @MainActor in
+      await Task.yield()
+      guard !Task.isCancelled else { return }
+      beginBackgroundPreview(
+        beforeDuration: beforeDuration,
+        afterDuration: afterDuration
+      )
+    }
+  }
+
+  private func beginBackgroundPreview(
+    beforeDuration: Double,
+    afterDuration: Double
+  ) {
+    let originalTheme = pendingOriginalTheme ?? lastThemeSnapshot ?? currentTheme
+    previewFadeTask?.cancel()
+    activeUpdatedTheme = pendingUpdatedTheme ?? currentTheme
+    pendingOriginalTheme = nil
+    pendingUpdatedTheme = nil
+    previewShowsUpdatedTheme = beforeDuration <= 0
+    previewThemeSnapshot =
+      beforeDuration > 0
+      ? originalTheme
+      : activeUpdatedTheme ?? currentTheme
+
+    backgroundPreviewTask?.cancel()
+    var visibilityTransaction = Transaction(animation: nil)
+    visibilityTransaction.disablesAnimations = true
+    withTransaction(visibilityTransaction) {
+      backgroundPreviewOpacity = 0
+      isShowingBackgroundOnly = true
+    }
+    withAnimation(.easeInOut(duration: 0.1)) {
+      backgroundPreviewOpacity = 1
+    }
+
+    backgroundPreviewTask = Task { @MainActor in
+      if beforeDuration > 0 {
+        try? await Task.sleep(for: .seconds(beforeDuration))
+        guard !Task.isCancelled else { return }
+
+        var themeTransaction = Transaction(animation: nil)
+        themeTransaction.disablesAnimations = true
+        withTransaction(themeTransaction) {
+          previewShowsUpdatedTheme = true
+          previewThemeSnapshot = activeUpdatedTheme ?? currentTheme
+        }
+      }
+
+      guard activeSliderTitle == nil else { return }
+      if afterDuration > 0 {
+        try? await Task.sleep(for: .seconds(afterDuration))
+        guard !Task.isCancelled else { return }
+      }
+      endBackgroundPreview()
+    }
+  }
+
+  private func restartBackgroundPreviewHold(afterDuration: Double) {
+    backgroundPreviewTask?.cancel()
+    guard activeSliderTitle == nil else { return }
+
+    backgroundPreviewTask = Task { @MainActor in
+      if afterDuration > 0 {
+        try? await Task.sleep(for: .seconds(afterDuration))
+        guard !Task.isCancelled else { return }
+      }
+      endBackgroundPreview()
+    }
+  }
+
+  private func updateSliderActivity(
+    title: String,
+    value: String,
+    isEditing: Bool
+  ) {
+    if isEditing {
+      let beginsInteraction = activeSliderTitle == nil
+      activeSliderTitle = title
+      activeSliderValue = value
+      if beginsInteraction {
+        beginSliderBackgroundPreviewIfNeeded()
+      }
+      return
+    }
+
+    guard activeSliderTitle == title else { return }
+    activeSliderTitle = nil
+    activeSliderValue = nil
+    lastSliderInteractionEnd = Date()
+
+    if isShowingBackgroundOnly, previewShowsUpdatedTheme {
+      restartBackgroundPreviewHold(
+        afterDuration: particleSettings.backgroundPreviewAfterApplyingDuration
+      )
+    }
+  }
+
+  private func beginSliderBackgroundPreviewIfNeeded() {
+    guard !isShowingBackgroundOnly else { return }
+
+    let beforeDuration = particleSettings.backgroundPreviewBeforeApplyingDuration
+    let afterDuration = particleSettings.backgroundPreviewAfterApplyingDuration
+    guard beforeDuration > 0 || afterDuration > 0 else { return }
+
+    previewDebounceTask?.cancel()
+    backgroundPreviewTask?.cancel()
+    let unchangedTheme = lastThemeSnapshot ?? currentTheme
+    pendingOriginalTheme = unchangedTheme
+    pendingUpdatedTheme = currentTheme
+    beginBackgroundPreview(
+      beforeDuration: beforeDuration,
+      afterDuration: afterDuration
+    )
+  }
+
+  private func endBackgroundPreview() {
+    previewDebounceTask?.cancel()
+    backgroundPreviewTask?.cancel()
+    previewFadeTask?.cancel()
+    pendingOriginalTheme = nil
+    pendingUpdatedTheme = nil
+    withAnimation(.easeInOut(duration: 0.2)) {
+      backgroundPreviewOpacity = 0
+    }
+
+    previewFadeTask = Task { @MainActor in
+      try? await Task.sleep(for: .milliseconds(100))
+      guard !Task.isCancelled, backgroundPreviewOpacity == 0 else { return }
+
+      activeUpdatedTheme = nil
+      previewThemeSnapshot = nil
+      previewShowsUpdatedTheme = false
+      var visibilityTransaction = Transaction(animation: nil)
+      visibilityTransaction.disablesAnimations = true
+      withTransaction(visibilityTransaction) {
+        isShowingBackgroundOnly = false
+      }
+    }
+  }
+
+  private var currentEditorSnapshot: ThemePaletteEditorSnapshot {
+    ThemePaletteEditorSnapshot(
+      sharedPalette: sharedPalette,
+      sharedCustomColor: sharedCustomColor,
+      sharedMultiColor: sharedMultiColor,
+      ribbonPalette: ribbonPalette,
+      ribbonCustomColor: ribbonCustomColor,
+      ribbonMultiColor: ribbonMultiColor,
+      particleSettings: particleSettings,
+      isPlayStation3XMBPresetExplicit: isPlayStation3XMBPresetExplicit,
+      savedColorsJSON: savedColorsJSON
+    )
+  }
+
+  private var canRevert: Bool {
+    pendingUndoSnapshot != nil || !undoSnapshots.isEmpty
+  }
+
+  private func handleEditorSnapshotChange(
+    from oldSnapshot: ThemePaletteEditorSnapshot,
+    to newSnapshot: ThemePaletteEditorSnapshot
+  ) {
+    guard !isClosingEditor else { return }
+    recordEditorChange()
+    guard oldSnapshot.visualState != newSnapshot.visualState else { return }
+
+    if isOnlyPortraitWideningChange(from: oldSnapshot, to: newSnapshot)
+      || isOnlyBackgroundPreviewTimingChange(from: oldSnapshot, to: newSnapshot)
+    {
+      lastThemeSnapshot = currentTheme
+      return
+    }
+
+    scheduleBackgroundPreview()
+  }
+
+  private func isOnlyPortraitWideningChange(
+    from oldSnapshot: ThemePaletteEditorSnapshot,
+    to newSnapshot: ThemePaletteEditorSnapshot
+  ) -> Bool {
+    guard
+      oldSnapshot.sharedPalette == newSnapshot.sharedPalette,
+      oldSnapshot.sharedCustomColor == newSnapshot.sharedCustomColor,
+      oldSnapshot.sharedMultiColor == newSnapshot.sharedMultiColor,
+      oldSnapshot.ribbonPalette == newSnapshot.ribbonPalette,
+      oldSnapshot.ribbonCustomColor == newSnapshot.ribbonCustomColor,
+      oldSnapshot.ribbonMultiColor == newSnapshot.ribbonMultiColor,
+      oldSnapshot.particleSettings.widensPortraitBackground
+        != newSnapshot.particleSettings.widensPortraitBackground
+    else {
+      return false
+    }
+
+    var normalizedSettings = oldSnapshot.particleSettings
+    normalizedSettings.widensPortraitBackground =
+      newSnapshot.particleSettings.widensPortraitBackground
+    return normalizedSettings == newSnapshot.particleSettings
+  }
+
+  private func isOnlyBackgroundPreviewTimingChange(
+    from oldSnapshot: ThemePaletteEditorSnapshot,
+    to newSnapshot: ThemePaletteEditorSnapshot
+  ) -> Bool {
+    guard
+      oldSnapshot.sharedPalette == newSnapshot.sharedPalette,
+      oldSnapshot.sharedCustomColor == newSnapshot.sharedCustomColor,
+      oldSnapshot.sharedMultiColor == newSnapshot.sharedMultiColor,
+      oldSnapshot.ribbonPalette == newSnapshot.ribbonPalette,
+      oldSnapshot.ribbonCustomColor == newSnapshot.ribbonCustomColor,
+      oldSnapshot.ribbonMultiColor == newSnapshot.ribbonMultiColor,
+      oldSnapshot.particleSettings.backgroundPreviewBeforeApplyingDuration
+        != newSnapshot.particleSettings.backgroundPreviewBeforeApplyingDuration
+        || oldSnapshot.particleSettings.backgroundPreviewAfterApplyingDuration
+          != newSnapshot.particleSettings.backgroundPreviewAfterApplyingDuration
+    else {
+      return false
+    }
+
+    var normalizedSettings = oldSnapshot.particleSettings
+    normalizedSettings.backgroundPreviewBeforeApplyingDuration =
+      newSnapshot.particleSettings.backgroundPreviewBeforeApplyingDuration
+    normalizedSettings.backgroundPreviewAfterApplyingDuration =
+      newSnapshot.particleSettings.backgroundPreviewAfterApplyingDuration
+    return normalizedSettings == newSnapshot.particleSettings
+  }
+
+  private func tearDownEditor() {
+    if !isClosingEditor {
+      onSaveAppearance()
+      isClosingEditor = true
+    }
+
+    previewDebounceTask?.cancel()
+    backgroundPreviewTask?.cancel()
+    previewFadeTask?.cancel()
+    historyCommitTask?.cancel()
+    pendingOriginalTheme = nil
+    pendingUpdatedTheme = nil
+    activeUpdatedTheme = nil
+    previewThemeSnapshot = nil
+    previewShowsUpdatedTheme = false
+    activeSliderTitle = nil
+    activeSliderValue = nil
+    backgroundPreviewOpacity = 0
+    isShowingBackgroundOnly = false
+  }
+
+  private func recordEditorChange() {
+    let updatedSnapshot = currentEditorSnapshot
+    let previousSnapshot = lastEditorSnapshot ?? updatedSnapshot
+    guard updatedSnapshot != previousSnapshot else { return }
+
+    if pendingUndoSnapshot == nil {
+      pendingUndoSnapshot = previousSnapshot
+    }
+    lastEditorSnapshot = updatedSnapshot
+    redoSnapshots.removeAll()
+
+    historyCommitTask?.cancel()
+    historyCommitTask = Task { @MainActor in
+      try? await Task.sleep(for: .milliseconds(300))
+      guard !Task.isCancelled else { return }
+      commitPendingUndoSnapshot()
+    }
+  }
+
+  private func commitPendingUndoSnapshot() {
+    guard let snapshot = pendingUndoSnapshot else { return }
+    pendingUndoSnapshot = nil
+    undoSnapshots.append(snapshot)
+    if undoSnapshots.count > 64 {
+      undoSnapshots.removeFirst(undoSnapshots.count - 64)
+    }
+  }
+
+  private func revertLastChange() {
+    historyCommitTask?.cancel()
+    commitPendingUndoSnapshot()
+    guard let snapshot = undoSnapshots.popLast() else { return }
+
+    redoSnapshots.append(currentEditorSnapshot)
+    applyEditorSnapshot(snapshot)
+  }
+
+  private func redoLastChange() {
+    historyCommitTask?.cancel()
+    guard let snapshot = redoSnapshots.popLast() else { return }
+
+    undoSnapshots.append(currentEditorSnapshot)
+    applyEditorSnapshot(snapshot)
+  }
+
+  private func applyEditorSnapshot(_ snapshot: ThemePaletteEditorSnapshot) {
+    pendingUndoSnapshot = nil
+    sharedPalette = snapshot.sharedPalette
+    sharedCustomColor = snapshot.sharedCustomColor
+    sharedMultiColor = snapshot.sharedMultiColor
+    ribbonPalette = snapshot.ribbonPalette
+    ribbonCustomColor = snapshot.ribbonCustomColor
+    ribbonMultiColor = snapshot.ribbonMultiColor
+    particleSettings = snapshot.particleSettings
+    isPlayStation3XMBPresetExplicit = snapshot.isPlayStation3XMBPresetExplicit
+    savedColorsJSON = snapshot.savedColorsJSON
+    lastEditorSnapshot = snapshot
+  }
+
+  private func resetDynamicBackgroundSettingsAndPalettes() {
+    let defaults = DynamicAppearancePreferences.standard
+    sharedPalette = defaults.sharedPalette
+    sharedCustomColor = defaults.sharedCustomColor
+    sharedMultiColor = defaults.sharedMultiColor
+    ribbonPalette = defaults.ribbonPalette
+    ribbonCustomColor = defaults.ribbonCustomColor
+    ribbonMultiColor = defaults.ribbonMultiColor
+    particleSettings = defaults.particleSettings
+    isPlayStation3XMBPresetExplicit = defaults.isPlayStation3XMBPresetExplicit
+  }
+
+  private func cancelChanges() {
+    isClosingEditor = true
+    endBackgroundPreview()
+    if let initialEditorSnapshot {
+      applyEditorSnapshot(initialEditorSnapshot)
+    }
+    dismiss()
+  }
+
+  private func applyChanges() {
+    isClosingEditor = true
+    endBackgroundPreview()
+    onSaveAppearance()
+    dismiss()
+  }
+}

--- a/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicEffects.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicEffects.swift
@@ -1,0 +1,712 @@
+// DynamicEffects.swift — Shared dynamic background effects
+// SPDX-License-Identifier: GPL-3.0+
+
+import SwiftUI
+import UIKit
+
+struct OrbTrailBezierSegment {
+  let start: CGPoint
+  let end: CGPoint
+  let control1: CGPoint
+  let control2: CGPoint
+}
+
+enum OrbTrailGeometry {
+  static func segment(
+    points: [CGPoint],
+    index: Int,
+    maximumTangentLength: CGFloat
+  ) -> OrbTrailBezierSegment {
+    let start = points[index]
+    let end = points[index + 1]
+    let startTangent = tangent(
+      points: points,
+      index: index,
+      maximumLength: maximumTangentLength
+    )
+    let endTangent = tangent(
+      points: points,
+      index: index + 1,
+      maximumLength: maximumTangentLength
+    )
+
+    return OrbTrailBezierSegment(
+      start: start,
+      end: end,
+      control1: CGPoint(
+        x: start.x + startTangent.dx / 3,
+        y: start.y + startTangent.dy / 3
+      ),
+      control2: CGPoint(
+        x: end.x - endTangent.dx / 3,
+        y: end.y - endTangent.dy / 3
+      )
+    )
+  }
+
+  private static func tangent(
+    points: [CGPoint],
+    index: Int,
+    maximumLength: CGFloat
+  ) -> CGVector {
+    let point = points[index]
+    let previous = points[max(0, index - 1)]
+    let following = points[min(points.count - 1, index + 1)]
+    let raw = CGVector(
+      dx: (following.x - previous.x) * 0.5,
+      dy: (following.y - previous.y) * 0.5
+    )
+    let rawLength = hypot(raw.dx, raw.dy)
+    guard rawLength > 0 else { return .zero }
+
+    let adjacentLengths = [
+      hypot(point.x - previous.x, point.y - previous.y),
+      hypot(following.x - point.x, following.y - point.y),
+    ].filter { $0 > 0 }
+    guard let shortestAdjacent = adjacentLengths.min() else { return .zero }
+
+    let allowedLength = min(maximumLength, shortestAdjacent * 1.25)
+    let scale = min(1, allowedLength / rawLength)
+    return CGVector(dx: raw.dx * scale, dy: raw.dy * scale)
+  }
+}
+
+// MARK: - DynamicBackgroundEffects
+
+struct DynamicBackgroundTheme: Equatable {
+  let sharedPalette: ThemePalette
+  let sharedCustomColor: SavedPaletteColor?
+  let sharedMultiColor: ThemeMultiColorSelection
+  let ribbonPalette: ThemePalette
+  let ribbonCustomColor: SavedPaletteColor?
+  let ribbonMultiColor: ThemeMultiColorSelection
+  let particleSettings: DynamicParticleSettings
+
+  var usesDynamicSharedPalette: Bool {
+    if let sharedCustomColor {
+      return sharedCustomColor.isGradient
+    }
+
+    if sharedMultiColor.isEnabled {
+      return !sharedMultiColor.palettes.isEmpty
+        && sharedMultiColor.palettes.allSatisfy {
+          ThemePalette.primaryPalettes.contains($0)
+        }
+    }
+
+    return ThemePalette.primaryPalettes.contains(sharedPalette)
+  }
+
+  // Resolves the base palette used for background gradients and broad color fields.
+  func sharedColor(index: Int, time: TimeInterval) -> Color {
+    if sharedMultiColor.isEnabled {
+      return sharedMultiColor.color(
+        index: index,
+        time: time,
+        settings: particleSettings
+      )
+    }
+    return sharedCustomColor?.animatedColor(index: index, time: time)
+      ?? sharedPalette.animatedColor(index: index, time: time)
+  }
+
+  // Resolves the accent palette used for ribbons and foreground details.
+  func ribbonColor(index: Int, time: TimeInterval) -> Color {
+    if ribbonMultiColor.isEnabled {
+      return ribbonMultiColor.color(
+        index: index,
+        time: time,
+        settings: particleSettings
+      )
+    }
+    return ribbonCustomColor?.animatedColor(index: index, time: time)
+      ?? ribbonPalette.animatedColor(index: index, time: time)
+  }
+
+  // Keeps the default PS4 blue base while still allowing Shared Themes to override it.
+  func playStation4BaseColor(index: Int, time: TimeInterval) -> Color {
+    if sharedMultiColor.isEnabled {
+      return sharedMultiColor.color(
+        index: index,
+        time: time,
+        settings: particleSettings
+      )
+    }
+    if let sharedCustomColor {
+      return sharedCustomColor.animatedColor(index: index, time: time)
+    }
+    if sharedPalette == .blue {
+      switch index % 3 {
+      case 0:
+        return Color(red: 0.004, green: 0.025, blue: 0.16)
+      case 1:
+        return Color(red: 0.015, green: 0.2, blue: 0.58)
+      default:
+        return Color(red: 0.12, green: 0.42, blue: 1)
+      }
+    }
+    return sharedPalette.animatedColor(index: index, time: time)
+  }
+
+  var paletteDarkEffectStrength: Double {
+    guard
+      !particleSettings.disablesDarkPaletteEffects,
+      sharedCustomColor?.usesDarkEffect != false
+    else {
+      return 0
+    }
+    return min(2, max(0, particleSettings.paletteDarkEffectIntensity))
+  }
+
+  func paletteDarkEffectColor(at progress: Double) -> Color {
+    sharedCustomColor?.darkEffectColor(at: progress) ?? .black
+  }
+
+  var sharedPaletteGradientTilt: Double {
+    particleSettings.sharedPaletteGradientTilt
+  }
+
+  var sharedPaletteGradientCurvature: Double {
+    particleSettings.sharedPaletteGradientCurvature
+  }
+
+  func sharedGradientPoints(
+    from startPoint: UnitPoint,
+    to endPoint: UnitPoint
+  ) -> (start: UnitPoint, end: UnitPoint) {
+    transformedGradientPoints(
+      from: startPoint,
+      to: endPoint,
+      degrees: sharedPaletteGradientTilt,
+      offsetX: particleSettings.sharedPaletteGradientOffsetX,
+      offsetY: particleSettings.sharedPaletteGradientOffsetY,
+      width: particleSettings.sharedPaletteGradientWidth
+    )
+  }
+
+  // Produces an opaque palette stop shaded toward the customizable dark effect.
+  func paletteBackgroundColor(_ color: Color, darkness: Double) -> Color {
+    blendPaletteEffectColor(
+      color,
+      paletteDarkEffectColor(at: darkness),
+      amount: min(1, max(0, darkness * paletteDarkEffectStrength))
+    )
+  }
+
+  // Applies the same shared dark effect to vignettes without altering palette stops.
+  func paletteDarkOverlay(opacity: Double) -> Color {
+    paletteDarkEffectColor(at: opacity).opacity(
+      min(1, max(0, opacity * paletteDarkEffectStrength))
+    )
+  }
+
+  // Keeps default highlights white until the Ribbons palette is changed.
+  func highlightColor(index: Int, time: TimeInterval) -> Color {
+    if ribbonMultiColor.isEnabled || ribbonCustomColor != nil || ribbonPalette != .cyan {
+      return ribbonColor(index: index, time: time)
+    }
+    return .white
+  }
+}
+
+private func transformedGradientPoints(
+  from startPoint: UnitPoint,
+  to endPoint: UnitPoint,
+  degrees: Double,
+  offsetX: Double,
+  offsetY: Double,
+  width: Double
+) -> (start: UnitPoint, end: UnitPoint) {
+  let radians = degrees * .pi / 180
+  let cosine = CGFloat(cos(radians))
+  let sine = CGFloat(sin(radians))
+  let scale = CGFloat(max(0.05, width))
+  let center = CGPoint(
+    x: (startPoint.x + endPoint.x) * 0.5 + CGFloat(offsetX),
+    y: (startPoint.y + endPoint.y) * 0.5 + CGFloat(offsetY)
+  )
+  let halfVector = CGPoint(
+    x: (endPoint.x - startPoint.x) * 0.5 * scale,
+    y: (endPoint.y - startPoint.y) * 0.5 * scale
+  )
+  let rotatedHalfVector = CGPoint(
+    x: halfVector.x * cosine - halfVector.y * sine,
+    y: halfVector.x * sine + halfVector.y * cosine
+  )
+
+  return (
+    UnitPoint(
+      x: center.x - rotatedHalfVector.x,
+      y: center.y - rotatedHalfVector.y
+    ),
+    UnitPoint(
+      x: center.x + rotatedHalfVector.x,
+      y: center.y + rotatedHalfVector.y
+    )
+  )
+}
+
+private func blendPaletteEffectColor(
+  _ first: Color,
+  _ second: Color,
+  amount: Double
+) -> Color {
+  let progress = min(1, max(0, amount))
+  guard progress > 0 else { return first }
+
+  let firstColor = UIColor(first)
+  let secondColor = UIColor(second)
+  var firstRed: CGFloat = 0
+  var firstGreen: CGFloat = 0
+  var firstBlue: CGFloat = 0
+  var firstAlpha: CGFloat = 0
+  var secondRed: CGFloat = 0
+  var secondGreen: CGFloat = 0
+  var secondBlue: CGFloat = 0
+  var secondAlpha: CGFloat = 0
+
+  guard
+    firstColor.getRed(
+      &firstRed,
+      green: &firstGreen,
+      blue: &firstBlue,
+      alpha: &firstAlpha
+    ),
+    secondColor.getRed(
+      &secondRed,
+      green: &secondGreen,
+      blue: &secondBlue,
+      alpha: &secondAlpha
+    )
+  else {
+    return first
+  }
+
+  return Color(
+    red: Double(firstRed + (secondRed - firstRed) * progress),
+    green: Double(firstGreen + (secondGreen - firstGreen) * progress),
+    blue: Double(firstBlue + (secondBlue - firstBlue) * progress),
+    opacity: Double(firstAlpha + (secondAlpha - firstAlpha) * progress)
+  )
+}
+
+// MARK: - DynamicBackgroundUtilities
+
+enum DynamicBackgroundCoding {
+  static func decode<Value: Decodable>(
+    _ type: Value.Type,
+    from data: Data
+  ) -> Value? {
+    try? JSONDecoder().decode(type, from: data)
+  }
+
+  static func decode<Value: Decodable>(
+    _ type: Value.Type,
+    from json: String
+  ) -> Value? {
+    guard let data = json.data(using: .utf8) else { return nil }
+    return decode(type, from: data)
+  }
+
+  static func encode<Value: Encodable>(_ value: Value) -> Data? {
+    try? JSONEncoder().encode(value)
+  }
+
+  static func encodeJSONString<Value: Encodable>(_ value: Value) -> String? {
+    guard let data = encode(value) else { return nil }
+    return String(data: data, encoding: .utf8)
+  }
+}
+
+enum DynamicBackgroundMath {
+  static func clamp(_ value: Double, to range: ClosedRange<Double>) -> Double {
+    min(range.upperBound, max(range.lowerBound, value))
+  }
+
+  static func unit(_ value: Double) -> Double {
+    value - floor(value)
+  }
+
+  static func seededUnit(index: Int, salt: Double) -> Double {
+    unit(sin((Double(index) + 1) * salt) * 43_758.5453)
+  }
+
+  static func smoothstep(
+    from lowerBound: Double = 0,
+    to upperBound: Double = 1,
+    value: Double
+  ) -> Double {
+    let progress = clamp(
+      (value - lowerBound) / (upperBound - lowerBound),
+      to: 0...1
+    )
+    return progress * progress * (3 - 2 * progress)
+  }
+}
+
+enum DynamicBackgroundGeometry {
+  // Converts sampled points into a smooth Catmull-Rom-style cubic path.
+  static func smoothCurve(through points: [CGPoint]) -> Path {
+    guard let first = points.first else { return Path() }
+
+    var path = Path()
+    path.move(to: first)
+
+    for index in 0..<(points.count - 1) {
+      let previous = index > 0 ? points[index - 1] : points[index]
+      let current = points[index]
+      let next = points[index + 1]
+      let following = index + 2 < points.count ? points[index + 2] : next
+      let control1 = CGPoint(
+        x: current.x + (next.x - previous.x) / 6,
+        y: current.y + (next.y - previous.y) / 6
+      )
+      let control2 = CGPoint(
+        x: next.x - (following.x - current.x) / 6,
+        y: next.y - (following.y - current.y) / 6
+      )
+
+      path.addCurve(
+        to: next,
+        control1: control1,
+        control2: control2
+      )
+    }
+
+    return path
+  }
+}
+
+// MARK: - DynamicParticleOverlay
+
+struct DynamicParticleOverlay: View {
+  let theme: DynamicBackgroundTheme
+
+  @ViewBuilder
+  var body: some View {
+    if settings.style == .xmbMart {
+      PlayStation3XMBMartMetalSurface(
+        settings: settings.playStation3XMB,
+        theme: theme,
+        renderMode: .particlesOnly,
+        particleControls: martParticleControls
+      )
+      .ignoresSafeArea()
+    } else {
+      TimelineView(.animation(minimumInterval: 1 / 30)) { timeline in
+        let time = timeline.date.timeIntervalSinceReferenceDate
+        Canvas { context, size in
+          context.blendMode = .plusLighter
+          drawParticles(
+            context: &context,
+            size: size,
+            time: time
+          )
+        }
+        .ignoresSafeArea()
+      }
+    }
+  }
+
+  private var settings: DynamicParticleSettings {
+    theme.particleSettings
+  }
+
+  private var directedSpeed: Double {
+    settings.speed * settings.speedDirection * 2
+  }
+
+  private var martParticleControls: PlayStation3XMBMartParticleControls {
+    PlayStation3XMBMartParticleControls(
+      amount: settings.amount * settings.verticalDensity,
+      speed: settings.speed,
+      direction: settings.speedDirection,
+      dispersion: settings.dispersion,
+      verticalSpread: settings.verticalSpread,
+      outerDispersion: settings.outerDispersion,
+      verticalLevel: settings.verticalLevel,
+      size: settings.size,
+      brightness: settings.brightness,
+      opacity: settings.opacity,
+      depthVariation: settings.depthVariation
+    )
+  }
+
+  // Draws the selected particle family with the user's shared controls.
+  private func drawParticles(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval
+  ) {
+    switch settings.style {
+    case .xmb3:
+      drawXMBParticles(context: &context, size: size, time: time, baseCount: 150)
+    case .xmbMart:
+      return
+    case .ps1Dust:
+      drawPixelDust(context: &context, size: size, time: time, baseCount: 90)
+    case .ps4Glow:
+      drawGlowParticles(context: &context, size: size, time: time, baseCount: 56)
+    case .ps5Drift:
+      drawDriftParticles(context: &context, size: size, time: time, baseCount: 96)
+    case .mixed:
+      drawXMBParticles(context: &context, size: size, time: time, baseCount: 92)
+      drawPixelDust(context: &context, size: size, time: time, baseCount: 42)
+      drawGlowParticles(context: &context, size: size, time: time, baseCount: 28)
+      drawDriftParticles(context: &context, size: size, time: time, baseCount: 46)
+    }
+  }
+
+  // Draws XMB3-style sparkles around the selected vertical band.
+  private func drawXMBParticles(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval,
+    baseCount: Int
+  ) {
+    for index in 0..<particleCount(baseCount) {
+      let seed = DynamicBackgroundMath.unit(sin(Double(index + 1) * 12.9898) * 43_758.5453)
+      let secondarySeed = DynamicBackgroundMath.unit(sin(Double(index + 7) * 78.233) * 9_631.417)
+      let speed = (0.006 + Double(index % 7) * 0.0011) * directedSpeed
+      let progress = DynamicBackgroundMath.unit(seed + time * speed)
+      let center = particleCenter(
+        size: size,
+        progress: progress,
+        seed: seed,
+        time: time
+      )
+      let spread =
+        (CGFloat(secondarySeed) - 0.5)
+        * size.height
+        * (0.18 + CGFloat(seed) * 0.2)
+        * CGFloat(settings.dispersion)
+        * CGFloat(settings.verticalSpread)
+      let twinkle = particleTwinkle(seed: seed, secondarySeed: secondarySeed, time: time)
+      let diameter =
+        (CGFloat(0.7 + Double(index % 5) * 0.34) + CGFloat(twinkle) * 1.35)
+        * CGFloat(settings.size)
+        * particleDepthScale(seed: seed)
+
+      fillParticle(
+        context: &context,
+        rect: CGRect(
+          x: CGFloat(progress) * size.width - diameter / 2,
+          y: center + spread + outerVerticalOffset(seed: secondarySeed, size: size)
+            + CGFloat(sin(time * 0.24 + seed * 18)) * 7 - diameter / 2,
+          width: diameter,
+          height: diameter
+        ),
+        color: particleColor(index: index, time: time),
+        opacity: (index.isMultiple(of: 8) ? 0.52 + twinkle * 0.48 : 0.18 + twinkle * 0.3)
+          * particleDepthOpacity(seed: seed)
+      )
+    }
+  }
+
+  // Draws small square particles based on the PS1 pixel dust.
+  private func drawPixelDust(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval,
+    baseCount: Int
+  ) {
+    for index in 0..<particleCount(baseCount) {
+      let seed = Double(index) * 1.731
+      let progress = DynamicBackgroundMath.unit(
+        Double(index) * 0.071
+          + time * (0.008 + Double(index % 4) * 0.002) * directedSpeed
+      )
+      let x =
+        CGFloat(
+          sin(seed * 2.17 + time * 0.02 * settings.drift * directedSpeed)
+            * 0.5 + 0.5
+        )
+        * size.width
+      let y =
+        size.height * CGFloat(settings.verticalLevel)
+        + CGFloat(0.5 - progress) * size.height * 0.7 * CGFloat(settings.dispersion)
+        * CGFloat(settings.verticalSpread)
+        + outerVerticalOffset(seed: DynamicBackgroundMath.unit(seed * 0.731), size: size)
+      let side =
+        CGFloat(index.isMultiple(of: 9) ? 2.2 : 1.1)
+        * CGFloat(settings.size)
+        * particleDepthScale(seed: seed)
+
+      context.fill(
+        Path(
+          CGRect(
+            x: x - side / 2,
+            y: y - side / 2,
+            width: side,
+            height: side
+          )
+        ),
+        with: .color(
+          particleColor(index: index, time: time).opacity(
+            settings.brightness * settings.opacity * particleDepthOpacity(seed: seed)
+          )
+        )
+      )
+    }
+  }
+
+  // Draws soft PS4-style floating particles around the selected band.
+  private func drawGlowParticles(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval,
+    baseCount: Int
+  ) {
+    for index in 0..<particleCount(baseCount) {
+      let seed = Double(index) * 1.618
+      let x =
+        CGFloat(sin(time * 0.035 * directedSpeed + seed) * 0.5 + 0.5)
+        * size.width
+      let y =
+        size.height * CGFloat(settings.verticalLevel)
+        + CGFloat(cos(time * 0.026 * directedSpeed + seed * 1.37))
+        * size.height
+        * 0.28
+        * CGFloat(settings.dispersion)
+        * CGFloat(settings.verticalSpread)
+        + outerVerticalOffset(seed: DynamicBackgroundMath.unit(seed * 0.619), size: size)
+      let diameter =
+        CGFloat(1.2 + Double(index % 4) * 0.55)
+        * CGFloat(settings.size)
+        * particleDepthScale(seed: seed)
+
+      fillParticle(
+        context: &context,
+        rect: CGRect(
+          x: x - diameter / 2,
+          y: y - diameter / 2,
+          width: diameter,
+          height: diameter
+        ),
+        color: particleColor(index: index, time: time),
+        opacity: (index.isMultiple(of: 5) ? 0.52 : 0.34)
+          * particleDepthOpacity(seed: seed)
+      )
+    }
+  }
+
+  // Draws PS5-style drifting points across the whole screen width.
+  private func drawDriftParticles(
+    context: inout GraphicsContext,
+    size: CGSize,
+    time: TimeInterval,
+    baseCount: Int
+  ) {
+    for index in 0..<particleCount(baseCount) {
+      let seed = Double(index) * 1.618
+      let progress = DynamicBackgroundMath.unit(
+        Double(index) * 0.047
+          + time * (0.006 + Double(index % 5) * 0.0015) * directedSpeed
+      )
+      let x =
+        CGFloat(progress) * size.width
+        + CGFloat(sin(time * 0.16 * directedSpeed + seed))
+        * 24 * CGFloat(settings.drift)
+      let y =
+        size.height * CGFloat(settings.verticalLevel)
+        + CGFloat(cos(seed * 1.37)) * size.height * 0.42 * CGFloat(settings.dispersion)
+        * CGFloat(settings.verticalSpread)
+        + outerVerticalOffset(seed: DynamicBackgroundMath.unit(seed * 0.487), size: size)
+        + CGFloat(sin(time * 0.1 * directedSpeed + seed))
+        * 38 * CGFloat(settings.drift)
+      let diameter =
+        CGFloat(0.8 + Double(index % 4) * 0.52)
+        * CGFloat(settings.size)
+        * particleDepthScale(seed: seed)
+
+      fillParticle(
+        context: &context,
+        rect: CGRect(
+          x: x - diameter / 2,
+          y: y - diameter / 2,
+          width: diameter,
+          height: diameter
+        ),
+        color: particleColor(index: index, time: time),
+        opacity: (index.isMultiple(of: 7) ? 0.58 : 0.28)
+          * particleDepthOpacity(seed: seed)
+      )
+    }
+  }
+
+  // Draws one particle ellipse with the shared brightness multiplier.
+  private func fillParticle(
+    context: inout GraphicsContext,
+    rect: CGRect,
+    color: Color,
+    opacity: Double
+  ) {
+    context.fill(
+      Path(ellipseIn: rect),
+      with: .color(color.opacity(opacity * settings.brightness * settings.opacity))
+    )
+  }
+
+  private func particleCenter(
+    size: CGSize,
+    progress: Double,
+    seed: Double,
+    time: TimeInterval
+  ) -> CGFloat {
+    let normalizedY =
+      CGFloat(settings.verticalLevel)
+      + 0.095
+      * CGFloat(
+        sin(progress * .pi * 2.1 - time * 0.11 * directedSpeed + seed * 5)
+      )
+      * CGFloat(settings.dispersion)
+      * CGFloat(settings.verticalSpread)
+    return size.height * normalizedY
+  }
+
+  private func outerVerticalOffset(seed: Double, size: CGSize) -> CGFloat {
+    guard settings.outerDispersion > 0 else { return 0 }
+
+    let centeredSeed = CGFloat(DynamicBackgroundMath.unit(seed) * 2 - 1)
+    let direction: CGFloat = centeredSeed < 0 ? -1 : 1
+    let edgeBias = pow(abs(centeredSeed), 0.45)
+    return direction * edgeBias * size.height * 0.16 * CGFloat(settings.outerDispersion)
+  }
+
+  private func particleDepthScale(seed: Double) -> CGFloat {
+    let variation = (DynamicBackgroundMath.unit(seed * 1.371) - 0.5) * settings.depthVariation
+    return CGFloat(max(0.25, 1 + variation))
+  }
+
+  private func particleDepthOpacity(seed: Double) -> Double {
+    let scale = Double(particleDepthScale(seed: seed))
+    return min(1.35, max(0.35, 0.72 + scale * 0.28))
+  }
+
+  private func particleTwinkle(
+    seed: Double,
+    secondarySeed: Double,
+    time: TimeInterval
+  ) -> Double {
+    pow(
+      max(0, sin(time * (0.9 + seed) * settings.speed + secondarySeed * 14)),
+      3
+    ) * settings.twinkle
+  }
+
+  private func particleColor(index: Int, time: TimeInterval) -> Color {
+    index.isMultiple(of: 8)
+      ? theme.highlightColor(index: index, time: time)
+      : theme.ribbonColor(index: index, time: time)
+  }
+
+  private func particleCount(_ baseCount: Int) -> Int {
+    min(
+      900,
+      max(
+        0,
+        Int(Double(baseCount) * settings.amount * settings.verticalDensity)
+      )
+    )
+  }
+}

--- a/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicPalettes.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicPalettes.swift
@@ -1,0 +1,639 @@
+// DynamicPalettes.swift — Dynamic background palette definitions
+// SPDX-License-Identifier: GPL-3.0+
+
+import Foundation
+import SwiftUI
+import UIKit
+
+// MARK: - ThemePalette
+
+enum ThemePalette: String, CaseIterable, Identifiable, Equatable, Codable {
+  case blue
+  case violet
+  case cyan
+  case pink
+  case gold
+  case crimson
+  case emerald
+  case midnight
+  case burgundy
+  case graphite
+  case noir
+  case silver
+  case slate
+  case charcoal
+  case navy
+  case deepTeal
+  case lavender
+  case sunset
+  case aurora
+  case multicolor
+  case xmbFrostedPearl
+  case xmbLunarGraphite
+  case xmbGildedSun
+  case xmbAntiqueDusk
+  case xmbSpringMeadow
+  case xmbSageMidnight
+  case xmbSakuraBloom
+  case xmbRoseTwilight
+  case xmbCloverField
+  case xmbForestVelvet
+  case xmbOrchidHaze
+  case xmbVioletNocturne
+  case xmbTurquoiseLagoon
+  case xmbTidalAbyss
+  case xmbAzureHorizon
+  case xmbOceanMidnight
+  case xmbAmethystGlow
+  case xmbPurpleEclipse
+  case xmbHarvestGold
+  case xmbEmberNight
+  case xmbBronzeAutumn
+  case xmbHearthShadow
+  case xmbWinterCoral
+  case xmbCinderRed
+
+  var id: String { rawValue }
+
+  static let primaryPalettes: [ThemePalette] = [
+    .blue, .violet, .cyan, .pink, .gold, .crimson, .emerald, .midnight,
+    .burgundy, .graphite, .noir, .silver, .slate, .charcoal, .navy,
+    .deepTeal, .lavender, .sunset, .aurora, .multicolor,
+  ]
+
+  static let morePalettes: [ThemePalette] = [
+    .xmbFrostedPearl, .xmbLunarGraphite,
+    .xmbGildedSun, .xmbAntiqueDusk,
+    .xmbSpringMeadow, .xmbSageMidnight,
+    .xmbSakuraBloom, .xmbRoseTwilight,
+    .xmbCloverField, .xmbForestVelvet,
+    .xmbOrchidHaze, .xmbVioletNocturne,
+    .xmbTurquoiseLagoon, .xmbTidalAbyss,
+    .xmbAzureHorizon, .xmbOceanMidnight,
+    .xmbAmethystGlow, .xmbPurpleEclipse,
+    .xmbHarvestGold, .xmbEmberNight,
+    .xmbBronzeAutumn, .xmbHearthShadow,
+    .xmbWinterCoral, .xmbCinderRed,
+  ]
+
+  var isMorePalette: Bool {
+    Self.morePalettes.contains(self)
+  }
+
+  var lightRibbonPaletteForMart: ThemePalette {
+    switch self {
+    case .blue, .violet, .cyan, .pink, .gold, .crimson, .emerald,
+      .silver, .lavender, .sunset, .aurora, .multicolor:
+      return self
+    case .midnight: return .blue
+    case .burgundy: return .pink
+    case .graphite, .noir: return .silver
+    case .slate: return .lavender
+    case .charcoal: return .gold
+    case .navy: return .cyan
+    case .deepTeal: return .emerald
+    case .xmbFrostedPearl: return self
+    case .xmbLunarGraphite: return .xmbFrostedPearl
+    case .xmbGildedSun: return self
+    case .xmbAntiqueDusk: return .xmbGildedSun
+    case .xmbSpringMeadow: return self
+    case .xmbSageMidnight: return .xmbSpringMeadow
+    case .xmbSakuraBloom: return self
+    case .xmbRoseTwilight: return .xmbSakuraBloom
+    case .xmbCloverField: return self
+    case .xmbForestVelvet: return .xmbCloverField
+    case .xmbOrchidHaze: return self
+    case .xmbVioletNocturne: return .xmbOrchidHaze
+    case .xmbTurquoiseLagoon: return self
+    case .xmbTidalAbyss: return .xmbTurquoiseLagoon
+    case .xmbAzureHorizon: return self
+    case .xmbOceanMidnight: return .xmbAzureHorizon
+    case .xmbAmethystGlow: return self
+    case .xmbPurpleEclipse: return .xmbAmethystGlow
+    case .xmbHarvestGold: return self
+    case .xmbEmberNight: return .xmbHarvestGold
+    case .xmbBronzeAutumn: return self
+    case .xmbHearthShadow: return .xmbBronzeAutumn
+    case .xmbWinterCoral: return self
+    case .xmbCinderRed: return .xmbWinterCoral
+    }
+  }
+
+  var title: String {
+    switch self {
+    case .noir:
+      return "Black Noir"
+    case .multicolor:
+      return "Multicolor"
+    case .deepTeal:
+      return "Deep Teal"
+    case .xmbFrostedPearl:
+      return "Frosted Pearl"
+    case .xmbLunarGraphite:
+      return "Lunar Graphite"
+    case .xmbGildedSun:
+      return "Gilded Sun"
+    case .xmbAntiqueDusk:
+      return "Antique Dusk"
+    case .xmbSpringMeadow:
+      return "Spring Meadow"
+    case .xmbSageMidnight:
+      return "Sage Midnight"
+    case .xmbSakuraBloom:
+      return "Sakura Bloom"
+    case .xmbRoseTwilight:
+      return "Rose Twilight"
+    case .xmbCloverField:
+      return "Clover Field"
+    case .xmbForestVelvet:
+      return "Forest Velvet"
+    case .xmbOrchidHaze:
+      return "Orchid Haze"
+    case .xmbVioletNocturne:
+      return "Violet Nocturne"
+    case .xmbTurquoiseLagoon:
+      return "Turquoise Lagoon"
+    case .xmbTidalAbyss:
+      return "Tidal Abyss"
+    case .xmbAzureHorizon:
+      return "Azure Horizon"
+    case .xmbOceanMidnight:
+      return "Ocean Midnight"
+    case .xmbAmethystGlow:
+      return "Amethyst Glow"
+    case .xmbPurpleEclipse:
+      return "Purple Eclipse"
+    case .xmbHarvestGold:
+      return "Harvest Gold"
+    case .xmbEmberNight:
+      return "Ember Night"
+    case .xmbBronzeAutumn:
+      return "Bronze Autumn"
+    case .xmbHearthShadow:
+      return "Hearth Shadow"
+    case .xmbWinterCoral:
+      return "Winter Coral"
+    case .xmbCinderRed:
+      return "Cinder Red"
+    default:
+      return rawValue.capitalized
+    }
+  }
+}
+
+// MARK: - ThemePaletteColors
+
+extension ThemePalette {
+  var colors: [Color] {
+    switch self {
+    case .blue:
+      return [
+        Color(red: 0.12, green: 0.42, blue: 1),
+        Color(red: 0.16, green: 0.78, blue: 1),
+        .white,
+      ]
+    case .violet:
+      return [
+        Color(red: 0.58, green: 0.24, blue: 1),
+        Color(red: 0.9, green: 0.26, blue: 0.86),
+        Color(red: 0.38, green: 0.12, blue: 0.72),
+      ]
+    case .cyan:
+      return [
+        Color(red: 0.05, green: 0.78, blue: 0.95),
+        Color(red: 0.14, green: 1, blue: 0.74),
+        .white,
+      ]
+    case .pink:
+      return [
+        Color(red: 0.95, green: 0.2, blue: 0.62),
+        Color(red: 0.72, green: 0.18, blue: 1),
+        Color(red: 1, green: 0.62, blue: 0.82),
+      ]
+    case .gold:
+      return [
+        Color(red: 1, green: 0.62, blue: 0.12),
+        Color(red: 1, green: 0.9, blue: 0.38),
+        Color(red: 0.78, green: 0.28, blue: 0.04),
+      ]
+    case .crimson:
+      return [
+        Color(red: 0.88, green: 0.06, blue: 0.18),
+        Color(red: 1, green: 0.24, blue: 0.38),
+        Color(red: 0.34, green: 0.01, blue: 0.06),
+      ]
+    case .emerald:
+      return [
+        Color(red: 0.04, green: 0.72, blue: 0.42),
+        Color(red: 0.2, green: 1, blue: 0.66),
+        Color(red: 0.01, green: 0.2, blue: 0.12),
+      ]
+    case .midnight:
+      return [
+        Color(red: 0.08, green: 0.12, blue: 0.42),
+        Color(red: 0.16, green: 0.3, blue: 0.72),
+        Color(red: 0.02, green: 0.04, blue: 0.14),
+      ]
+    case .burgundy:
+      return [
+        Color(red: 0.35, green: 0.03, blue: 0.14),
+        Color(red: 0.62, green: 0.08, blue: 0.28),
+        Color(red: 0.14, green: 0.01, blue: 0.06),
+      ]
+    case .graphite:
+      return [
+        Color(red: 0.32, green: 0.38, blue: 0.48),
+        Color(red: 0.62, green: 0.72, blue: 0.82),
+        Color(red: 0.07, green: 0.08, blue: 0.11),
+      ]
+    case .noir:
+      return [
+        Color(white: 0.58),
+        Color(white: 0.16),
+        Color(white: 0.9),
+      ]
+    case .silver:
+      return [
+        Color(white: 0.78),
+        Color(white: 0.95),
+        Color(white: 0.36),
+      ]
+    case .slate:
+      return [
+        Color(red: 0.28, green: 0.36, blue: 0.46),
+        Color(red: 0.46, green: 0.58, blue: 0.7),
+        Color(red: 0.08, green: 0.11, blue: 0.16),
+      ]
+    case .charcoal:
+      return [
+        Color(white: 0.24),
+        Color(white: 0.42),
+        Color(white: 0.055),
+      ]
+    case .navy:
+      return [
+        Color(red: 0.025, green: 0.09, blue: 0.28),
+        Color(red: 0.08, green: 0.24, blue: 0.56),
+        Color(red: 0.005, green: 0.018, blue: 0.08),
+      ]
+    case .deepTeal:
+      return [
+        Color(red: 0.02, green: 0.34, blue: 0.38),
+        Color(red: 0.04, green: 0.66, blue: 0.62),
+        Color(red: 0.004, green: 0.09, blue: 0.1),
+      ]
+    case .lavender:
+      return [
+        Color(red: 0.62, green: 0.48, blue: 0.94),
+        Color(red: 0.86, green: 0.72, blue: 1),
+        Color(red: 0.21, green: 0.12, blue: 0.38),
+      ]
+    case .sunset:
+      return [
+        Color(red: 1, green: 0.24, blue: 0.28),
+        Color(red: 1, green: 0.58, blue: 0.16),
+        Color(red: 0.58, green: 0.12, blue: 0.68),
+      ]
+    case .aurora:
+      return [
+        Color(red: 0.12, green: 0.9, blue: 0.68),
+        Color(red: 0.28, green: 0.44, blue: 1),
+        Color(red: 0.74, green: 0.2, blue: 0.94),
+      ]
+    case .xmbFrostedPearl:
+      return Self.xmbColors(start: (197, 197, 197), end: (201, 201, 201))
+    case .xmbLunarGraphite:
+      return Self.xmbColors(start: (181, 181, 181), end: (0, 0, 0))
+    case .xmbGildedSun:
+      return Self.xmbColors(start: (203, 158, 13), end: (219, 214, 41))
+    case .xmbAntiqueDusk:
+      return Self.xmbColors(start: (198, 188, 128), end: (0, 0, 0))
+    case .xmbSpringMeadow:
+      return Self.xmbColors(start: (142, 190, 40), end: (104, 168, 22))
+    case .xmbSageMidnight:
+      return Self.xmbColors(start: (152, 170, 113), end: (0, 0, 0))
+    case .xmbSakuraBloom:
+      return Self.xmbColors(start: (216, 182, 182), end: (231, 66, 117))
+    case .xmbRoseTwilight:
+      return Self.xmbColors(start: (212, 174, 182), end: (10, 8, 8))
+    case .xmbCloverField:
+      return Self.xmbColors(start: (19, 108, 19), end: (24, 156, 24))
+    case .xmbForestVelvet:
+      return Self.xmbColors(start: (48, 118, 48), end: (11, 3, 11))
+    case .xmbOrchidHaze:
+      return Self.xmbColors(start: (198, 120, 238), end: (103, 77, 161))
+    case .xmbVioletNocturne:
+      return Self.xmbColors(start: (209, 163, 225), end: (0, 0, 0))
+    case .xmbTurquoiseLagoon:
+      return Self.xmbColors(start: (0, 167, 146), end: (10, 240, 239))
+    case .xmbTidalAbyss:
+      return Self.xmbColors(start: (16, 129, 124), end: (17, 0, 0))
+    case .xmbAzureHorizon:
+      return Self.xmbColors(start: (0, 0, 95), end: (33, 217, 255))
+    case .xmbOceanMidnight:
+      return Self.xmbColors(start: (20, 159, 176), end: (0, 0, 31))
+    case .xmbAmethystGlow:
+      return Self.xmbColors(start: (146, 44, 155), end: (217, 98, 236))
+    case .xmbPurpleEclipse:
+      return Self.xmbColors(start: (116, 0, 153), end: (12, 0, 11))
+    case .xmbHarvestGold:
+      return Self.xmbColors(start: (227, 151, 15), end: (224, 187, 2))
+    case .xmbEmberNight:
+      return Self.xmbColors(start: (216, 142, 0), end: (0, 0, 0))
+    case .xmbBronzeAutumn:
+      return Self.xmbColors(start: (115, 68, 20), end: (154, 118, 47))
+    case .xmbHearthShadow:
+      return Self.xmbColors(start: (131, 86, 32), end: (18, 20, 17))
+    case .xmbWinterCoral:
+      return Self.xmbColors(start: (236, 68, 45), end: (214, 63, 43))
+    case .xmbCinderRed:
+      return Self.xmbColors(start: (157, 59, 44), end: (0, 0, 3))
+    case .multicolor:
+      return [
+        .cyan,
+        .pink,
+        .purple,
+        .green,
+        .orange,
+        .white,
+      ]
+    }
+  }
+
+  private static func xmbColors(
+    start: (red: Int, green: Int, blue: Int),
+    end: (red: Int, green: Int, blue: Int)
+  ) -> [Color] {
+    let startColor = Color(
+      red: Double(start.red) / 255,
+      green: Double(start.green) / 255,
+      blue: Double(start.blue) / 255
+    )
+    let endColor = Color(
+      red: Double(end.red) / 255,
+      green: Double(end.green) / 255,
+      blue: Double(end.blue) / 255
+    )
+    let midpoint = Color(
+      red: Double(start.red + end.red) / 510,
+      green: Double(start.green + end.green) / 510,
+      blue: Double(start.blue + end.blue) / 510
+    )
+    return [endColor, startColor, midpoint]
+  }
+}
+
+// MARK: - ThemePaletteRelationships
+
+extension ThemePalette {
+  var relatedMultiColorPalettes: [ThemePalette] {
+    switch self {
+    case .blue:
+      return [.blue, .cyan, .midnight, .silver]
+    case .violet:
+      return [.violet, .lavender, .pink, .aurora]
+    case .cyan:
+      return [.cyan, .deepTeal, .blue, .emerald]
+    case .pink:
+      return [.pink, .violet, .lavender, .sunset]
+    case .gold:
+      return [.gold, .sunset, .crimson, .silver]
+    case .crimson:
+      return [.crimson, .burgundy, .sunset, .gold]
+    case .emerald:
+      return [.emerald, .deepTeal, .cyan, .aurora]
+    case .midnight:
+      return [.midnight, .navy, .blue, .slate]
+    case .burgundy:
+      return [.burgundy, .crimson, .pink, .noir]
+    case .graphite:
+      return [.graphite, .slate, .silver, .charcoal]
+    case .noir:
+      return [.noir, .charcoal, .graphite, .silver]
+    case .silver:
+      return [.silver, .graphite, .slate, .blue]
+    case .slate:
+      return [.slate, .graphite, .navy, .silver]
+    case .charcoal:
+      return [.charcoal, .graphite, .noir, .slate]
+    case .navy:
+      return [.navy, .midnight, .blue, .deepTeal]
+    case .deepTeal:
+      return [.deepTeal, .cyan, .emerald, .navy]
+    case .lavender:
+      return [.lavender, .violet, .pink, .aurora]
+    case .sunset:
+      return [.sunset, .gold, .crimson, .pink]
+    case .aurora:
+      return [.aurora, .cyan, .emerald, .violet]
+    case .xmbFrostedPearl, .xmbLunarGraphite:
+      return [.xmbFrostedPearl, .xmbLunarGraphite, .silver, .graphite]
+    case .xmbGildedSun, .xmbAntiqueDusk:
+      return [.xmbGildedSun, .xmbAntiqueDusk, .gold, .xmbBronzeAutumn]
+    case .xmbSpringMeadow, .xmbSageMidnight:
+      return [.xmbSpringMeadow, .xmbSageMidnight, .emerald, .deepTeal]
+    case .xmbSakuraBloom, .xmbRoseTwilight:
+      return [.xmbSakuraBloom, .xmbRoseTwilight, .pink, .burgundy]
+    case .xmbCloverField, .xmbForestVelvet:
+      return [.xmbCloverField, .xmbForestVelvet, .emerald, .charcoal]
+    case .xmbOrchidHaze, .xmbVioletNocturne:
+      return [.xmbOrchidHaze, .xmbVioletNocturne, .violet, .lavender]
+    case .xmbTurquoiseLagoon, .xmbTidalAbyss:
+      return [.xmbTurquoiseLagoon, .xmbTidalAbyss, .cyan, .deepTeal]
+    case .xmbAzureHorizon, .xmbOceanMidnight:
+      return [.xmbAzureHorizon, .xmbOceanMidnight, .blue, .navy]
+    case .xmbAmethystGlow, .xmbPurpleEclipse:
+      return [.xmbAmethystGlow, .xmbPurpleEclipse, .pink, .violet]
+    case .xmbHarvestGold, .xmbEmberNight:
+      return [.xmbHarvestGold, .xmbEmberNight, .gold, .crimson]
+    case .xmbBronzeAutumn, .xmbHearthShadow:
+      return [.xmbBronzeAutumn, .xmbHearthShadow, .gold, .charcoal]
+    case .xmbWinterCoral, .xmbCinderRed:
+      return [.xmbWinterCoral, .xmbCinderRed, .crimson, .burgundy]
+    case .multicolor:
+      return [.multicolor, .cyan, .pink, .gold]
+    }
+  }
+
+  // Returns a static palette color, or rotates through hues for Multicolor.
+  func animatedColor(index: Int, time: TimeInterval) -> Color {
+    guard self == .multicolor else {
+      return colors[index % colors.count]
+    }
+    let hue = (time * 0.055 + Double(index) * 0.137)
+      .truncatingRemainder(dividingBy: 1)
+    return Color(
+      hue: hue,
+      saturation: 0.86,
+      brightness: 1
+    )
+  }
+}
+
+// MARK: - ThemePaletteTarget
+
+enum ThemePaletteTarget: String, CaseIterable, Identifiable {
+  case shared
+  case ribbons
+  case particles
+
+  var id: String { rawValue }
+
+  var title: String {
+    switch self {
+    case .shared:
+      return "Shared Themes"
+    case .ribbons:
+      return "Ribbons"
+    case .particles:
+      return "Dynamic Settings"
+    }
+  }
+}
+
+// MARK: - SavedPaletteColor
+
+struct SavedPaletteColor: Codable, Hashable, Identifiable {
+  let hex: String
+  let gradientHexes: [String]?
+  let darkEffectHex: String?
+  let darkEffectGradientHexes: [String]?
+  let darkEffectEnabled: Bool?
+
+  var id: String {
+    ([hex] + (gradientHexes ?? []) + [darkEffectHex ?? ""]
+      + (darkEffectGradientHexes ?? [])
+      + [darkEffectEnabled.map(String.init) ?? ""]).joined(separator: "-")
+  }
+
+  var isGradient: Bool {
+    guard let gradientHexes else { return false }
+    return gradientHexes.count > 1
+  }
+
+  var gradientColors: [Color] {
+    if let gradientHexes, !gradientHexes.isEmpty {
+      return gradientHexes.map(Self.color(from:))
+    }
+
+    let components = rgbComponents
+    return [
+      Color(
+        red: components.red * 0.34,
+        green: components.green * 0.34,
+        blue: components.blue * 0.34
+      ),
+      Color(
+        red: components.red,
+        green: components.green,
+        blue: components.blue
+      ),
+      Color(
+        red: components.red + (1 - components.red) * 0.38,
+        green: components.green + (1 - components.green) * 0.38,
+        blue: components.blue + (1 - components.blue) * 0.38
+      ),
+    ]
+  }
+
+  var darkEffectColor: Color? {
+    darkEffectColor(at: 0)
+  }
+
+  var usesDarkEffect: Bool {
+    darkEffectEnabled ?? true
+  }
+
+  func darkEffectColor(at progress: Double) -> Color? {
+    let hexes = darkEffectGradientHexes ?? darkEffectHex.map { [$0] }
+    guard let hexes, let firstHex = hexes.first else { return nil }
+    guard hexes.count > 1 else { return Self.color(from: firstHex) }
+
+    let position = min(1, max(0, progress)) * Double(hexes.count - 1)
+    let lowerIndex = min(hexes.count - 1, Int(floor(position)))
+    let upperIndex = min(hexes.count - 1, lowerIndex + 1)
+    let amount = position - Double(lowerIndex)
+    let lower = Self.rgbComponents(for: hexes[lowerIndex])
+    let upper = Self.rgbComponents(for: hexes[upperIndex])
+    return Color(
+      red: lower.red + (upper.red - lower.red) * amount,
+      green: lower.green + (upper.green - lower.green) * amount,
+      blue: lower.blue + (upper.blue - lower.blue) * amount
+    )
+  }
+
+  // Stores a SwiftUI color as an RGB hex value that can be saved in AppStorage.
+  init?(color: Color) {
+    guard let hex = Self.hexValue(for: color) else { return nil }
+    self.hex = hex
+    gradientHexes = nil
+    darkEffectHex = nil
+    darkEffectGradientHexes = nil
+    darkEffectEnabled = nil
+  }
+
+  init?(
+    colors: [Color],
+    darkEffectColors: [Color]? = nil,
+    darkEffectEnabled: Bool = true
+  ) {
+    let hexes = colors.compactMap(Self.hexValue(for:))
+    guard hexes.count == colors.count, hexes.count > 1 else { return nil }
+    let darkEffectHexes = darkEffectColors?.compactMap(Self.hexValue(for:))
+    guard darkEffectColors == nil || darkEffectHexes?.count == darkEffectColors?.count else {
+      return nil
+    }
+    hex = hexes[0]
+    gradientHexes = hexes
+    darkEffectHex = darkEffectHexes?.first
+    darkEffectGradientHexes = darkEffectHexes
+    self.darkEffectEnabled = darkEffectEnabled
+  }
+
+  // Resolves either a saved gradient stop or the generated variants of a solid color.
+  func animatedColor(index: Int, time _: TimeInterval) -> Color {
+    let colors = gradientColors
+    return colors[index % colors.count]
+  }
+
+  private var rgbComponents: (red: Double, green: Double, blue: Double) {
+    Self.rgbComponents(for: hex)
+  }
+
+  private static func color(from hex: String) -> Color {
+    let components = rgbComponents(for: hex)
+    return Color(
+      red: components.red,
+      green: components.green,
+      blue: components.blue
+    )
+  }
+
+  private static func rgbComponents(
+    for hex: String
+  ) -> (red: Double, green: Double, blue: Double) {
+    let value = UInt64(hex.dropFirst(), radix: 16) ?? 0
+    return (
+      Double((value >> 16) & 0xFF) / 255,
+      Double((value >> 8) & 0xFF) / 255,
+      Double(value & 0xFF) / 255
+    )
+  }
+
+  private static func hexValue(for color: Color) -> String? {
+    let uiColor = UIColor(color)
+    var red: CGFloat = 0
+    var green: CGFloat = 0
+    var blue: CGFloat = 0
+    var alpha: CGFloat = 0
+    guard uiColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
+      return nil
+    }
+    return String(
+      format: "#%02X%02X%02X",
+      Int(red * 255),
+      Int(green * 255),
+      Int(blue * 255)
+    )
+  }
+}

--- a/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicSettings.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicSettings.swift
@@ -1,0 +1,2389 @@
+// DynamicSettings.swift — Dynamic background models and advanced controls
+// SPDX-License-Identifier: GPL-3.0+
+
+import Foundation
+import SwiftUI
+import UIKit
+
+// MARK: - DynamicBackgroundSettings
+
+enum DynamicParticleStyle: String, CaseIterable, Identifiable, Codable {
+  case xmb3
+  case xmbMart
+  case ps1Dust
+  case ps4Glow
+  case ps5Drift
+  case mixed
+
+  var id: String { rawValue }
+
+  var title: String {
+    switch self {
+    case .xmb3:
+      return "XMB3 Sparkles"
+    case .xmbMart:
+      return "PlayStation 3 XMB by Mart"
+    case .ps1Dust:
+      return "PS1 Dust"
+    case .ps4Glow:
+      return "PS4 Glow"
+    case .ps5Drift:
+      return "PS5 Drift"
+    case .mixed:
+      return "Mixed"
+    }
+  }
+}
+
+struct DynamicBackgroundMotionSettings: Equatable, Codable {
+  var multicolorAmbientSpeed = 1.0
+  var lightSpeedMotionSpeed = 1.0
+  var spatialRetroSpeed = 1.0
+  var towersOrbsSpeed = 1.0
+  var playStation2MenuSceneSpeed = 1.0
+  var playStation2MenuFramesPerSecond = 15.0
+  var playStation2MenuYawSpeed = 2.0
+  var playStation2MenuRollSpeed = 6.0
+  var playStation2MenuOrbitDegrees = 25.0
+  var playStation2MenuColorsTowers = false
+  var faceButtonsSpeed = 1.0
+  var faceButtonsShowsLightBands = true
+  var playStationPortableBlurSpeed = 1.0
+  var playStation3SplinesSpeed = 1.0
+  var playStation4ParticlesSpeed = 1.0
+  var playStation4WavesSpeed = 1.0
+  var playStationRibbonsSpeed = 1.0
+  var playStationPortableBlur = PlayStationPortableBlurSettings()
+  var playStation3Splines = PlayStation3SplinesSettings()
+  var playStation4Particles = PlayStation4ParticlesSettings()
+  var playStation4Waves = PlayStation4WavesSettings()
+  var playStationRibbons = PlayStationRibbonsSettings()
+}
+
+struct DynamicParticleSettings: Equatable, Codable {
+  var isEnabled = false
+  var style: DynamicParticleStyle = .xmb3
+  var amount = 1.0
+  var speed = 1.0
+  var speedDirection = 0.5
+  var dispersion = 1.0
+  var verticalSpread = 1.0
+  var verticalDensity = 1.0
+  var outerDispersion = 0.0
+  var size = 1.0
+  var brightness = 0.7
+  var opacity = 1.0
+  var depthVariation = 0.0
+  var twinkle = 0.65
+  var drift = 0.55
+  var verticalLevel = 0.5
+  var widensPortraitBackground = true
+  var backgroundPreviewBeforeApplyingDuration = 0.3
+  var backgroundPreviewAfterApplyingDuration = 0.7
+  var disablesDarkPaletteEffects = false
+  var paletteDarkEffectIntensity = 1.0
+  var sharedPaletteGradientTilt = 0.0
+  var sharedPaletteGradientOffsetX = 0.0
+  var sharedPaletteGradientOffsetY = 0.0
+  var sharedPaletteGradientWidth = 1.0
+  var sharedPaletteGradientCurvature = 0.0
+  var multiColorAnimationSpeed = 1.0
+  var multiColorAnimationSmoothness = 0.85
+  var multiColorAnimationSpread = 0.35
+  var faceButtonsEnabled = false
+  var faceButtonAmount = 1.0
+  var faceButtonSpeed = 0.33
+  var faceButtonDispersion = 1.0
+  var faceButtonSize = 1.0
+  var faceButtonOpacity = 0.86
+  var faceButtonRotation = 1.0
+  var faceButtonPulse = 0.75
+  var playStation3XMB = PlayStation3XMBSettings()
+  var backgrounds = DynamicBackgroundMotionSettings()
+}
+
+struct ThemeMultiColorSelection: Equatable, Codable {
+  var isEnabled = false
+  var animates = false
+  var palettes: [ThemePalette] = [.blue, .cyan, .pink, .gold]
+
+  private var activePalettes: [ThemePalette] {
+    palettes.isEmpty ? [.blue] : palettes
+  }
+
+  // Enables multi-color mode and gives it a valid fallback palette.
+  mutating func setEnabled(_ enabled: Bool, fallback: ThemePalette) {
+    isEnabled = enabled
+    if enabled {
+      palettes = fallback.relatedMultiColorPalettes
+    }
+  }
+
+  // Adds or removes a palette while keeping at least one multi-color selected.
+  mutating func toggle(_ palette: ThemePalette, fallback: ThemePalette) {
+    if let index = palettes.firstIndex(of: palette) {
+      if palettes.count > 1 {
+        palettes.remove(at: index)
+      }
+    } else {
+      palettes.append(palette)
+    }
+
+    if palettes.isEmpty {
+      palettes = [fallback]
+    }
+  }
+
+  // Returns the numbered selection badge for a palette in multi-color mode.
+  func selectionNumber(for palette: ThemePalette) -> Int? {
+    guard let index = palettes.firstIndex(of: palette) else { return nil }
+    return index + 1
+  }
+
+  // Resolves colors from the selected palette list with optional soft animation.
+  func color(
+    index: Int,
+    time: TimeInterval,
+    settings: DynamicParticleSettings
+  ) -> Color {
+    let selectedPalettes = activePalettes
+
+    guard animates, selectedPalettes.count > 1 else {
+      return selectedPalettes[index % selectedPalettes.count].animatedColor(
+        index: index,
+        time: 0
+      )
+    }
+
+    let progress =
+      time * max(0.02, settings.multiColorAnimationSpeed) / 8
+      + Double(index) * settings.multiColorAnimationSpread
+    let step = Int(floor(progress))
+    let fraction = progress - floor(progress)
+    let fromPalette = selectedPalettes[positiveModulo(index + step, selectedPalettes.count)]
+    let toPalette = selectedPalettes[positiveModulo(index + step + 1, selectedPalettes.count)]
+    let blend = easedBlend(
+      fraction,
+      smoothness: settings.multiColorAnimationSmoothness
+    )
+
+    return blendedColor(
+      fromPalette.animatedColor(
+        index: index,
+        time: time * 0.12
+      ),
+      toPalette.animatedColor(
+        index: index,
+        time: time * 0.12
+      ),
+      amount: blend
+    )
+  }
+
+  private func easedBlend(_ fraction: Double, smoothness: Double) -> Double {
+    let clampedSmoothness = min(1, max(0, smoothness))
+    let smooth = fraction * fraction * (3 - 2 * fraction)
+    return fraction * (1 - clampedSmoothness) + smooth * clampedSmoothness
+  }
+
+  private func blendedColor(_ first: Color, _ second: Color, amount: Double) -> Color {
+    let firstColor = UIColor(first)
+    let secondColor = UIColor(second)
+    var firstRed: CGFloat = 0
+    var firstGreen: CGFloat = 0
+    var firstBlue: CGFloat = 0
+    var firstAlpha: CGFloat = 0
+    var secondRed: CGFloat = 0
+    var secondGreen: CGFloat = 0
+    var secondBlue: CGFloat = 0
+    var secondAlpha: CGFloat = 0
+
+    guard
+      firstColor.getRed(
+        &firstRed,
+        green: &firstGreen,
+        blue: &firstBlue,
+        alpha: &firstAlpha
+      ),
+      secondColor.getRed(
+        &secondRed,
+        green: &secondGreen,
+        blue: &secondBlue,
+        alpha: &secondAlpha
+      )
+    else {
+      return amount < 0.5 ? first : second
+    }
+
+    let blend = min(1, max(0, amount))
+    return Color(
+      red: Double(firstRed + (secondRed - firstRed) * blend),
+      green: Double(firstGreen + (secondGreen - firstGreen) * blend),
+      blue: Double(firstBlue + (secondBlue - firstBlue) * blend),
+      opacity: Double(firstAlpha + (secondAlpha - firstAlpha) * blend)
+    )
+  }
+
+  private func positiveModulo(_ value: Int, _ divisor: Int) -> Int {
+    ((value % divisor) + divisor) % divisor
+  }
+}
+
+// MARK: - PlayStationBackgroundSettings
+
+struct PlayStation3SplinesSettings: Equatable, Codable {
+  var showsSplines = true
+  var showsParticles = true
+  var strandCount = 15.0
+  var verticalPosition = 0.66
+  var strandSpacing = 1.0
+  var waveAmplitude = 1.0
+  var detailAmplitude = 1.0
+  var phaseSpread = 1.0
+  var glowOpacity = 1.0
+  var coreOpacity = 1.0
+  var glowWidth = 1.0
+  var coreWidth = 1.0
+  var glowBlur = 1.0
+  var particleCount = 150.0
+  var particleSpeed = 1.0
+  var particleSpread = 1.0
+  var particleSize = 1.0
+  var particleOpacity = 1.0
+  var particleTwinkle = 1.0
+  var backgroundIntensity = 1.0
+  var vignetteIntensity = 1.0
+}
+
+struct PlayStation4ParticlesSettings: Equatable, Codable {
+  var showsParticles = true
+  var showsWaves = true
+  var showsWaveGlow = true
+  var showsWaveCores = true
+  var particleCount = 150.0
+  var particleSpeed = 1.0
+  var particleVerticalPosition = 0.48
+  var particleSpread = 1.0
+  var particleSize = 1.0
+  var particleOpacity = 1.0
+  var particleTwinkle = 1.0
+  var waveCount = 8.0
+  var waveVerticalPosition = 0.48
+  var waveSpacing = 1.0
+  var waveAmplitude = 1.0
+  var waveCurvature = 1.0
+  var phaseSpread = 1.0
+  var glowBlur = 18.0
+  var glowWidth = 1.0
+  var glowOpacity = 1.0
+  var coreWidth = 1.0
+  var coreOpacity = 1.0
+  var backgroundIntensity = 1.0
+  var vignetteIntensity = 1.0
+}
+
+struct PlayStation4WavesSettings: Equatable, Codable {
+  var showsAmbientGlows = true
+  var showsParticles = true
+  var showsWaves = true
+  var showsWaveGlow = true
+  var showsWaveCores = true
+  var particleCount = 38.0
+  var particleSpeed = 1.0
+  var particleSpread = 1.0
+  var particleSize = 1.0
+  var particleOpacity = 1.0
+  var waveCount = 8.0
+  var waveVerticalPosition = 0.48
+  var waveSpacing = 1.0
+  var waveAmplitude = 1.0
+  var waveCurvature = 1.0
+  var phaseSpread = 1.0
+  var glowBlur = 18.0
+  var glowWidth = 1.0
+  var glowOpacity = 1.0
+  var coreWidth = 1.0
+  var coreOpacity = 1.0
+  var ambientGlowScale = 1.0
+  var ambientGlowIntensity = 1.0
+  var vignetteIntensity = 1.0
+}
+
+struct PlayStationRibbonsSettings: Equatable, Codable {
+  var showsPanels = true
+  var showsPanelGlow = true
+  var showsPanelEdges = true
+  var showsParticles = true
+  var panelCount = 6.0
+  var panelVerticalPosition = 0.14
+  var panelSpacing = 1.0
+  var panelAmplitude = 1.0
+  var panelThickness = 1.0
+  var panelCurvature = 1.0
+  var phaseSpread = 1.0
+  var panelFillOpacity = 1.0
+  var panelGlowOpacity = 1.0
+  var panelGlowBlur = 1.0
+  var panelEdgeOpacity = 1.0
+  var panelEdgeWidth = 1.0
+  var particleCount = 86.0
+  var particleSpeed = 1.0
+  var particleDrift = 1.0
+  var particleVerticalSpread = 1.0
+  var particleSize = 1.0
+  var particleOpacity = 1.0
+  var ambientGlowScale = 1.0
+  var ambientGlowIntensity = 1.0
+  var vignetteIntensity = 1.0
+}
+
+struct PlayStationPortableBlurSettings: Equatable, Codable {
+  var showsRibbons = true
+  var showsGlow = true
+  var showsCores = true
+  var alternatesDirection = true
+  var ribbonCount = 7.0
+  var verticalOffset = 0.0
+  var waveAmplitude = 1.0
+  var detailAmplitude = 1.0
+  var phaseSpread = 1.0
+  var broadWidth = 1.0
+  var glowBlur = 1.0
+  var glowOpacity = 1.0
+  var coreWidth = 1.0
+  var coreBlur = 1.0
+  var coreOpacity = 1.0
+  var backgroundIntensity = 1.0
+  var ambientGlowScale = 1.0
+  var ambientGlowIntensity = 1.0
+  var vignetteIntensity = 0.0
+}
+
+// MARK: - PlayStation3XMBSettings
+
+enum PlayStation3XMBGradientPreset: String, CaseIterable, Identifiable, Codable {
+  case theme
+  case original
+  case januaryDay = "01_day"
+  case januaryNight = "01_night"
+  case februaryDay = "02_day"
+  case februaryNight = "02_night"
+  case marchDay = "03_day"
+  case marchNight = "03_night"
+  case aprilDay = "04_day"
+  case aprilNight = "04_night"
+  case mayDay = "05_day"
+  case mayNight = "05_night"
+  case juneDay = "06_day"
+  case juneNight = "06_night"
+  case julyDay = "07_day"
+  case julyNight = "07_night"
+  case augustDay = "08_day"
+  case augustNight = "08_night"
+  case septemberDay = "09_day"
+  case septemberNight = "09_night"
+  case octoberDay = "10_day"
+  case octoberNight = "10_night"
+  case novemberDay = "11_day"
+  case novemberNight = "11_night"
+  case decemberDay = "12_day"
+  case decemberNight = "12_night"
+
+  var id: String { rawValue }
+
+  var title: String {
+    switch self {
+    case .theme:
+      return "Shared Themes + Ribbons"
+    case .original:
+      return "Original (RGB Sliders)"
+    case .januaryDay: return "01 (Day)"
+    case .januaryNight: return "01 (Night)"
+    case .februaryDay: return "02 (Day)"
+    case .februaryNight: return "02 (Night)"
+    case .marchDay: return "03 (Day)"
+    case .marchNight: return "03 (Night)"
+    case .aprilDay: return "04 (Day)"
+    case .aprilNight: return "04 (Night)"
+    case .mayDay: return "05 (Day)"
+    case .mayNight: return "05 (Night)"
+    case .juneDay: return "06 (Day)"
+    case .juneNight: return "06 (Night)"
+    case .julyDay: return "07 (Day)"
+    case .julyNight: return "07 (Night)"
+    case .augustDay: return "08 (Day)"
+    case .augustNight: return "08 (Night)"
+    case .septemberDay: return "09 (Day)"
+    case .septemberNight: return "09 (Night)"
+    case .octoberDay: return "10 (Day)"
+    case .octoberNight: return "10 (Night)"
+    case .novemberDay: return "11 (Day)"
+    case .novemberNight: return "11 (Night)"
+    case .decemberDay: return "12 (Day)"
+    case .decemberNight: return "12 (Night)"
+    }
+  }
+}
+
+struct PlayStation3XMBSettings: Equatable, Codable {
+  var gradientPreset: PlayStation3XMBGradientPreset = .theme
+
+  var colorR = 37.0
+  var colorG = 89.0
+  var colorB = 179.0
+  var gradientTopMul = 0.09
+  var gradientBotMul = 0.62
+
+  var particleCount = 600.0
+  var particleOpacity = 0.75
+  var particleSizeBase = 10.0
+  var particleSizeVariance = 1.5
+  var particleFlowSpeed = 0.18
+  var particleVerticalSpread = 1.0
+  var particleVerticalDensity = 1.0
+  var particleOuterDispersion = 0.0
+  var particleDepthVariation = 0.0
+  var particlesFollowWaveY = true
+
+  var flowSpeed = 0.18
+  var tension = 0.12
+  var damping = 0.0001
+  var length = 0.306001
+  var spacing = 407.658
+  var timeStep = 1.0
+
+  var bandAmplitude = 0.2
+  var bandSecondaryFrequency = 7.0
+  var bandSecondaryAmplitude = 0.025
+  var travelSpeed1 = 0.25
+  var travelAmplitude1 = 0.014
+  var travelSpeed2 = 0.15
+  var travelAmplitude2 = 0.008
+
+  var perturbation = 0.0998587
+  var perturbationScale = 0.07
+  var waveCosineAmplitude = 0.09
+  var waveBias = -0.1
+  var waveHeightScale = 0.5
+  var waveSoftClip = 0.22
+
+  var reversePipelineBlend = 0.45
+  var reverseDescriptorStrength = 0.7
+  var reverseSyntheticDescriptorSeed = 1337.0
+  var reverseSyntheticDescriptorMotion = 0.65
+  var reverseKernelGain = 0.04
+  var reverseNormalizeGain = 0.08
+  var reverseKernelPhaseStep = 0.45
+  var reverseIndexJitter = 0.006
+  var reverseTemporalSmooth = 0.84
+
+  var fresnelPower = 4.0
+  var fresnelScale = 0.5
+  var opacity = 0.7
+  var brightness = 0.35
+  var zDetailScale = 0.08
+
+  var ffdScale1X = 5.67726
+  var ffdScale1Y = 1.00077
+  var ffdScale1Z = 1.0
+  var ffdScale2X = 2.82755
+  var ffdScale2Y = 1.27579
+  var ffdScale2Z = 2.88782
+  var ffdOffsetX = 0.0
+  var ffdOffsetY = -0.469999
+  var ffdOffsetZ = 0.0
+  var ffdYAmplitude = 0.05
+  var ffdZAmplitude = 0.06
+}
+
+// MARK: - DynamicAppearancePreferences
+
+struct DynamicAppearancePreferences: Codable, Equatable {
+  private static let storageKey = "ARMSX2iOSDynamicAppearancePreferences"
+  private static let currentVersion = 1
+
+  var version = currentVersion
+  var dynamicBackground: DynamicBackgroundStyle
+  var sharedPalette: ThemePalette
+  var sharedCustomColor: SavedPaletteColor?
+  var sharedMultiColor: ThemeMultiColorSelection
+  var ribbonPalette: ThemePalette
+  var ribbonCustomColor: SavedPaletteColor?
+  var ribbonMultiColor: ThemeMultiColorSelection
+  var particleSettings: DynamicParticleSettings
+  var hasSelectedPlayStation3XMBByMart: Bool
+  var isPlayStation3XMBPresetExplicit: Bool
+
+  static let standard = DynamicAppearancePreferences(
+    dynamicBackground: .playStation2Menu,
+    sharedPalette: .xmbAzureHorizon,
+    sharedCustomColor: nil,
+    sharedMultiColor: ThemeMultiColorSelection(),
+    ribbonPalette: .xmbAzureHorizon,
+    ribbonCustomColor: nil,
+    ribbonMultiColor: ThemeMultiColorSelection(),
+    particleSettings: DynamicParticleSettings(),
+    hasSelectedPlayStation3XMBByMart: false,
+    isPlayStation3XMBPresetExplicit: false
+  )
+
+  static func load(from userDefaults: UserDefaults = .standard) -> Self? {
+    guard
+      let data = userDefaults.data(forKey: storageKey),
+      let preferences = DynamicBackgroundCoding.decode(Self.self, from: data),
+      preferences.version == currentVersion
+    else {
+      return nil
+    }
+
+    return preferences
+  }
+
+  func save(to userDefaults: UserDefaults = .standard) {
+    guard let data = DynamicBackgroundCoding.encode(self) else { return }
+    userDefaults.set(data, forKey: Self.storageKey)
+  }
+}
+
+// MARK: - PlayStationBackgroundSettingsControls
+
+struct DynamicSettingsSliderActivity: @unchecked Sendable {
+  let update: (_ title: String, _ value: String, _ isEditing: Bool) -> Void
+}
+
+private struct DynamicSettingsSliderActivityKey: EnvironmentKey {
+  static let defaultValue = DynamicSettingsSliderActivity { _, _, _ in }
+}
+
+extension EnvironmentValues {
+  var dynamicSettingsSliderActivity: DynamicSettingsSliderActivity {
+    get { self[DynamicSettingsSliderActivityKey.self] }
+    set { self[DynamicSettingsSliderActivityKey.self] = newValue }
+  }
+}
+
+struct BackgroundSettingsResetHeader: View {
+  let action: () -> Void
+
+  var body: some View {
+    HStack {
+      Text("Advanced controls")
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(.white.opacity(0.62))
+      Spacer()
+      Button(action: action) {
+        Label("Reset all", systemImage: "arrow.counterclockwise")
+          .font(.caption.weight(.semibold))
+      }
+      .buttonStyle(.borderless)
+    }
+  }
+}
+
+struct DynamicSettingsResetButton: View {
+  let title: String
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      Image(systemName: "arrow.counterclockwise")
+        .font(.caption.weight(.semibold))
+        .frame(width: 28, height: 28)
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.borderless)
+    .foregroundStyle(.white.opacity(0.7))
+    .accessibilityLabel("Reset \(title)")
+  }
+}
+
+struct BackgroundControlSection<Content: View>: View {
+  let title: String
+  let content: Content
+
+  init(_ title: String, @ViewBuilder content: () -> Content) {
+    self.title = title
+    self.content = content()
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Label(title, systemImage: sectionIcon)
+        .font(.caption.weight(.bold))
+        .foregroundStyle(.white.opacity(0.78))
+      content
+    }
+    .padding(.vertical, 4)
+  }
+
+  private var sectionIcon: String {
+    switch title {
+    case "Visibility": return "eye"
+    case "Native particles": return "sparkles"
+    case "Environment": return "circle.lefthalf.filled"
+    default: return title.contains("material") ? "slider.horizontal.3" : "waveform.path"
+    }
+  }
+}
+
+struct DynamicSettingsValueSlider: View {
+  let title: String
+  @Binding var value: Double
+  let range: ClosedRange<Double>
+  let step: Double?
+  let formattedValue: String
+  let resetValue: Double?
+
+  @Environment(\.dynamicSettingsSliderActivity) private var sliderActivity
+  @State private var isEditing = false
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack {
+        Text(title)
+        Spacer()
+        Text(formattedValue)
+          .foregroundStyle(.white.opacity(0.62))
+
+        if let resetValue {
+          DynamicSettingsResetButton(title: title) {
+            value = resetValue
+          }
+        }
+      }
+      .font(.caption.weight(.semibold))
+
+      Group {
+        if let step {
+          Slider(value: $value, in: range, step: step)
+        } else {
+          Slider(value: $value, in: range)
+        }
+      }
+      .simultaneousGesture(
+        DragGesture(minimumDistance: 0)
+          .onChanged { _ in
+            guard !isEditing else { return }
+            isEditing = true
+            sliderActivity.update(title, formattedValue, true)
+          }
+          .onEnded { _ in
+            guard isEditing else { return }
+            isEditing = false
+            sliderActivity.update(title, formattedValue, false)
+          }
+      )
+      .onChange(of: value) { _, _ in
+        guard isEditing else { return }
+        sliderActivity.update(title, formattedValue, true)
+      }
+    }
+  }
+}
+
+struct BackgroundControlToggle: View {
+  let title: String
+  @Binding var value: Bool
+  let defaultValue: Bool
+
+  var body: some View {
+    HStack {
+      Toggle(title, isOn: $value)
+      DynamicSettingsResetButton(title: title) {
+        value = defaultValue
+      }
+    }
+    .font(.caption.weight(.semibold))
+  }
+}
+
+@MainActor
+func controlSlider(
+  _ title: String,
+  value: Binding<Double>,
+  range: ClosedRange<Double>,
+  defaultValue: Double,
+  format: @escaping (Double) -> String
+) -> some View {
+  DynamicSettingsValueSlider(
+    title: title,
+    value: value,
+    range: range,
+    step: nil,
+    formattedValue: format(value.wrappedValue),
+    resetValue: defaultValue
+  )
+}
+
+@MainActor
+func settingResetButton(
+  _ title: String,
+  action: @escaping () -> Void
+) -> some View {
+  DynamicSettingsResetButton(title: title, action: action)
+}
+
+extension View {
+  func dynamicSettingsCard() -> some View {
+    padding(14)
+      .background {
+        RoundedRectangle(cornerRadius: 16, style: .continuous)
+          .fill(.gray.opacity(0.16))
+      }
+      .overlay {
+        RoundedRectangle(cornerRadius: 16, style: .continuous)
+          .stroke(.white.opacity(0.09), lineWidth: 0.7)
+      }
+  }
+}
+
+enum DynamicSettingsExpansion {
+  static func binding(
+    storage: Binding<String>,
+    identifier: String
+  ) -> Binding<Bool> {
+    Binding(
+      get: { identifierSet(in: storage.wrappedValue).contains(identifier) },
+      set: { isExpanded in
+        var identifiers = identifierSet(in: storage.wrappedValue)
+        if isExpanded {
+          identifiers.insert(identifier)
+        } else {
+          identifiers.remove(identifier)
+        }
+        storage.wrappedValue = identifiers.sorted().joined(separator: "|")
+      }
+    )
+  }
+
+  private static func identifierSet(in storage: String) -> Set<String> {
+    Set(storage.split(separator: "|").map(String.init))
+  }
+}
+
+@MainActor
+func controlToggle(
+  _ title: String,
+  value: Binding<Bool>,
+  defaultValue: Bool
+) -> some View {
+  BackgroundControlToggle(
+    title: title,
+    value: value,
+    defaultValue: defaultValue
+  )
+}
+
+func count(_ value: Double) -> String {
+  String(format: "%.0f", value)
+}
+
+func percent(_ value: Double) -> String {
+  "\(Int(value * 100))%"
+}
+
+func signedPercent(_ value: Double) -> String {
+  String(format: "%+.0f%%", value * 100)
+}
+
+func multiplier(_ value: Double) -> String {
+  String(format: "%.2fx", value)
+}
+
+func points(_ value: Double) -> String {
+  String(format: "%.1f pt", value)
+}
+
+// MARK: - DynamicBackgroundSettingsControls
+
+struct DynamicBackgroundSettingsControls: View {
+  @Binding var particleSettings: DynamicParticleSettings
+  @Binding var isPlayStation3XMBPresetExplicit: Bool
+  let dynamicBackground: DynamicBackgroundStyle
+
+  @AppStorage("ARMSX2iOSDynamicExpandedNestedGroups")
+  private var expandedDynamicSettingsGroups = ""
+  private let defaults = DynamicBackgroundMotionSettings()
+
+  var body: some View {
+    settingsContent
+      .onAppear(perform: expandCurrentBackgroundSettings)
+      .onChange(of: dynamicBackground) { _, _ in
+        expandCurrentBackgroundSettings()
+      }
+  }
+
+  private var settingsContent: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      if dynamicBackground == .playStation3XMBByMart {
+        backgroundSettingGroup(.playStation3XMBByMart) {
+          PlayStation3XMBMartSettingsControls(
+            settings: $particleSettings.playStation3XMB,
+            isPresetExplicit: $isPlayStation3XMBPresetExplicit
+          )
+        }
+      }
+      activeBackgroundSettingGroup(.multicolorAmbient) {
+        backgroundSpeedSlider(
+          value: $particleSettings.backgrounds.multicolorAmbientSpeed,
+          defaultValue: defaults.multicolorAmbientSpeed
+        )
+      }
+      activeBackgroundSettingGroup(.lightSpeed) {
+        backgroundSpeedSlider(
+          value: $particleSettings.backgrounds.lightSpeedMotionSpeed,
+          defaultValue: defaults.lightSpeedMotionSpeed
+        )
+      }
+      activeBackgroundSettingGroup(.spatialRetro) {
+        backgroundSpeedSlider(
+          value: $particleSettings.backgrounds.spatialRetroSpeed,
+          defaultValue: defaults.spatialRetroSpeed
+        )
+      }
+      activeBackgroundSettingGroup(.towersOrbs) {
+        backgroundSpeedSlider(
+          value: $particleSettings.backgrounds.towersOrbsSpeed,
+          defaultValue: defaults.towersOrbsSpeed
+        )
+      }
+      activeBackgroundSettingGroup(.playStation2Menu) {
+        particleSlider(
+          "FPS",
+          value: $particleSettings.backgrounds.playStation2MenuFramesPerSecond,
+          range: 15...120,
+          step: 1,
+          formattedValue:
+            "\(Int(particleSettings.backgrounds.playStation2MenuFramesPerSecond)) FPS",
+          resetValue: defaults.playStation2MenuFramesPerSecond
+        )
+        backgroundSpeedSlider(
+          value: $particleSettings.backgrounds.playStation2MenuSceneSpeed,
+          defaultValue: defaults.playStation2MenuSceneSpeed
+        )
+        particleSlider(
+          "Orbit angle",
+          value: $particleSettings.backgrounds.playStation2MenuOrbitDegrees,
+          range: 0...45,
+          formattedValue: String(
+            format: "%.0f°",
+            particleSettings.backgrounds.playStation2MenuOrbitDegrees
+          ),
+          resetValue: defaults.playStation2MenuOrbitDegrees
+        )
+        particleSlider(
+          "Yaw speed",
+          value: $particleSettings.backgrounds.playStation2MenuYawSpeed,
+          range: 0...10,
+          formattedValue: String(
+            format: "%.1fx",
+            particleSettings.backgrounds.playStation2MenuYawSpeed
+          ),
+          resetValue: defaults.playStation2MenuYawSpeed
+        )
+        particleSlider(
+          "Roll speed",
+          value: $particleSettings.backgrounds.playStation2MenuRollSpeed,
+          range: 0...12,
+          formattedValue: String(
+            format: "%.1fx",
+            particleSettings.backgrounds.playStation2MenuRollSpeed
+          ),
+          resetValue: defaults.playStation2MenuRollSpeed
+        )
+        HStack {
+          Toggle(
+            "Colour towers",
+            isOn: $particleSettings.backgrounds.playStation2MenuColorsTowers
+          )
+          settingResetButton("Colour towers") {
+            particleSettings.backgrounds.playStation2MenuColorsTowers =
+              defaults.playStation2MenuColorsTowers
+          }
+        }
+      }
+      activeBackgroundSettingGroup(.faceButtons) {
+        backgroundSpeedSlider(
+          value: $particleSettings.backgrounds.faceButtonsSpeed,
+          defaultValue: defaults.faceButtonsSpeed
+        )
+        HStack {
+          Toggle(
+            "Show line waves",
+            isOn: $particleSettings.backgrounds.faceButtonsShowsLightBands
+          )
+          settingResetButton("Show Face Buttons line waves") {
+            particleSettings.backgrounds.faceButtonsShowsLightBands =
+              defaults.faceButtonsShowsLightBands
+          }
+        }
+      }
+      activeBackgroundSettingGroup(.playStationPortableBlur) {
+        backgroundSpeedSlider(
+          value: $particleSettings.backgrounds.playStationPortableBlurSpeed,
+          defaultValue: defaults.playStationPortableBlurSpeed
+        )
+        PlayStationPortableBlurSettingsControls(
+          settings: $particleSettings.backgrounds.playStationPortableBlur
+        )
+      }
+      activeBackgroundSettingGroup(.playStation3Splines) {
+        backgroundSpeedSlider(
+          value: $particleSettings.backgrounds.playStation3SplinesSpeed,
+          defaultValue: defaults.playStation3SplinesSpeed
+        )
+        PlayStation3SplinesSettingsControls(
+          settings: $particleSettings.backgrounds.playStation3Splines
+        )
+      }
+      activeBackgroundSettingGroup(.playStation4Particles) {
+        backgroundSpeedSlider(
+          value: $particleSettings.backgrounds.playStation4ParticlesSpeed,
+          defaultValue: defaults.playStation4ParticlesSpeed
+        )
+        PlayStation4ParticlesSettingsControls(
+          settings: $particleSettings.backgrounds.playStation4Particles
+        )
+      }
+      activeBackgroundSettingGroup(.playStation4Waves) {
+        backgroundSpeedSlider(
+          value: $particleSettings.backgrounds.playStation4WavesSpeed,
+          defaultValue: defaults.playStation4WavesSpeed
+        )
+        PlayStation4WavesSettingsControls(
+          settings: $particleSettings.backgrounds.playStation4Waves
+        )
+      }
+      activeBackgroundSettingGroup(.playStationRibbons) {
+        backgroundSpeedSlider(
+          value: $particleSettings.backgrounds.playStationRibbonsSpeed,
+          defaultValue: defaults.playStationRibbonsSpeed
+        )
+        PlayStationRibbonsSettingsControls(
+          settings: $particleSettings.backgrounds.playStationRibbons
+        )
+      }
+    }
+  }
+
+  private func backgroundSettingGroup<Content: View>(
+    _ background: DynamicBackgroundStyle,
+    @ViewBuilder content: @escaping () -> Content
+  ) -> some View {
+    DisclosureGroup(
+      isExpanded: DynamicSettingsExpansion.binding(
+        storage: $expandedDynamicSettingsGroups,
+        identifier: background.settingsExpansionIdentifier
+      )
+    ) {
+      VStack(alignment: .leading, spacing: 12) {
+        content()
+      }
+      .padding(.top, 10)
+    } label: {
+      Label(background.title, systemImage: background.systemImage)
+        .font(.subheadline.weight(.semibold))
+        .foregroundStyle(.white)
+    }
+  }
+
+  @ViewBuilder
+  private func activeBackgroundSettingGroup<Content: View>(
+    _ background: DynamicBackgroundStyle,
+    @ViewBuilder content: @escaping () -> Content
+  ) -> some View {
+    if background == dynamicBackground {
+      backgroundSettingGroup(background, content: content)
+    }
+  }
+
+  private func expandCurrentBackgroundSettings() {
+    DynamicSettingsExpansion.binding(
+      storage: $expandedDynamicSettingsGroups,
+      identifier: dynamicBackground.settingsExpansionIdentifier
+    ).wrappedValue = true
+  }
+
+  private func backgroundSpeedSlider(
+    value: Binding<Double>,
+    defaultValue: Double
+  ) -> some View {
+    particleSlider(
+      "Motion speed",
+      value: value,
+      range: 0.1...4,
+      formattedValue: String(format: "%.1fx", value.wrappedValue),
+      resetValue: defaultValue
+    )
+  }
+
+  private func particleSlider(
+    _ title: String,
+    value: Binding<Double>,
+    range: ClosedRange<Double>,
+    step: Double? = nil,
+    formattedValue: String,
+    resetValue: Double
+  ) -> some View {
+    DynamicSettingsValueSlider(
+      title: title,
+      value: value,
+      range: range,
+      step: step,
+      formattedValue: formattedValue,
+      resetValue: resetValue
+    )
+  }
+
+}
+
+// MARK: - DynamicParticleSettingsControls
+
+struct DynamicParticleSettingsControls: View {
+  @Binding var particleSettings: DynamicParticleSettings
+  @Binding var isPlayStation3XMBPresetExplicit: Bool
+  let dynamicBackground: DynamicBackgroundStyle
+  let resetAllSettingsAndPalettes: () -> Void
+
+  @AppStorage("ARMSX2iOSDynamicAddParticlesExpanded")
+  private var showsAddParticlesSettings = true
+  @AppStorage("ARMSX2iOSDynamicBackgroundsExpanded")
+  private var showsBackgroundSettings = false
+  @AppStorage("ARMSX2iOSDynamicMultiColorExpanded")
+  private var showsMultiColorSettings = false
+  @AppStorage("ARMSX2iOSDynamicFaceButtonsExpanded")
+  private var showsFaceButtonSettings = false
+  private let defaults = DynamicParticleSettings()
+
+  var body: some View {
+    particleSection
+      .onAppear { showsBackgroundSettings = true }
+      .onChange(of: dynamicBackground) { _, _ in
+        showsBackgroundSettings = true
+      }
+  }
+
+  private var particleSection: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      dynamicSettingsGroup(
+        "Add particles",
+        isExpanded: $showsAddParticlesSettings
+      ) {
+        addParticlesSettings
+      }
+
+      dynamicSettingsGroup(
+        "Dynamic Backgrounds Settings",
+        isExpanded: $showsBackgroundSettings
+      ) {
+        DynamicBackgroundSettingsControls(
+          particleSettings: $particleSettings,
+          isPlayStation3XMBPresetExplicit: $isPlayStation3XMBPresetExplicit,
+          dynamicBackground: dynamicBackground
+        )
+      }
+
+      dynamicSettingsGroup(
+        "Multi-color animation",
+        isExpanded: $showsMultiColorSettings
+      ) {
+        multiColorAnimationSettings
+      }
+
+      dynamicSettingsGroup(
+        "Add face buttons",
+        isExpanded: $showsFaceButtonSettings
+      ) {
+        faceButtonSettings
+      }
+
+      HStack {
+        Toggle("Widen theme in portrait", isOn: $particleSettings.widensPortraitBackground)
+        settingResetButton("Widen theme in portrait") {
+          particleSettings.widensPortraitBackground =
+            defaults.widensPortraitBackground
+        }
+      }
+      .font(.subheadline.weight(.semibold))
+      .foregroundStyle(.white)
+      .dynamicSettingsCard()
+
+      particleSlider(
+        "See background preview before applying",
+        value: $particleSettings.backgroundPreviewBeforeApplyingDuration,
+        range: 0.0...3.0,
+        formattedValue: String(
+          format: "%.1fs",
+          particleSettings.backgroundPreviewBeforeApplyingDuration
+        )
+      )
+      .dynamicSettingsCard()
+
+      particleSlider(
+        "See background preview after applying",
+        value: $particleSettings.backgroundPreviewAfterApplyingDuration,
+        range: 0.0...3.0,
+        formattedValue: String(
+          format: "%.1fs",
+          particleSettings.backgroundPreviewAfterApplyingDuration
+        )
+      )
+      .dynamicSettingsCard()
+
+      Button(role: .destructive, action: resetAllSettingsAndPalettes) {
+        Label("Reset Dynamic Background Settings", systemImage: "arrow.counterclockwise")
+          .font(.subheadline.weight(.bold))
+          .frame(maxWidth: .infinity)
+          .frame(height: 44)
+      }
+      .buttonStyle(.plain)
+      .foregroundStyle(.red)
+      .glassSurface(
+        tint: Color.red.opacity(0.12),
+        interactive: true,
+        cornerRadius: 14
+      )
+      .accessibilityHint("Resets all dynamic settings and selected palettes")
+    }
+  }
+
+  private var addParticlesSettings: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack {
+        Toggle("Enable particles", isOn: $particleSettings.isEnabled)
+        settingResetButton("Add particles") {
+          particleSettings.isEnabled = defaults.isEnabled
+        }
+      }
+
+      HStack {
+        Picker("Particle style", selection: $particleSettings.style) {
+          ForEach(DynamicParticleStyle.allCases) { style in
+            Text(style.title).tag(style)
+          }
+        }
+        .pickerStyle(.menu)
+        settingResetButton("Particle style") {
+          particleSettings.style = defaults.style
+        }
+      }
+
+      particleSlider(
+        "Amount",
+        value: $particleSettings.amount,
+        range: 0.2...3.0,
+        formattedValue: "\(Int(particleSettings.amount * 100))%"
+      )
+      particleSlider(
+        "Speed",
+        value: $particleSettings.speed,
+        range: 0.1...3.0,
+        formattedValue: String(format: "%.1fx", particleSettings.speed)
+      )
+      particleSlider(
+        "Direction of speed",
+        value: $particleSettings.speedDirection,
+        range: -1.0...1.0,
+        formattedValue: String(
+          format: "%+.0f%%",
+          particleSettings.speedDirection * 100
+        )
+      )
+      particleSlider(
+        "Dispersion",
+        value: $particleSettings.dispersion,
+        range: 0.25...1.8,
+        formattedValue: "\(Int(particleSettings.dispersion * 100))%"
+      )
+      particleSlider(
+        "Y-axis spread",
+        value: $particleSettings.verticalSpread,
+        range: 0.25...3.0,
+        formattedValue: "\(Int(particleSettings.verticalSpread * 100))%"
+      )
+      particleSlider(
+        "Y-axis density",
+        value: $particleSettings.verticalDensity,
+        range: 0.25...3.0,
+        formattedValue: "\(Int(particleSettings.verticalDensity * 100))%"
+      )
+      particleSlider(
+        "Outer top/bottom dispersion",
+        value: $particleSettings.outerDispersion,
+        range: 0.0...2.5,
+        formattedValue: "\(Int(particleSettings.outerDispersion * 100))%"
+      )
+      particleSlider(
+        "Vertical level",
+        value: $particleSettings.verticalLevel,
+        range: 0.18...0.82,
+        formattedValue: "\(Int(particleSettings.verticalLevel * 100))%"
+      )
+      particleSlider(
+        "Size",
+        value: $particleSettings.size,
+        range: 0.4...2.4,
+        formattedValue: String(format: "%.1fx", particleSettings.size)
+      )
+      particleSlider(
+        "Brightness",
+        value: $particleSettings.brightness,
+        range: 0.15...1.35,
+        formattedValue: "\(Int(particleSettings.brightness * 100))%"
+      )
+      particleSlider(
+        "Particle opacity",
+        value: $particleSettings.opacity,
+        range: 0.05...1.5,
+        formattedValue: "\(Int(particleSettings.opacity * 100))%"
+      )
+      particleSlider(
+        "Depth variation",
+        value: $particleSettings.depthVariation,
+        range: 0.0...1.5,
+        formattedValue: "\(Int(particleSettings.depthVariation * 100))%"
+      )
+      particleSlider(
+        "Twinkle",
+        value: $particleSettings.twinkle,
+        range: 0.0...1.5,
+        formattedValue: "\(Int(particleSettings.twinkle * 100))%"
+      )
+      particleSlider(
+        "Drift",
+        value: $particleSettings.drift,
+        range: 0.0...1.5,
+        formattedValue: "\(Int(particleSettings.drift * 100))%"
+      )
+
+    }
+  }
+
+  private var multiColorAnimationSettings: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      particleSlider(
+        "Color speed",
+        value: $particleSettings.multiColorAnimationSpeed,
+        range: 0.1...4.0,
+        formattedValue: String(format: "%.1fx", particleSettings.multiColorAnimationSpeed)
+      )
+      particleSlider(
+        "Color smoothness",
+        value: $particleSettings.multiColorAnimationSmoothness,
+        range: 0.0...1.0,
+        formattedValue: "\(Int(particleSettings.multiColorAnimationSmoothness * 100))%"
+      )
+      particleSlider(
+        "Color wave",
+        value: $particleSettings.multiColorAnimationSpread,
+        range: 0.0...1.2,
+        formattedValue: "\(Int(particleSettings.multiColorAnimationSpread * 100))%"
+      )
+    }
+  }
+
+  private var faceButtonSettings: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack {
+        Toggle("Enable face buttons", isOn: $particleSettings.faceButtonsEnabled)
+        settingResetButton("Add Face Buttons") {
+          particleSettings.faceButtonsEnabled =
+            defaults.faceButtonsEnabled
+        }
+      }
+
+      particleSlider(
+        "Face Buttons amount",
+        value: $particleSettings.faceButtonAmount,
+        range: 0.15...2.5,
+        formattedValue: "\(Int(particleSettings.faceButtonAmount * 100))%"
+      )
+      particleSlider(
+        "Face Buttons speed",
+        value: $particleSettings.faceButtonSpeed,
+        range: 0.05...1.25,
+        formattedValue: String(format: "%.2fx", particleSettings.faceButtonSpeed)
+      )
+      particleSlider(
+        "Face Buttons dispersion",
+        value: $particleSettings.faceButtonDispersion,
+        range: 0.25...2.2,
+        formattedValue: "\(Int(particleSettings.faceButtonDispersion * 100))%"
+      )
+      particleSlider(
+        "Face Buttons size",
+        value: $particleSettings.faceButtonSize,
+        range: 0.35...2.4,
+        formattedValue: String(format: "%.1fx", particleSettings.faceButtonSize)
+      )
+      particleSlider(
+        "Face Buttons opacity",
+        value: $particleSettings.faceButtonOpacity,
+        range: 0.1...1.4,
+        formattedValue: "\(Int(particleSettings.faceButtonOpacity * 100))%"
+      )
+      particleSlider(
+        "Face Buttons rotation",
+        value: $particleSettings.faceButtonRotation,
+        range: 0.0...2.0,
+        formattedValue: "\(Int(particleSettings.faceButtonRotation * 100))%"
+      )
+      particleSlider(
+        "Face Buttons pulse",
+        value: $particleSettings.faceButtonPulse,
+        range: 0.0...1.6,
+        formattedValue: "\(Int(particleSettings.faceButtonPulse * 100))%"
+      )
+    }
+  }
+
+  private func dynamicSettingsGroup<Content: View>(
+    _ title: String,
+    isExpanded: Binding<Bool>,
+    @ViewBuilder content: @escaping () -> Content
+  ) -> some View {
+    DisclosureGroup(isExpanded: isExpanded) {
+      VStack(alignment: .leading, spacing: 12) {
+        content()
+      }
+      .padding(.top, 10)
+    } label: {
+      Text(title)
+        .font(.headline)
+        .foregroundStyle(.white)
+    }
+    .dynamicSettingsCard()
+  }
+
+  private func particleSlider(
+    _ title: String,
+    value: Binding<Double>,
+    range: ClosedRange<Double>,
+    step: Double? = nil,
+    formattedValue: String,
+    resetValue: Double? = nil
+  ) -> some View {
+    DynamicSettingsValueSlider(
+      title: title,
+      value: value,
+      range: range,
+      step: step,
+      formattedValue: formattedValue,
+      resetValue: resetValue ?? particleResetValue(for: title)
+    )
+  }
+
+  private func particleResetValue(for title: String) -> Double? {
+    switch title {
+    case "Amount": return defaults.amount
+    case "Speed": return defaults.speed
+    case "Direction of speed": return defaults.speedDirection
+    case "Dispersion": return defaults.dispersion
+    case "Y-axis spread": return defaults.verticalSpread
+    case "Y-axis density": return defaults.verticalDensity
+    case "Outer top/bottom dispersion": return defaults.outerDispersion
+    case "Vertical level": return defaults.verticalLevel
+    case "Size": return defaults.size
+    case "Brightness": return defaults.brightness
+    case "Particle opacity": return defaults.opacity
+    case "Depth variation": return defaults.depthVariation
+    case "Twinkle": return defaults.twinkle
+    case "Drift": return defaults.drift
+    case "See background preview before applying":
+      return defaults.backgroundPreviewBeforeApplyingDuration
+    case "See background preview after applying":
+      return defaults.backgroundPreviewAfterApplyingDuration
+    case "Motion speed": return defaults.backgrounds.multicolorAmbientSpeed
+    case "FPS": return defaults.backgrounds.playStation2MenuFramesPerSecond
+    case "Orbit angle": return defaults.backgrounds.playStation2MenuOrbitDegrees
+    case "Yaw speed": return defaults.backgrounds.playStation2MenuYawSpeed
+    case "Roll speed": return defaults.backgrounds.playStation2MenuRollSpeed
+    case "Color speed": return defaults.multiColorAnimationSpeed
+    case "Color smoothness": return defaults.multiColorAnimationSmoothness
+    case "Color wave": return defaults.multiColorAnimationSpread
+    case "Face Buttons amount": return defaults.faceButtonAmount
+    case "Face Buttons speed": return defaults.faceButtonSpeed
+    case "Face Buttons dispersion": return defaults.faceButtonDispersion
+    case "Face Buttons size": return defaults.faceButtonSize
+    case "Face Buttons opacity": return defaults.faceButtonOpacity
+    case "Face Buttons rotation": return defaults.faceButtonRotation
+    case "Face Buttons pulse": return defaults.faceButtonPulse
+    default: return nil
+    }
+  }
+}
+
+// MARK: - PlayStation3SplinesSettingsControls
+
+struct PlayStation3SplinesSettingsControls: View {
+  @Binding var settings: PlayStation3SplinesSettings
+  private let defaults = PlayStation3SplinesSettings()
+
+  var body: some View {
+    BackgroundSettingsResetHeader { settings = defaults }
+
+    BackgroundControlSection("Visibility") {
+      controlToggle(
+        "Show splines", value: $settings.showsSplines, defaultValue: defaults.showsSplines)
+      controlToggle(
+        "Show native particles", value: $settings.showsParticles,
+        defaultValue: defaults.showsParticles)
+    }
+    BackgroundControlSection("Spline geometry") {
+      controlSlider(
+        "Strand count", value: $settings.strandCount, range: 1...30,
+        defaultValue: defaults.strandCount, format: count)
+      controlSlider(
+        "Vertical position", value: $settings.verticalPosition, range: 0.2...0.9,
+        defaultValue: defaults.verticalPosition, format: percent)
+      controlSlider(
+        "Strand spacing", value: $settings.strandSpacing, range: 0...3,
+        defaultValue: defaults.strandSpacing, format: multiplier)
+      controlSlider(
+        "Wave amplitude", value: $settings.waveAmplitude, range: 0...3,
+        defaultValue: defaults.waveAmplitude, format: multiplier)
+      controlSlider(
+        "Detail amplitude", value: $settings.detailAmplitude, range: 0...3,
+        defaultValue: defaults.detailAmplitude, format: multiplier)
+      controlSlider(
+        "Phase spread", value: $settings.phaseSpread, range: 0...3,
+        defaultValue: defaults.phaseSpread, format: multiplier)
+    }
+    BackgroundControlSection("Spline material") {
+      controlSlider(
+        "Glow opacity", value: $settings.glowOpacity, range: 0...3,
+        defaultValue: defaults.glowOpacity, format: percent)
+      controlSlider(
+        "Core opacity", value: $settings.coreOpacity, range: 0...3,
+        defaultValue: defaults.coreOpacity, format: percent)
+      controlSlider(
+        "Glow width", value: $settings.glowWidth, range: 0.1...3, defaultValue: defaults.glowWidth,
+        format: multiplier)
+      controlSlider(
+        "Core width", value: $settings.coreWidth, range: 0.1...4, defaultValue: defaults.coreWidth,
+        format: multiplier)
+      controlSlider(
+        "Glow blur", value: $settings.glowBlur, range: 0...3, defaultValue: defaults.glowBlur,
+        format: multiplier)
+    }
+    BackgroundControlSection("Native particles") {
+      controlSlider(
+        "Particle count", value: $settings.particleCount, range: 0...600,
+        defaultValue: defaults.particleCount, format: count)
+      controlSlider(
+        "Particle speed", value: $settings.particleSpeed, range: 0...4,
+        defaultValue: defaults.particleSpeed, format: multiplier)
+      controlSlider(
+        "Particle spread", value: $settings.particleSpread, range: 0...3,
+        defaultValue: defaults.particleSpread, format: multiplier)
+      controlSlider(
+        "Particle size", value: $settings.particleSize, range: 0.1...5,
+        defaultValue: defaults.particleSize, format: multiplier)
+      controlSlider(
+        "Particle opacity", value: $settings.particleOpacity, range: 0...3,
+        defaultValue: defaults.particleOpacity, format: percent)
+      controlSlider(
+        "Twinkle speed", value: $settings.particleTwinkle, range: 0...4,
+        defaultValue: defaults.particleTwinkle, format: multiplier)
+    }
+    BackgroundControlSection("Environment") {
+      controlSlider(
+        "Background intensity", value: $settings.backgroundIntensity, range: 0...2,
+        defaultValue: defaults.backgroundIntensity, format: percent)
+      controlSlider(
+        "Vignette intensity", value: $settings.vignetteIntensity, range: 0...3,
+        defaultValue: defaults.vignetteIntensity, format: percent)
+    }
+  }
+}
+
+// MARK: - PlayStation4ParticlesSettingsControls
+
+struct PlayStation4ParticlesSettingsControls: View {
+  @Binding var settings: PlayStation4ParticlesSettings
+  private let defaults = PlayStation4ParticlesSettings()
+
+  var body: some View {
+    BackgroundSettingsResetHeader { settings = defaults }
+
+    BackgroundControlSection("Visibility") {
+      controlToggle(
+        "Show native particles", value: $settings.showsParticles,
+        defaultValue: defaults.showsParticles)
+      controlToggle(
+        "Show wave bundle", value: $settings.showsWaves, defaultValue: defaults.showsWaves)
+      controlToggle(
+        "Show wave glow", value: $settings.showsWaveGlow, defaultValue: defaults.showsWaveGlow)
+      controlToggle(
+        "Show wave cores", value: $settings.showsWaveCores, defaultValue: defaults.showsWaveCores)
+    }
+    BackgroundControlSection("Native particles") {
+      controlSlider(
+        "Particle count", value: $settings.particleCount, range: 0...700,
+        defaultValue: defaults.particleCount, format: count)
+      controlSlider(
+        "Particle speed", value: $settings.particleSpeed, range: 0...4,
+        defaultValue: defaults.particleSpeed, format: multiplier)
+      controlSlider(
+        "Particle height", value: $settings.particleVerticalPosition, range: 0...1,
+        defaultValue: defaults.particleVerticalPosition, format: percent)
+      controlSlider(
+        "Particle spread", value: $settings.particleSpread, range: 0...3,
+        defaultValue: defaults.particleSpread, format: multiplier)
+      controlSlider(
+        "Particle size", value: $settings.particleSize, range: 0.1...5,
+        defaultValue: defaults.particleSize, format: multiplier)
+      controlSlider(
+        "Particle opacity", value: $settings.particleOpacity, range: 0...3,
+        defaultValue: defaults.particleOpacity, format: percent)
+      controlSlider(
+        "Twinkle speed", value: $settings.particleTwinkle, range: 0...4,
+        defaultValue: defaults.particleTwinkle, format: multiplier)
+    }
+    BackgroundControlSection("Wave geometry") {
+      controlSlider(
+        "Wave count", value: $settings.waveCount, range: 1...16, defaultValue: defaults.waveCount,
+        format: count)
+      controlSlider(
+        "Wave height", value: $settings.waveVerticalPosition, range: 0...1,
+        defaultValue: defaults.waveVerticalPosition, format: percent)
+      controlSlider(
+        "Wave spacing", value: $settings.waveSpacing, range: 0...3,
+        defaultValue: defaults.waveSpacing, format: multiplier)
+      controlSlider(
+        "Wave amplitude", value: $settings.waveAmplitude, range: 0...3,
+        defaultValue: defaults.waveAmplitude, format: multiplier)
+      controlSlider(
+        "Wave curvature", value: $settings.waveCurvature, range: 0...3,
+        defaultValue: defaults.waveCurvature, format: multiplier)
+      controlSlider(
+        "Phase spread", value: $settings.phaseSpread, range: 0...3,
+        defaultValue: defaults.phaseSpread, format: multiplier)
+    }
+    BackgroundControlSection("Wave material") {
+      controlSlider(
+        "Glow blur", value: $settings.glowBlur, range: 0...50, defaultValue: defaults.glowBlur,
+        format: points)
+      controlSlider(
+        "Glow width", value: $settings.glowWidth, range: 0.1...3, defaultValue: defaults.glowWidth,
+        format: multiplier)
+      controlSlider(
+        "Glow opacity", value: $settings.glowOpacity, range: 0...3,
+        defaultValue: defaults.glowOpacity, format: percent)
+      controlSlider(
+        "Core width", value: $settings.coreWidth, range: 0.1...4, defaultValue: defaults.coreWidth,
+        format: multiplier)
+      controlSlider(
+        "Core opacity", value: $settings.coreOpacity, range: 0...3,
+        defaultValue: defaults.coreOpacity, format: percent)
+    }
+    BackgroundControlSection("Environment") {
+      controlSlider(
+        "Background intensity", value: $settings.backgroundIntensity, range: 0...2,
+        defaultValue: defaults.backgroundIntensity, format: percent)
+      controlSlider(
+        "Vignette intensity", value: $settings.vignetteIntensity, range: 0...3,
+        defaultValue: defaults.vignetteIntensity, format: percent)
+    }
+  }
+}
+
+// MARK: - PlayStation4WavesSettingsControls
+
+struct PlayStation4WavesSettingsControls: View {
+  @Binding var settings: PlayStation4WavesSettings
+  private let defaults = PlayStation4WavesSettings()
+
+  var body: some View {
+    BackgroundSettingsResetHeader { settings = defaults }
+
+    BackgroundControlSection("Visibility") {
+      controlToggle(
+        "Show ambient glows", value: $settings.showsAmbientGlows,
+        defaultValue: defaults.showsAmbientGlows)
+      controlToggle(
+        "Show native particles", value: $settings.showsParticles,
+        defaultValue: defaults.showsParticles)
+      controlToggle("Show waves", value: $settings.showsWaves, defaultValue: defaults.showsWaves)
+      controlToggle(
+        "Show wave glow", value: $settings.showsWaveGlow, defaultValue: defaults.showsWaveGlow)
+      controlToggle(
+        "Show wave cores", value: $settings.showsWaveCores, defaultValue: defaults.showsWaveCores)
+    }
+    BackgroundControlSection("Native particles") {
+      controlSlider(
+        "Particle count", value: $settings.particleCount, range: 0...300,
+        defaultValue: defaults.particleCount, format: count)
+      controlSlider(
+        "Particle speed", value: $settings.particleSpeed, range: 0...4,
+        defaultValue: defaults.particleSpeed, format: multiplier)
+      controlSlider(
+        "Particle spread", value: $settings.particleSpread, range: 0...3,
+        defaultValue: defaults.particleSpread, format: multiplier)
+      controlSlider(
+        "Particle size", value: $settings.particleSize, range: 0.1...5,
+        defaultValue: defaults.particleSize, format: multiplier)
+      controlSlider(
+        "Particle opacity", value: $settings.particleOpacity, range: 0...3,
+        defaultValue: defaults.particleOpacity, format: percent)
+    }
+    BackgroundControlSection("Wave geometry") {
+      controlSlider(
+        "Wave count", value: $settings.waveCount, range: 1...16, defaultValue: defaults.waveCount,
+        format: count)
+      controlSlider(
+        "Wave height", value: $settings.waveVerticalPosition, range: 0...1,
+        defaultValue: defaults.waveVerticalPosition, format: percent)
+      controlSlider(
+        "Wave spacing", value: $settings.waveSpacing, range: 0...3,
+        defaultValue: defaults.waveSpacing, format: multiplier)
+      controlSlider(
+        "Wave amplitude", value: $settings.waveAmplitude, range: 0...3,
+        defaultValue: defaults.waveAmplitude, format: multiplier)
+      controlSlider(
+        "Wave curvature", value: $settings.waveCurvature, range: 0...3,
+        defaultValue: defaults.waveCurvature, format: multiplier)
+      controlSlider(
+        "Phase spread", value: $settings.phaseSpread, range: 0...3,
+        defaultValue: defaults.phaseSpread, format: multiplier)
+    }
+    BackgroundControlSection("Wave material") {
+      controlSlider(
+        "Glow blur", value: $settings.glowBlur, range: 0...50, defaultValue: defaults.glowBlur,
+        format: points)
+      controlSlider(
+        "Glow width", value: $settings.glowWidth, range: 0.1...3, defaultValue: defaults.glowWidth,
+        format: multiplier)
+      controlSlider(
+        "Glow opacity", value: $settings.glowOpacity, range: 0...3,
+        defaultValue: defaults.glowOpacity, format: percent)
+      controlSlider(
+        "Core width", value: $settings.coreWidth, range: 0.1...4, defaultValue: defaults.coreWidth,
+        format: multiplier)
+      controlSlider(
+        "Core opacity", value: $settings.coreOpacity, range: 0...3,
+        defaultValue: defaults.coreOpacity, format: percent)
+    }
+    BackgroundControlSection("Environment") {
+      controlSlider(
+        "Ambient glow scale", value: $settings.ambientGlowScale, range: 0.1...3,
+        defaultValue: defaults.ambientGlowScale, format: multiplier)
+      controlSlider(
+        "Ambient glow intensity", value: $settings.ambientGlowIntensity, range: 0...3,
+        defaultValue: defaults.ambientGlowIntensity, format: percent)
+      controlSlider(
+        "Vignette intensity", value: $settings.vignetteIntensity, range: 0...3,
+        defaultValue: defaults.vignetteIntensity, format: percent)
+    }
+  }
+}
+
+// MARK: - PlayStationRibbonsSettingsControls
+
+struct PlayStationRibbonsSettingsControls: View {
+  @Binding var settings: PlayStationRibbonsSettings
+  private let defaults = PlayStationRibbonsSettings()
+
+  var body: some View {
+    BackgroundSettingsResetHeader { settings = defaults }
+
+    BackgroundControlSection("Visibility") {
+      controlToggle("Show panels", value: $settings.showsPanels, defaultValue: defaults.showsPanels)
+      controlToggle(
+        "Show panel glow", value: $settings.showsPanelGlow, defaultValue: defaults.showsPanelGlow)
+      controlToggle(
+        "Show panel edges", value: $settings.showsPanelEdges, defaultValue: defaults.showsPanelEdges
+      )
+      controlToggle(
+        "Show native particles", value: $settings.showsParticles,
+        defaultValue: defaults.showsParticles)
+    }
+    BackgroundControlSection("Panel geometry") {
+      controlSlider(
+        "Panel count", value: $settings.panelCount, range: 1...12,
+        defaultValue: defaults.panelCount, format: count)
+      controlSlider(
+        "Panel height", value: $settings.panelVerticalPosition, range: -0.2...0.8,
+        defaultValue: defaults.panelVerticalPosition, format: percent)
+      controlSlider(
+        "Panel spacing", value: $settings.panelSpacing, range: 0...2,
+        defaultValue: defaults.panelSpacing, format: multiplier)
+      controlSlider(
+        "Panel amplitude", value: $settings.panelAmplitude, range: 0...3,
+        defaultValue: defaults.panelAmplitude, format: multiplier)
+      controlSlider(
+        "Panel thickness", value: $settings.panelThickness, range: 0.1...4,
+        defaultValue: defaults.panelThickness, format: multiplier)
+      controlSlider(
+        "Panel curvature", value: $settings.panelCurvature, range: 0...3,
+        defaultValue: defaults.panelCurvature, format: multiplier)
+      controlSlider(
+        "Phase spread", value: $settings.phaseSpread, range: 0...3,
+        defaultValue: defaults.phaseSpread, format: multiplier)
+    }
+    BackgroundControlSection("Panel material") {
+      controlSlider(
+        "Fill opacity", value: $settings.panelFillOpacity, range: 0...3,
+        defaultValue: defaults.panelFillOpacity, format: percent)
+      controlSlider(
+        "Glow opacity", value: $settings.panelGlowOpacity, range: 0...3,
+        defaultValue: defaults.panelGlowOpacity, format: percent)
+      controlSlider(
+        "Glow blur", value: $settings.panelGlowBlur, range: 0...3,
+        defaultValue: defaults.panelGlowBlur, format: multiplier)
+      controlSlider(
+        "Edge opacity", value: $settings.panelEdgeOpacity, range: 0...3,
+        defaultValue: defaults.panelEdgeOpacity, format: percent)
+      controlSlider(
+        "Edge width", value: $settings.panelEdgeWidth, range: 0.1...4,
+        defaultValue: defaults.panelEdgeWidth, format: multiplier)
+    }
+    BackgroundControlSection("Native particles") {
+      controlSlider(
+        "Particle count", value: $settings.particleCount, range: 0...500,
+        defaultValue: defaults.particleCount, format: count)
+      controlSlider(
+        "Particle speed", value: $settings.particleSpeed, range: 0...4,
+        defaultValue: defaults.particleSpeed, format: multiplier)
+      controlSlider(
+        "Particle drift", value: $settings.particleDrift, range: 0...4,
+        defaultValue: defaults.particleDrift, format: multiplier)
+      controlSlider(
+        "Vertical spread", value: $settings.particleVerticalSpread, range: 0...3,
+        defaultValue: defaults.particleVerticalSpread, format: multiplier)
+      controlSlider(
+        "Particle size", value: $settings.particleSize, range: 0.1...5,
+        defaultValue: defaults.particleSize, format: multiplier)
+      controlSlider(
+        "Particle opacity", value: $settings.particleOpacity, range: 0...3,
+        defaultValue: defaults.particleOpacity, format: percent)
+    }
+    BackgroundControlSection("Environment") {
+      controlSlider(
+        "Ambient glow scale", value: $settings.ambientGlowScale, range: 0.1...3,
+        defaultValue: defaults.ambientGlowScale, format: multiplier)
+      controlSlider(
+        "Ambient glow intensity", value: $settings.ambientGlowIntensity, range: 0...3,
+        defaultValue: defaults.ambientGlowIntensity, format: percent)
+      controlSlider(
+        "Vignette intensity", value: $settings.vignetteIntensity, range: 0...3,
+        defaultValue: defaults.vignetteIntensity, format: percent)
+    }
+  }
+}
+
+// MARK: - PlayStationPortableBlurSettingsControls
+
+struct PlayStationPortableBlurSettingsControls: View {
+  @Binding var settings: PlayStationPortableBlurSettings
+  private let defaults = PlayStationPortableBlurSettings()
+
+  var body: some View {
+    BackgroundSettingsResetHeader { settings = defaults }
+
+    BackgroundControlSection("Visibility") {
+      controlToggle(
+        "Show ribbons", value: $settings.showsRibbons, defaultValue: defaults.showsRibbons)
+      controlToggle(
+        "Show ribbon glow", value: $settings.showsGlow, defaultValue: defaults.showsGlow)
+      controlToggle(
+        "Show ribbon cores", value: $settings.showsCores, defaultValue: defaults.showsCores)
+      controlToggle(
+        "Alternate direction", value: $settings.alternatesDirection,
+        defaultValue: defaults.alternatesDirection)
+    }
+    BackgroundControlSection("Ribbon geometry") {
+      controlSlider(
+        "Ribbon count", value: $settings.ribbonCount, range: 1...14,
+        defaultValue: defaults.ribbonCount, format: count)
+      controlSlider(
+        "Vertical offset", value: $settings.verticalOffset, range: -0.6...0.6,
+        defaultValue: defaults.verticalOffset, format: signedPercent)
+      controlSlider(
+        "Wave amplitude", value: $settings.waveAmplitude, range: 0...3,
+        defaultValue: defaults.waveAmplitude, format: multiplier)
+      controlSlider(
+        "Detail amplitude", value: $settings.detailAmplitude, range: 0...3,
+        defaultValue: defaults.detailAmplitude, format: multiplier)
+      controlSlider(
+        "Phase spread", value: $settings.phaseSpread, range: 0...3,
+        defaultValue: defaults.phaseSpread, format: multiplier)
+    }
+    BackgroundControlSection("Ribbon material") {
+      controlSlider(
+        "Broad width", value: $settings.broadWidth, range: 0.1...4,
+        defaultValue: defaults.broadWidth, format: multiplier)
+      controlSlider(
+        "Glow blur", value: $settings.glowBlur, range: 0...3, defaultValue: defaults.glowBlur,
+        format: multiplier)
+      controlSlider(
+        "Glow opacity", value: $settings.glowOpacity, range: 0...3,
+        defaultValue: defaults.glowOpacity, format: percent)
+      controlSlider(
+        "Core width", value: $settings.coreWidth, range: 0.1...4, defaultValue: defaults.coreWidth,
+        format: multiplier)
+      controlSlider(
+        "Core blur", value: $settings.coreBlur, range: 0...3, defaultValue: defaults.coreBlur,
+        format: multiplier)
+      controlSlider(
+        "Core opacity", value: $settings.coreOpacity, range: 0...3,
+        defaultValue: defaults.coreOpacity, format: percent)
+    }
+    BackgroundControlSection("Environment") {
+      controlSlider(
+        "Background intensity", value: $settings.backgroundIntensity, range: 0...2,
+        defaultValue: defaults.backgroundIntensity, format: percent)
+      controlSlider(
+        "Ambient glow scale", value: $settings.ambientGlowScale, range: 0.1...3,
+        defaultValue: defaults.ambientGlowScale, format: multiplier)
+      controlSlider(
+        "Ambient glow intensity", value: $settings.ambientGlowIntensity, range: 0...3,
+        defaultValue: defaults.ambientGlowIntensity, format: percent)
+      controlSlider(
+        "Vignette intensity", value: $settings.vignetteIntensity, range: 0...3,
+        defaultValue: defaults.vignetteIntensity, format: percent)
+    }
+  }
+}
+
+// MARK: - PlayStation3XMBMartSettingsControls
+
+struct PlayStation3XMBMartSettingsControls: View {
+  @Binding var settings: PlayStation3XMBSettings
+  @Binding var isPresetExplicit: Bool
+  @AppStorage("ARMSX2iOSDynamicExpandedNestedGroups")
+  private var expandedGroups = ""
+  private let defaults = PlayStation3XMBSettings()
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack {
+        Spacer()
+
+        Button {
+          settings = defaults
+          isPresetExplicit = false
+        } label: {
+          Label("Reset", systemImage: "arrow.counterclockwise")
+            .font(.caption.weight(.semibold))
+        }
+        .buttonStyle(.borderless)
+      }
+
+      xmbMartSettingGroup("Background") {
+        HStack {
+          Picker(
+            "Gradient preset",
+            selection: gradientPresetBinding
+          ) {
+            ForEach(PlayStation3XMBGradientPreset.allCases) { preset in
+              Text(preset.title).tag(preset)
+            }
+          }
+          .pickerStyle(.menu)
+          settingResetButton("Gradient preset") {
+            settings.gradientPreset =
+              defaults.gradientPreset
+            isPresetExplicit = false
+          }
+        }
+
+        particleSlider(
+          "Color red",
+          value: $settings.colorR,
+          range: 0...255,
+          formattedValue: String(format: "%.0f", settings.colorR)
+        )
+        particleSlider(
+          "Color green",
+          value: $settings.colorG,
+          range: 0...255,
+          formattedValue: String(format: "%.0f", settings.colorG)
+        )
+        particleSlider(
+          "Color blue",
+          value: $settings.colorB,
+          range: 0...255,
+          formattedValue: String(format: "%.0f", settings.colorB)
+        )
+        particleSlider(
+          "Gradient top multiplier",
+          value: $settings.gradientTopMul,
+          range: 0...0.3,
+          formattedValue: String(format: "%.3f", settings.gradientTopMul)
+        )
+        particleSlider(
+          "Gradient bottom multiplier",
+          value: $settings.gradientBotMul,
+          range: 0.2...1.2,
+          formattedValue: String(format: "%.3f", settings.gradientBotMul)
+        )
+      }
+
+      xmbMartSettingGroup("Particles") {
+        particleSlider(
+          "Count",
+          value: $settings.particleCount,
+          range: 10...4000,
+          formattedValue: String(format: "%.0f", settings.particleCount)
+        )
+        particleSlider(
+          "Opacity",
+          value: $settings.particleOpacity,
+          range: 0...1,
+          formattedValue: String(format: "%.2f", settings.particleOpacity)
+        )
+        particleSlider(
+          "Base size",
+          value: $settings.particleSizeBase,
+          range: 1...40,
+          formattedValue: String(format: "%.1f", settings.particleSizeBase)
+        )
+        particleSlider(
+          "Size variance",
+          value: $settings.particleSizeVariance,
+          range: 0...50,
+          formattedValue: String(format: "%.1f", settings.particleSizeVariance)
+        )
+        particleSlider(
+          "Particle flow speed",
+          value: $settings.particleFlowSpeed,
+          range: 0...3,
+          formattedValue: String(format: "%.2f", settings.particleFlowSpeed)
+        )
+        particleSlider(
+          "Y-axis spread",
+          value: $settings.particleVerticalSpread,
+          range: 0.25...3.0,
+          formattedValue: "\(Int(settings.particleVerticalSpread * 100))%",
+          resetValue: defaults.particleVerticalSpread
+        )
+        particleSlider(
+          "Y-axis density",
+          value: $settings.particleVerticalDensity,
+          range: 0.25...3.0,
+          formattedValue: "\(Int(settings.particleVerticalDensity * 100))%",
+          resetValue: defaults.particleVerticalDensity
+        )
+        particleSlider(
+          "Outer top/bottom dispersion",
+          value: $settings.particleOuterDispersion,
+          range: 0.0...2.5,
+          formattedValue: "\(Int(settings.particleOuterDispersion * 100))%",
+          resetValue: defaults.particleOuterDispersion
+        )
+        particleSlider(
+          "Depth variation",
+          value: $settings.particleDepthVariation,
+          range: 0.0...1.5,
+          formattedValue: "\(Int(settings.particleDepthVariation * 100))%",
+          resetValue: defaults.particleDepthVariation
+        )
+        HStack {
+          Toggle(
+            "Follow wave Y-axis",
+            isOn: $settings.particlesFollowWaveY
+          )
+          settingResetButton("Follow wave Y-axis") {
+            settings.particlesFollowWaveY =
+              defaults.particlesFollowWaveY
+          }
+        }
+      }
+
+      xmbMartSettingGroup("Spline motion") {
+        particleSlider(
+          "Flow speed",
+          value: $settings.flowSpeed,
+          range: 0...1.2,
+          formattedValue: String(format: "%.3f", settings.flowSpeed)
+        )
+        particleSlider(
+          "Tension",
+          value: $settings.tension,
+          range: 0...0.5,
+          formattedValue: String(format: "%.3f", settings.tension)
+        )
+        particleSlider(
+          "Damping",
+          value: $settings.damping,
+          range: 0...0.002,
+          formattedValue: String(format: "%.5f", settings.damping)
+        )
+        particleSlider(
+          "Length",
+          value: $settings.length,
+          range: 0.05...1.2,
+          formattedValue: String(format: "%.3f", settings.length)
+        )
+        particleSlider(
+          "Spacing",
+          value: $settings.spacing,
+          range: 10...800,
+          formattedValue: String(format: "%.0f", settings.spacing)
+        )
+        particleSlider(
+          "Time step",
+          value: $settings.timeStep,
+          range: 0.1...4,
+          formattedValue: String(format: "%.2f", settings.timeStep)
+        )
+      }
+
+      xmbMartSettingGroup("Bands and travel") {
+        particleSlider(
+          "Band amplitude",
+          value: $settings.bandAmplitude,
+          range: 0...0.6,
+          formattedValue: String(format: "%.3f", settings.bandAmplitude)
+        )
+        particleSlider(
+          "Secondary frequency",
+          value: $settings.bandSecondaryFrequency,
+          range: 0.5...16,
+          formattedValue: String(format: "%.1f", settings.bandSecondaryFrequency)
+        )
+        particleSlider(
+          "Secondary amplitude",
+          value: $settings.bandSecondaryAmplitude,
+          range: 0...0.12,
+          formattedValue: String(format: "%.3f", settings.bandSecondaryAmplitude)
+        )
+        particleSlider(
+          "Travel speed 1",
+          value: $settings.travelSpeed1,
+          range: 0...1.5,
+          formattedValue: String(format: "%.2f", settings.travelSpeed1)
+        )
+        particleSlider(
+          "Travel amplitude 1",
+          value: $settings.travelAmplitude1,
+          range: 0...0.08,
+          formattedValue: String(format: "%.3f", settings.travelAmplitude1)
+        )
+        particleSlider(
+          "Travel speed 2",
+          value: $settings.travelSpeed2,
+          range: 0...1.5,
+          formattedValue: String(format: "%.2f", settings.travelSpeed2)
+        )
+        particleSlider(
+          "Travel amplitude 2",
+          value: $settings.travelAmplitude2,
+          range: 0...0.08,
+          formattedValue: String(format: "%.3f", settings.travelAmplitude2)
+        )
+      }
+
+      xmbMartSettingGroup("Wave shaping") {
+        particleSlider(
+          "Perturbation",
+          value: $settings.perturbation,
+          range: 0...0.3,
+          formattedValue: String(format: "%.3f", settings.perturbation)
+        )
+        particleSlider(
+          "Perturbation scale",
+          value: $settings.perturbationScale,
+          range: 0...0.3,
+          formattedValue: String(format: "%.3f", settings.perturbationScale)
+        )
+        particleSlider(
+          "Cosine amplitude",
+          value: $settings.waveCosineAmplitude,
+          range: 0...0.3,
+          formattedValue: String(format: "%.3f", settings.waveCosineAmplitude)
+        )
+        particleSlider(
+          "Wave bias",
+          value: $settings.waveBias,
+          range: -0.3...0.3,
+          formattedValue: String(format: "%.3f", settings.waveBias)
+        )
+        particleSlider(
+          "Height scale",
+          value: $settings.waveHeightScale,
+          range: 0...1,
+          formattedValue: String(format: "%.3f", settings.waveHeightScale)
+        )
+        particleSlider(
+          "Soft clip",
+          value: $settings.waveSoftClip,
+          range: 0.05...0.5,
+          formattedValue: String(format: "%.3f", settings.waveSoftClip)
+        )
+      }
+
+      xmbMartSettingGroup("Reverse pipeline") {
+        particleSlider(
+          "Pipeline blend",
+          value: $settings.reversePipelineBlend,
+          range: 0...1,
+          formattedValue: String(format: "%.2f", settings.reversePipelineBlend)
+        )
+        particleSlider(
+          "Descriptor strength",
+          value: $settings.reverseDescriptorStrength,
+          range: 0...2,
+          formattedValue: String(format: "%.2f", settings.reverseDescriptorStrength)
+        )
+        particleSlider(
+          "Descriptor seed",
+          value: $settings.reverseSyntheticDescriptorSeed,
+          range: 0...100_000,
+          formattedValue: String(format: "%.0f", settings.reverseSyntheticDescriptorSeed)
+        )
+        particleSlider(
+          "Descriptor motion",
+          value: $settings.reverseSyntheticDescriptorMotion,
+          range: 0...5,
+          formattedValue: String(format: "%.2f", settings.reverseSyntheticDescriptorMotion)
+        )
+        particleSlider(
+          "Kernel gain",
+          value: $settings.reverseKernelGain,
+          range: 0...1,
+          formattedValue: String(format: "%.3f", settings.reverseKernelGain)
+        )
+        particleSlider(
+          "Normalize gain",
+          value: $settings.reverseNormalizeGain,
+          range: 0...2,
+          formattedValue: String(format: "%.2f", settings.reverseNormalizeGain)
+        )
+        particleSlider(
+          "Kernel phase step",
+          value: $settings.reverseKernelPhaseStep,
+          range: 0...8,
+          formattedValue: String(format: "%.2f", settings.reverseKernelPhaseStep)
+        )
+        particleSlider(
+          "Index jitter",
+          value: $settings.reverseIndexJitter,
+          range: 0...0.5,
+          formattedValue: String(format: "%.3f", settings.reverseIndexJitter)
+        )
+        particleSlider(
+          "Temporal smoothing",
+          value: $settings.reverseTemporalSmooth,
+          range: 0...0.98,
+          formattedValue: String(format: "%.2f", settings.reverseTemporalSmooth)
+        )
+      }
+
+      xmbMartSettingGroup("Material") {
+        particleSlider(
+          "Fresnel power",
+          value: $settings.fresnelPower,
+          range: 0.2...8,
+          formattedValue: String(format: "%.2f", settings.fresnelPower)
+        )
+        particleSlider(
+          "Fresnel scale",
+          value: $settings.fresnelScale,
+          range: 0...2,
+          formattedValue: String(format: "%.2f", settings.fresnelScale)
+        )
+        particleSlider(
+          "Wave opacity",
+          value: $settings.opacity,
+          range: 0...1,
+          formattedValue: String(format: "%.3f", settings.opacity)
+        )
+        particleSlider(
+          "Spline brightness",
+          value: $settings.brightness,
+          range: 0...2,
+          formattedValue: String(format: "%.2f", settings.brightness)
+        )
+        particleSlider(
+          "Z detail scale",
+          value: $settings.zDetailScale,
+          range: 0...0.25,
+          formattedValue: String(format: "%.3f", settings.zDetailScale)
+        )
+      }
+
+      xmbMartSettingGroup("Free-form deformation") {
+        particleSlider(
+          "Scale 1 X",
+          value: $settings.ffdScale1X,
+          range: 0...8,
+          formattedValue: String(format: "%.2f", settings.ffdScale1X)
+        )
+        particleSlider(
+          "Scale 1 Y",
+          value: $settings.ffdScale1Y,
+          range: 0...3,
+          formattedValue: String(format: "%.2f", settings.ffdScale1Y)
+        )
+        particleSlider(
+          "Scale 1 Z",
+          value: $settings.ffdScale1Z,
+          range: 0...3,
+          formattedValue: String(format: "%.2f", settings.ffdScale1Z)
+        )
+        particleSlider(
+          "Scale 2 X",
+          value: $settings.ffdScale2X,
+          range: 0...8,
+          formattedValue: String(format: "%.2f", settings.ffdScale2X)
+        )
+        particleSlider(
+          "Scale 2 Y",
+          value: $settings.ffdScale2Y,
+          range: 0...3,
+          formattedValue: String(format: "%.2f", settings.ffdScale2Y)
+        )
+        particleSlider(
+          "Scale 2 Z",
+          value: $settings.ffdScale2Z,
+          range: 0...6,
+          formattedValue: String(format: "%.2f", settings.ffdScale2Z)
+        )
+        particleSlider(
+          "Offset X",
+          value: $settings.ffdOffsetX,
+          range: -2...2,
+          formattedValue: String(format: "%.2f", settings.ffdOffsetX)
+        )
+        particleSlider(
+          "Offset Y",
+          value: $settings.ffdOffsetY,
+          range: -2...2,
+          formattedValue: String(format: "%.2f", settings.ffdOffsetY)
+        )
+        particleSlider(
+          "Offset Z",
+          value: $settings.ffdOffsetZ,
+          range: -2...2,
+          formattedValue: String(format: "%.2f", settings.ffdOffsetZ)
+        )
+        particleSlider(
+          "Y amplitude",
+          value: $settings.ffdYAmplitude,
+          range: 0...0.3,
+          formattedValue: String(format: "%.3f", settings.ffdYAmplitude)
+        )
+        particleSlider(
+          "Z amplitude",
+          value: $settings.ffdZAmplitude,
+          range: 0...0.3,
+          formattedValue: String(format: "%.3f", settings.ffdZAmplitude)
+        )
+      }
+    }
+  }
+
+  private var gradientPresetBinding: Binding<PlayStation3XMBGradientPreset> {
+    Binding(
+      get: { settings.gradientPreset },
+      set: { preset in
+        settings.gradientPreset = preset
+        isPresetExplicit = true
+      }
+    )
+  }
+
+  private func particleSlider(
+    _ title: String,
+    value: Binding<Double>,
+    range: ClosedRange<Double>,
+    step: Double? = nil,
+    formattedValue: String,
+    resetValue: Double? = nil
+  ) -> some View {
+    DynamicSettingsValueSlider(
+      title: title,
+      value: value,
+      range: range,
+      step: step,
+      formattedValue: formattedValue,
+      resetValue: resetValue ?? defaultValue(for: title)
+    )
+  }
+
+  private func xmbMartSettingGroup<Content: View>(
+    _ title: String,
+    @ViewBuilder content: @escaping () -> Content
+  ) -> some View {
+    DisclosureGroup(
+      isExpanded: DynamicSettingsExpansion.binding(
+        storage: $expandedGroups,
+        identifier: "mart.\(title)"
+      )
+    ) {
+      VStack(alignment: .leading, spacing: 12) {
+        content()
+      }
+      .padding(.top, 10)
+    } label: {
+      Text(title)
+        .font(.subheadline.weight(.semibold))
+    }
+  }
+
+  private func defaultValue(for title: String) -> Double? {
+    switch title {
+    case "Color red": return defaults.colorR
+    case "Color green": return defaults.colorG
+    case "Color blue": return defaults.colorB
+    case "Gradient top multiplier": return defaults.gradientTopMul
+    case "Gradient bottom multiplier": return defaults.gradientBotMul
+    case "Count": return defaults.particleCount
+    case "Opacity": return defaults.particleOpacity
+    case "Base size": return defaults.particleSizeBase
+    case "Size variance": return defaults.particleSizeVariance
+    case "Particle flow speed": return defaults.particleFlowSpeed
+    case "Y-axis spread": return defaults.particleVerticalSpread
+    case "Y-axis density": return defaults.particleVerticalDensity
+    case "Outer top/bottom dispersion": return defaults.particleOuterDispersion
+    case "Depth variation": return defaults.particleDepthVariation
+    case "Flow speed": return defaults.flowSpeed
+    case "Tension": return defaults.tension
+    case "Damping": return defaults.damping
+    case "Length": return defaults.length
+    case "Spacing": return defaults.spacing
+    case "Time step": return defaults.timeStep
+    case "Band amplitude": return defaults.bandAmplitude
+    case "Secondary frequency": return defaults.bandSecondaryFrequency
+    case "Secondary amplitude": return defaults.bandSecondaryAmplitude
+    case "Travel speed 1": return defaults.travelSpeed1
+    case "Travel amplitude 1": return defaults.travelAmplitude1
+    case "Travel speed 2": return defaults.travelSpeed2
+    case "Travel amplitude 2": return defaults.travelAmplitude2
+    case "Perturbation": return defaults.perturbation
+    case "Perturbation scale": return defaults.perturbationScale
+    case "Cosine amplitude": return defaults.waveCosineAmplitude
+    case "Wave bias": return defaults.waveBias
+    case "Height scale": return defaults.waveHeightScale
+    case "Soft clip": return defaults.waveSoftClip
+    case "Pipeline blend": return defaults.reversePipelineBlend
+    case "Descriptor strength": return defaults.reverseDescriptorStrength
+    case "Descriptor seed": return defaults.reverseSyntheticDescriptorSeed
+    case "Descriptor motion": return defaults.reverseSyntheticDescriptorMotion
+    case "Kernel gain": return defaults.reverseKernelGain
+    case "Normalize gain": return defaults.reverseNormalizeGain
+    case "Kernel phase step": return defaults.reverseKernelPhaseStep
+    case "Index jitter": return defaults.reverseIndexJitter
+    case "Temporal smoothing": return defaults.reverseTemporalSmooth
+    case "Fresnel power": return defaults.fresnelPower
+    case "Fresnel scale": return defaults.fresnelScale
+    case "Wave opacity": return defaults.opacity
+    case "Spline brightness": return defaults.brightness
+    case "Z detail scale": return defaults.zDetailScale
+    case "Scale 1 X": return defaults.ffdScale1X
+    case "Scale 1 Y": return defaults.ffdScale1Y
+    case "Scale 1 Z": return defaults.ffdScale1Z
+    case "Scale 2 X": return defaults.ffdScale2X
+    case "Scale 2 Y": return defaults.ffdScale2Y
+    case "Scale 2 Z": return defaults.ffdScale2Z
+    case "Offset X": return defaults.ffdOffsetX
+    case "Offset Y": return defaults.ffdOffsetY
+    case "Offset Z": return defaults.ffdOffsetZ
+    case "Y amplitude": return defaults.ffdYAmplitude
+    case "Z amplitude": return defaults.ffdZAmplitude
+    default: return nil
+    }
+  }
+}

--- a/platforms/ios/app/src/main/swift/Views/Background/Dynamic/PlayStation3XMBByMartShaderLibrary.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/Dynamic/PlayStation3XMBByMartShaderLibrary.swift
@@ -1,0 +1,383 @@
+// PlayStation3XMBByMartShaderLibrary.swift — runtime Metal library for the XMB background
+// SPDX-License-Identifier: MIT
+
+import Foundation
+@preconcurrency import Metal
+
+@MainActor
+enum PlayStation3XMBByMartShaderLibrary {
+  private static var cachedLibrary: MTLLibrary?
+  private static var activeRendererCount = 0
+
+  static func makeLibrary(device: MTLDevice) -> MTLLibrary? {
+    if let cachedLibrary {
+      return cachedLibrary
+    }
+
+    if let defaultLibrary = device.makeDefaultLibrary(),
+      requiredFunctions.allSatisfy({
+        defaultLibrary.makeFunction(name: $0) != nil
+      })
+    {
+      cachedLibrary = defaultLibrary
+      return defaultLibrary
+    }
+
+    do {
+      let library = try device.makeLibrary(source: source, options: nil)
+      cachedLibrary = library
+      return library
+    } catch {
+      NSLog(
+        "[ARMSX2 Dynamic Backgrounds] XMB shader compilation failed: %@",
+        error.localizedDescription
+      )
+      return nil
+    }
+  }
+
+  static func retainForRenderer() {
+    activeRendererCount += 1
+  }
+
+  static func releaseForRenderer() {
+    guard activeRendererCount > 0 else {
+      cachedLibrary = nil
+      return
+    }
+
+    activeRendererCount -= 1
+    if activeRendererCount == 0 {
+      cachedLibrary = nil
+    }
+  }
+
+  static func releaseIfUnused() {
+    if activeRendererCount == 0 {
+      cachedLibrary = nil
+    }
+  }
+
+  private static let requiredFunctions = [
+    "xmbBackgroundVertex",
+    "xmbBackgroundFragment",
+    "xmbWaveVertex",
+    "xmbWaveFragment",
+    "xmbParticleVertex",
+    "xmbParticleFragment",
+  ]
+
+  private static let source = #"""
+// PlayStation 3 XMB recreation shaders
+// SPDX-License-Identifier: MIT
+
+#include <metal_stdlib>
+using namespace metal;
+
+struct XMBBackgroundUniforms {
+  float4 startColor;
+  float4 endColor;
+  float4 directionRange;
+  float4 geometry;
+};
+
+struct XMBBackgroundVertexOut {
+  float4 position [[position]];
+  float2 uvYDown;
+};
+
+vertex XMBBackgroundVertexOut xmbBackgroundVertex(
+  uint vertexID [[vertex_id]]
+) {
+  const float2 positions[4] = {
+    float2(-1.0, -1.0),
+    float2(1.0, -1.0),
+    float2(-1.0, 1.0),
+    float2(1.0, 1.0),
+  };
+  float2 position = positions[vertexID];
+  XMBBackgroundVertexOut output;
+  output.position = float4(position, 0.0, 1.0);
+  output.uvYDown = float2(
+    position.x * 0.5 + 0.5,
+    1.0 - (position.y * 0.5 + 0.5)
+  );
+  return output;
+}
+
+fragment float4 xmbBackgroundFragment(
+  XMBBackgroundVertexOut input [[stage_in]],
+  constant XMBBackgroundUniforms &uniforms [[buffer(0)]]
+) {
+  float2 direction = uniforms.directionRange.xy;
+  float minimum = uniforms.directionRange.z;
+  float span = max(uniforms.directionRange.w, 1e-6);
+  float2 offsetUV = input.uvYDown - uniforms.geometry.xy;
+  float projection = dot(offsetUV, direction);
+  float2 perpendicular = float2(-direction.y, direction.x);
+  float perpendicularPosition = dot(
+    offsetUV - float2(0.5),
+    perpendicular
+  );
+  projection += uniforms.geometry.w
+    * perpendicularPosition
+    * perpendicularPosition
+    * span
+    * 0.78;
+  float normalizedProgress = (projection - minimum) / span;
+  float progress = clamp(
+    (normalizedProgress - 0.5) / max(uniforms.geometry.z, 0.05) + 0.5,
+    0.0,
+    1.0
+  );
+  float smoothProgress = progress * progress * (3.0 - 2.0 * progress);
+  return float4(
+    mix(uniforms.startColor.rgb, uniforms.endColor.rgb, smoothProgress),
+    1.0
+  );
+}
+
+struct XMBWaveUniforms {
+  float4 timing;
+  float4 geometry;
+  float4 shaping;
+  float4 detail;
+  float4 ffdScale1;
+  float4 ffdScale2;
+  float4 ffdOffset;
+  float4 material;
+  float4 color;
+};
+
+struct XMBWaveVertexOut {
+  float4 position [[position]];
+  float3 worldPosition;
+};
+
+vertex XMBWaveVertexOut xmbWaveVertex(
+  uint vertexID [[vertex_id]],
+  const device float2 *positions [[buffer(0)]],
+  constant XMBWaveUniforms &uniforms [[buffer(1)]],
+  texture2d<float> splineTexture [[texture(0)]]
+) {
+  constexpr sampler splineSampler(
+    coord::normalized,
+    address::clamp_to_edge,
+    filter::linear
+  );
+  float2 inputPosition = positions[vertexID];
+  float3 position = float3(inputPosition.x, 0.0, inputPosition.y);
+  float2 uv = (inputPosition + 1.0) * 0.5;
+  position.y = splineTexture.sample(splineSampler, uv).r;
+
+  float time = uniforms.timing.x;
+  float flowSpeed = uniforms.timing.y;
+  float tension = uniforms.timing.z;
+  float damping = uniforms.timing.w;
+  float length = uniforms.geometry.x;
+  float spacing = uniforms.geometry.y;
+  float perturbation = uniforms.geometry.z;
+  float perturbationScale = uniforms.geometry.w;
+  float timeStep = uniforms.shaping.x;
+  float waveCosineAmplitude = uniforms.shaping.y;
+  float waveBias = uniforms.shaping.z;
+  float waveHeightScale = uniforms.shaping.w;
+
+  float3 ffd1 = position * uniforms.ffdScale1.xyz + uniforms.ffdOffset.xyz;
+  float3 ffd2 = position * uniforms.ffdScale2.xyz + uniforms.ffdOffset.xyz;
+  position.y += sin(ffd1.x + time * flowSpeed) * uniforms.detail.y;
+  position.z += cos(ffd2.z + time * flowSpeed) * uniforms.detail.z;
+
+  float baseWave = cos(position.x * 2.0 - time * 0.5 * timeStep)
+    * waveCosineAmplitude + waveBias;
+  baseWave *= 1.0 - damping;
+  baseWave += tension
+    * sin(position.x * length + time * flowSpeed * timeStep * 0.25);
+  float structured = perturbation * perturbationScale * (
+    sin(
+      (position.x * length * 6.0 + position.z * 0.5)
+        * spacing * 0.01
+        + time * flowSpeed * timeStep * 0.7
+    ) * 0.5
+      + sin(
+        (position.x * length * 10.0 - position.z * 0.8)
+          * spacing * 0.005
+          - time * flowSpeed * timeStep * 0.35
+      ) * 0.25
+  );
+  float totalWave = (baseWave + structured) * waveHeightScale;
+  float softClip = max(uniforms.detail.x, 1e-4);
+  totalWave = softClip * tanh(totalWave / softClip);
+  position.y -= totalWave;
+
+  float2 shiftedUV = uv;
+  shiftedUV.x = fract(
+    shiftedUV.x - time * flowSpeed * 0.04 * timeStep
+  );
+  position.z -= splineTexture.sample(splineSampler, shiftedUV).r
+    * uniforms.detail.w;
+
+  XMBWaveVertexOut output;
+  output.position = float4(position, 1.0);
+  output.worldPosition = position;
+  return output;
+}
+
+fragment float4 xmbWaveFragment(
+  XMBWaveVertexOut input [[stage_in]],
+  constant XMBWaveUniforms &uniforms [[buffer(1)]]
+) {
+  float3 derivativeX = dfdx(input.worldPosition);
+  float3 derivativeY = dfdy(input.worldPosition);
+  float3 normal = normalize(cross(derivativeX, derivativeY));
+  float fresnel = uniforms.material.w * pow(
+    1.0 + dot(float3(0.0, 0.0, -1.0), normal),
+    uniforms.material.z
+  );
+  float alpha = fresnel * uniforms.material.x * uniforms.material.y;
+  return float4(uniforms.color.rgb, alpha);
+}
+
+struct XMBParticleUniforms {
+  float4 timing;
+  float4 sizing;
+  float4 color;
+  float4 distribution;
+  float4 waveFollowing;
+};
+
+struct XMBParticleVertexOut {
+  float4 position [[position]];
+  float pointSize [[point_size]];
+  float alpha;
+};
+
+vertex XMBParticleVertexOut xmbParticleVertex(
+  uint vertexID [[vertex_id]],
+  const device float3 *seeds [[buffer(0)]],
+  constant XMBParticleUniforms &uniforms [[buffer(1)]],
+  constant XMBWaveUniforms &waveUniforms [[buffer(2)]],
+  texture2d<float> splineTexture [[texture(0)]]
+) {
+  constexpr sampler splineSampler(
+    coord::normalized,
+    address::clamp_to_edge,
+    filter::linear
+  );
+  float3 seed = seeds[vertexID];
+  float time = uniforms.timing.x * uniforms.timing.y;
+  float ratio = uniforms.timing.z;
+  float horizontalVelocity = uniforms.distribution.z < 0.5
+    ? seed.x - 0.5
+    : abs(seed.x - 0.5) * uniforms.distribution.x;
+  float x = fract(time * horizontalVelocity / 15.0 + seed.y * 50.0)
+    * 2.0 - 1.0;
+  float flowOffset = sin(
+    sign(seed.y) * time * (seed.y + 1.5) / 4.0 + seed.x * 100.0
+  ) / ((6.0 - seed.x * 4.0 * seed.y) / ratio);
+  float opacityVariation = mix(
+    sin(time * (seed.x + 0.5) * 12.0 + seed.y * 10.0),
+    sin(time * (seed.y + 1.5) * 6.0 + seed.x * 4.0),
+    flowOffset * 0.5 + 0.5
+  ) * seed.x + seed.y;
+
+  float outerSeed = seed.y * 2.0 - 1.0;
+  float outerOffset = sign(outerSeed)
+    * pow(abs(outerSeed), 0.45)
+    * uniforms.distribution.w
+    * 0.16;
+  float waveY = 0.0;
+  if (uniforms.waveFollowing.x > 0.5) {
+    float3 wavePosition = float3(x, 0.0, 0.0);
+    float2 waveUV = (wavePosition.xz + 1.0) * 0.5;
+    wavePosition.y = splineTexture.sample(splineSampler, waveUV).r;
+
+    float3 ffd1 = wavePosition * waveUniforms.ffdScale1.xyz
+      + waveUniforms.ffdOffset.xyz;
+    float3 ffd2 = wavePosition * waveUniforms.ffdScale2.xyz
+      + waveUniforms.ffdOffset.xyz;
+    wavePosition.y += sin(
+      ffd1.x + waveUniforms.timing.x * waveUniforms.timing.y
+    ) * waveUniforms.detail.y;
+    wavePosition.z += cos(
+      ffd2.z + waveUniforms.timing.x * waveUniforms.timing.y
+    ) * waveUniforms.detail.z;
+
+    float baseWave = cos(
+      wavePosition.x * 2.0
+        - waveUniforms.timing.x * 0.5 * waveUniforms.shaping.x
+    ) * waveUniforms.shaping.y + waveUniforms.shaping.z;
+    baseWave *= 1.0 - waveUniforms.timing.w;
+    baseWave += waveUniforms.timing.z * sin(
+      wavePosition.x * waveUniforms.geometry.x
+        + waveUniforms.timing.x
+          * waveUniforms.timing.y
+          * waveUniforms.shaping.x
+          * 0.25
+    );
+    float structured = waveUniforms.geometry.z * waveUniforms.geometry.w * (
+      sin(
+        (wavePosition.x * waveUniforms.geometry.x * 6.0
+          + wavePosition.z * 0.5)
+          * waveUniforms.geometry.y
+          * 0.01
+          + waveUniforms.timing.x
+            * waveUniforms.timing.y
+            * waveUniforms.shaping.x
+            * 0.7
+      ) * 0.5
+        + sin(
+          (wavePosition.x * waveUniforms.geometry.x * 10.0
+            - wavePosition.z * 0.8)
+            * waveUniforms.geometry.y
+            * 0.005
+            - waveUniforms.timing.x
+              * waveUniforms.timing.y
+              * waveUniforms.shaping.x
+              * 0.35
+        ) * 0.25
+    );
+    float totalWave = (baseWave + structured) * waveUniforms.shaping.w;
+    float softClip = max(waveUniforms.detail.x, 1e-4);
+    totalWave = softClip * tanh(totalWave / softClip);
+    waveY = wavePosition.y - totalWave;
+  }
+
+  float y = waveY
+    + uniforms.sizing.w
+    + flowOffset * uniforms.distribution.y
+    + outerOffset;
+
+  XMBParticleVertexOut output;
+  output.position = float4(x, y, 0.0, 1.0);
+  float depthScale = max(
+    0.25,
+    1.0 + (seed.x - 0.5) * uniforms.color.a
+  );
+  output.pointSize = (seed.z * uniforms.sizing.y + uniforms.sizing.x)
+    * uniforms.sizing.z
+    * depthScale;
+  output.alpha = opacityVariation * opacityVariation
+    * (1.0 - fract(seed.x + time * 0.00285));
+  return output;
+}
+
+fragment float4 xmbParticleFragment(
+  XMBParticleVertexOut input [[stage_in]],
+  float2 pointCoordinate [[point_coord]],
+  constant XMBParticleUniforms &uniforms [[buffer(1)]]
+) {
+  float2 centered = pointCoordinate * 2.0 - 1.0;
+  float distanceSquared = dot(centered, centered);
+  if (distanceSquared > 1.0) {
+    discard_fragment();
+  }
+  float sparkle = (1.0 - distanceSquared) * (1.0 - distanceSquared);
+  float alpha = input.alpha * uniforms.timing.w * sparkle;
+  bool rendersTransparentParticles = uniforms.distribution.z >= 0.5
+    || uniforms.waveFollowing.y > 0.5;
+  float outputAlpha = rendersTransparentParticles ? alpha : 1.0;
+  return float4(uniforms.color.rgb * alpha, outputAlpha);
+}
+"""#
+}

--- a/platforms/ios/app/src/main/swift/Views/Background/VideoBackgroundView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/VideoBackgroundView.swift
@@ -19,6 +19,10 @@ private struct VideoBackgroundPlayer: UIViewRepresentable {
 
     func makeUIView(context: Context) -> LoopingVideoView { LoopingVideoView() }
     func updateUIView(_ uiView: LoopingVideoView, context: Context) { uiView.configure(url: url, muted: muted, fitMode: fitMode) }
+
+	static func dismantleUIView(_ uiView: LoopingVideoView, coordinator: ()) {
+		MainActor.assumeIsolated { uiView.teardown() }
+	}
 }
 
 private final class LoopingVideoView: UIView {
@@ -26,11 +30,11 @@ private final class LoopingVideoView: UIView {
     private var playerLooper: AVPlayerLooper?
     private var player: AVQueuePlayer?
     private var currentURL: URL?
+    private var releasedForGameplay = false
 
     deinit {
         MainActor.assumeIsolated {
-            pause()
-            NotificationCenter.default.removeObserver(self)
+			teardown()
         }
     }
 
@@ -45,13 +49,14 @@ private final class LoopingVideoView: UIView {
     }
 
     func configure(url: URL, muted: Bool, fitMode: BackgroundFitMode) {
+        guard !releasedForGameplay else { return }
         let gravity = videoGravity(for: fitMode)
 
         // Rebuild the player when the source changes so swapping the background
         // (portrait ↔ landscape, or replacing a video) actually takes effect.
         // The early-return-on-existing-player meant a second video was silently ignored.
         if player != nil, currentURL != url {
-            teardownPlayer()
+			teardown()
         }
 
         if player != nil {
@@ -77,19 +82,21 @@ private final class LoopingVideoView: UIView {
         layoutIfNeeded()
 
         NotificationCenter.default.addObserver(self, selector: #selector(pause), name: UIApplication.didEnterBackgroundNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(resumeIfReady), name: UIApplication.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(pause), name: UIScene.willDeactivateNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(resumeIfReady), name: UIScene.didActivateNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(releaseResourcesForGameplay), name: AppState.releaseMenuBackgroundResourcesNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(adaptToPowerState), name: .NSProcessInfoPowerStateDidChange, object: nil)
         adaptToPowerState()
     }
 
-    private func teardownPlayer() {
+	func teardown() {
         player?.pause()
         NotificationCenter.default.removeObserver(self)
         playerLayer?.removeFromSuperlayer()
         player = nil
         playerLooper = nil
         playerLayer = nil
+		currentURL = nil
     }
 
     @objc private func pause() { player?.pause() }
@@ -98,6 +105,11 @@ private final class LoopingVideoView: UIView {
         guard UIApplication.shared.applicationState != .background, !ProcessInfo.processInfo.isLowPowerModeEnabled else { return }
         player?.seek(to: .zero)
         player?.play()
+    }
+
+    @objc private func releaseResourcesForGameplay() {
+        releasedForGameplay = true
+        teardown()
     }
 
     @objc private func adaptToPowerState() {

--- a/platforms/ios/app/src/main/swift/Views/CoverThumbnailView.swift
+++ b/platforms/ios/app/src/main/swift/Views/CoverThumbnailView.swift
@@ -63,7 +63,15 @@ struct CoverThumbnailView: View {
             return
         }
 
-        image = await CoverThumbnailCache.shared.thumbnail(for: coverURL, signature: coverSignature, width: width, height: height, scale: scale)
+        let loadedImage = await CoverThumbnailCache.shared.thumbnail(
+            for: coverURL,
+            signature: coverSignature,
+            width: width,
+            height: height,
+            scale: scale
+        )
+        guard !Task.isCancelled else { return }
+        image = loadedImage
     }
 }
 
@@ -71,6 +79,9 @@ final class CoverThumbnailCache: @unchecked Sendable {
     static let shared = CoverThumbnailCache()
 
     private let cache = NSCache<NSString, UIImage>()
+    private let stateLock = NSLock()
+    private var generation: UInt64 = 0
+    private var acceptsImages = true
 
     private init() {
         cache.countLimit = 768
@@ -78,18 +89,24 @@ final class CoverThumbnailCache: @unchecked Sendable {
     }
 
     func cachedImage(for url: URL, signature: String?, width: CGFloat, height: CGFloat, scale: CGFloat) -> UIImage? {
-        cache.object(forKey: cacheKey(for: url, signature: signature, width: width, height: height, scale: scale))
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard acceptsImages else { return nil }
+        return cache.object(forKey: cacheKey(for: url, signature: signature, width: width, height: height, scale: scale))
     }
 
     func thumbnail(for url: URL, signature: String?, width: CGFloat, height: CGFloat, scale: CGFloat) async -> UIImage? {
         let key = cacheKey(for: url, signature: signature, width: width, height: height, scale: scale)
-        if let cached = cache.object(forKey: key) {
-            return cached
+        guard let request = beginRequest(for: key) else { return nil }
+        if let cachedImage = request.cachedImage {
+            return cachedImage
         }
+        let requestGeneration = request.generation
 
         let path = url.path
         let maxPixelSize = max(1, Int(max(width, height) * scale))
-        let image = await Task.detached(priority: .utility) {
+        let decodeTask = Task.detached(priority: .utility) {
+            guard !Task.isCancelled else { return nil as UIImage? }
             let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
             let thumbnailOptions = [
                 kCGImageSourceCreateThumbnailFromImageAlways: true,
@@ -100,16 +117,22 @@ final class CoverThumbnailCache: @unchecked Sendable {
 
             guard let source = CGImageSourceCreateWithURL(url as CFURL, sourceOptions),
                   let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions) else {
-                return UIImage(contentsOfFile: path)
+                let fallback = UIImage(contentsOfFile: path)
+                return Task.isCancelled ? nil : fallback
             }
 
+            guard !Task.isCancelled else { return nil }
             return UIImage(cgImage: cgImage, scale: scale, orientation: .up)
-        }.value
-
-        if let image {
-            let cost = max(1, Int(image.size.width * image.scale * image.size.height * image.scale * 4))
-            cache.setObject(image, forKey: key, cost: cost)
         }
+        let image = await withTaskCancellationHandler {
+            await decodeTask.value
+        } onCancel: {
+            decodeTask.cancel()
+        }
+
+        guard !Task.isCancelled, let image else { return nil }
+        let cost = max(1, Int(image.size.width * image.scale * image.size.height * image.scale * 4))
+        guard insert(image, for: key, cost: cost, generation: requestGeneration) else { return nil }
 
         return image
     }
@@ -120,6 +143,37 @@ final class CoverThumbnailCache: @unchecked Sendable {
         let modified = values?.contentModificationDate?.timeIntervalSince1970 ?? 0
         let size = values?.fileSize ?? 0
         return "\(url.path)|\(modified)|\(size)"
+    }
+
+    func activateForMenu() {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard !acceptsImages else { return }
+        generation &+= 1
+        acceptsImages = true
+    }
+
+    func releaseForGameplay() {
+        stateLock.lock()
+        generation &+= 1
+        acceptsImages = false
+        cache.removeAllObjects()
+        stateLock.unlock()
+    }
+
+    private func beginRequest(for key: NSString) -> (generation: UInt64, cachedImage: UIImage?)? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard acceptsImages else { return nil }
+        return (generation, cache.object(forKey: key))
+    }
+
+    private func insert(_ image: UIImage, for key: NSString, cost: Int, generation requestGeneration: UInt64) -> Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard acceptsImages, generation == requestGeneration else { return false }
+        cache.setObject(image, forKey: key, cost: cost)
+        return true
     }
 
     private func cacheKey(for url: URL, signature: String?, width: CGFloat, height: CGFloat, scale: CGFloat) -> NSString {

--- a/platforms/ios/app/src/main/swift/Views/GameListView.swift
+++ b/platforms/ios/app/src/main/swift/Views/GameListView.swift
@@ -114,6 +114,11 @@ private final class GameLibrarySnapshot {
 		entriesByID = Dictionary(entries.map { ($0.id, $0) }, uniquingKeysWith: { current, _ in current })
 	}
 
+	func releaseEntriesForGameplay() {
+		orderedEntries.removeAll(keepingCapacity: false)
+		entriesByID.removeAll(keepingCapacity: false)
+	}
+
 	/// Returns cached metadata when the file is unchanged: a matching modification
 	/// time, or a matching size when the modification time is unavailable (some
 	/// external folders report no stable date).
@@ -161,15 +166,12 @@ struct GameListView: View {
 	@State private var coverStore = CoverStore.shared
 	@State private var externalLibrary = ExternalGameLibrary.shared
 	@State private var externalCoverAutoDownloadAttemptedIDs = Set<String>()
+	@State private var coverWorkTask: Task<Void, Never>?
 	@State private var showGameImporter = false
 	@State private var isLoadingGames = false
 	@State private var showCoverImporter = false
     @State private var showCoverPhotoPicker = false
-    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
-
-    private var cardMaterial: Material {
-        reduceTransparency ? .regularMaterial : .thinMaterial
-    }
+    @Environment(\.menuTabIsActive) private var menuTabIsActive
     @State private var showRestartAlert = false
     @State private var showStopAlert = false
     @State private var showCoverTemplateEditor = false
@@ -197,7 +199,13 @@ struct GameListView: View {
 #endif
     // Background state is now kept in SettingsStore and rendered by BackgroundContainerView.
     private var hasCustomBackground: Bool {
-        settings.backgroundPrimaryAsset != nil || settings.backgroundLandscapeAsset != nil
+        settings.dynamicBackgroundsEnabled
+            || settings.backgroundPrimaryAsset != nil
+            || settings.backgroundLandscapeAsset != nil
+    }
+
+    private var shouldRenderLibraryBackground: Bool {
+		menuTabIsActive
     }
 
     private struct CoverFlowMetrics {
@@ -243,12 +251,13 @@ struct GameListView: View {
         }
         .ignoresSafeArea()
         .accessibilityHidden(true)
+		.allowsHitTesting(false)
     }
 
     var body: some View {
         NavigationStack {
             ZStack {
-                if hasCustomBackground {
+                if hasCustomBackground && shouldRenderLibraryBackground {
                     libraryBackgroundLayer
                 }
 
@@ -549,8 +558,9 @@ struct GameListView: View {
                     .presentationDetents([.large])
                     .presentationDragIndicator(.visible)
             }
-        }
+		}
 		.onAppear {
+			CoverThumbnailCache.shared.activateForMenu()
 			externalLibrary.reload()
 			restoreCachedGamesIfNeeded()
 			loadGames(autoDownloadExternalCovers: true)
@@ -570,6 +580,10 @@ struct GameListView: View {
 		.onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("ARMSX2iOSReturnToMenu"))) { _ in
 			restoreCachedGamesIfNeeded()
 			loadGames(autoDownloadExternalCovers: false)
+		}
+		.onDisappear {
+			guard case .playing = appState.currentScreen else { return }
+			releaseLibraryResourcesForGameplay()
 		}
     }
 
@@ -739,11 +753,12 @@ struct GameListView: View {
     }
 
     private func gameRow(_ game: ISOEntry) -> some View {
-        Button {
+		let running = isRunning(game)
+		return Button {
             open(game)
         } label: {
             HStack(spacing: 12) {
-                coverThumbnail(for: game)
+				coverThumbnail(for: game, running: running)
 
                 VStack(alignment: .leading, spacing: 4) {
                     HStack(spacing: 6) {
@@ -751,7 +766,7 @@ struct GameListView: View {
                             .font(.body)
                             .fontWeight(.medium)
                             .foregroundStyle(.primary)
-						if isRunning(game) {
+						if running {
 							Image(systemName: "circle.fill")
 								.font(.system(size: 8))
 								.foregroundStyle(.green)
@@ -783,8 +798,8 @@ struct GameListView: View {
 				.buttonStyle(.plain)
 				.accessibilityLabel(game.isFavorite ? settings.localized("Remove from favorites") : settings.localized("Add to favorites"))
 
-				Image(systemName: isRunning(game) ? "play.fill" : "chevron.right")
-					.foregroundStyle(isRunning(game) ? .green : .secondary)
+				Image(systemName: running ? "play.fill" : "chevron.right")
+					.foregroundStyle(running ? .green : .secondary)
 					.font(.caption)
 					.accessibilityHidden(true)
 			}
@@ -796,27 +811,28 @@ struct GameListView: View {
     }
 
     private func gameGridCard(_ game: ISOEntry) -> some View {
-        Button {
-            open(game)
-        } label: {
+		let running = isRunning(game)
+		return Button {
+			open(game)
+		} label: {
             VStack(alignment: .center, spacing: 10) {
-                ZStack(alignment: .topTrailing) {
-                    coverThumbnail(for: game, width: 126, height: 189)
-                        .frame(maxWidth: .infinity)
+				ZStack(alignment: .topTrailing) {
+					coverThumbnail(for: game, width: 126, height: 189, running: running)
+						.frame(maxWidth: .infinity)
 
 					Button {
 						toggleFavorite(game)
 					} label: {
 						Image(systemName: game.isFavorite ? "star.fill" : "star")
-                            .font(.callout.weight(.semibold))
-                            .foregroundStyle(game.isFavorite ? .yellow : .white.opacity(0.86))
-                            .padding(6)
-                            .background(.black.opacity(0.36), in: Circle())
-                    }
-                    .buttonStyle(.plain)
-                    .padding(6)
-                    .accessibilityLabel(game.isFavorite ? settings.localized("Remove from favorites") : settings.localized("Add to favorites"))
-                }
+							.font(.callout.weight(.semibold))
+							.foregroundStyle(game.isFavorite ? .yellow : .white.opacity(0.86))
+							.padding(6)
+							.background(.black.opacity(0.36), in: Circle())
+					}
+					.buttonStyle(.plain)
+					.padding(6)
+					.accessibilityLabel(game.isFavorite ? settings.localized("Remove from favorites") : settings.localized("Add to favorites"))
+				}
 
                 VStack(alignment: .center, spacing: 4) {
                     HStack(alignment: .firstTextBaseline, spacing: 5) {
@@ -826,7 +842,7 @@ struct GameListView: View {
                             .lineLimit(2)
                             .multilineTextAlignment(.center)
                             .frame(maxWidth: .infinity, alignment: .center)
-                        if isRunning(game) {
+						if running {
                             Image(systemName: "circle.fill")
                                 .font(.system(size: 7))
                                 .foregroundStyle(.green)
@@ -857,40 +873,42 @@ struct GameListView: View {
             }
             .padding(12)
             .frame(maxWidth: .infinity, minHeight: 268, alignment: .top)
-            .background(cardMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
-				.overlay {
-					RoundedRectangle(cornerRadius: 18, style: .continuous)
-						.strokeBorder(isRunning(game) ? .green.opacity(0.6) : .white.opacity(0.08), lineWidth: 1)
-				}
+			.glassSurface(clear: true, cornerRadius: 18)
         }
-        .buttonStyle(.plain)
-        .contextMenu {
-            gameContextMenu(for: game)
-        }
+		.buttonStyle(.plain)
+		.contextMenu {
+			gameContextMenu(for: game)
+		}
     }
 
     private func coverFlowCard(_ game: ISOEntry, metrics: CoverFlowMetrics) -> some View {
-        Button {
-            open(game)
-        } label: {
+		let running = isRunning(game)
+		return Button {
+			open(game)
+		} label: {
             VStack(spacing: metrics.cardSpacing) {
-                ZStack(alignment: .topTrailing) {
-                    coverThumbnail(for: game, width: metrics.coverWidth, height: metrics.coverHeight)
-                        .shadow(color: .black.opacity(0.28), radius: 18, y: 10)
+				ZStack(alignment: .topTrailing) {
+					coverThumbnail(
+						for: game,
+						width: metrics.coverWidth,
+						height: metrics.coverHeight,
+						running: running
+					)
+					.shadow(color: running ? .clear : .black.opacity(0.28), radius: 18, y: 10)
 
 					Button {
 						toggleFavorite(game)
 					} label: {
-                        Image(systemName: game.isFavorite ? "star.fill" : "star")
-                            .font((metrics.isCompact ? Font.subheadline : Font.headline).weight(.semibold))
-                            .foregroundStyle(game.isFavorite ? .yellow : .white.opacity(0.88))
-                            .padding(metrics.favoritePadding)
-                            .background(.black.opacity(0.48), in: Circle())
-                    }
-                    .buttonStyle(.plain)
-                    .padding(metrics.favoriteInset)
-                    .accessibilityLabel(game.isFavorite ? settings.localized("Remove from favorites") : settings.localized("Add to favorites"))
-                }
+						Image(systemName: game.isFavorite ? "star.fill" : "star")
+							.font((metrics.isCompact ? Font.subheadline : Font.headline).weight(.semibold))
+							.foregroundStyle(game.isFavorite ? .yellow : .white.opacity(0.88))
+							.padding(metrics.favoritePadding)
+							.background(.black.opacity(0.48), in: Circle())
+					}
+					.buttonStyle(.plain)
+					.padding(metrics.favoriteInset)
+					.accessibilityLabel(game.isFavorite ? settings.localized("Remove from favorites") : settings.localized("Add to favorites"))
+				}
 
                 VStack(spacing: 4) {
                     Text(coverStore.displayName(forGameName: game.name))
@@ -912,26 +930,32 @@ struct GameListView: View {
                 .frame(width: metrics.textWidth)
             }
             .padding(metrics.cardPadding)
-            .background(cardMaterial, in: RoundedRectangle(cornerRadius: metrics.cornerRadius, style: .continuous))
-			.overlay {
-				RoundedRectangle(cornerRadius: metrics.cornerRadius, style: .continuous)
-					.strokeBorder(isRunning(game) ? .green.opacity(0.7) : .white.opacity(0.12), lineWidth: 1)
-			}
+			.glassSurface(clear: true, cornerRadius: metrics.cornerRadius)
         }
-        .buttonStyle(.plain)
-        .contextMenu {
-            gameContextMenu(for: game)
-        }
+		.buttonStyle(.plain)
+		.contextMenu {
+			gameContextMenu(for: game)
+		}
     }
 
-    private func coverThumbnail(for game: ISOEntry, width: CGFloat = 58, height: CGFloat = 87) -> some View {
-        CoverThumbnailView(
+	private func coverThumbnail(
+		for game: ISOEntry,
+		width: CGFloat = 58,
+		height: CGFloat = 87,
+		running: Bool
+	) -> some View {
+		CoverThumbnailView(
             gameName: game.name,
             coverURL: game.coverURL,
             coverSignature: game.coverSignature,
             width: width,
             height: height
         )
+		.shadow(
+			color: running ? .green.opacity(0.7) : .clear,
+			radius: running ? 12 : 0,
+			y: running ? 4 : 0
+		)
     }
 
     private func vmStatusCard(gameName: String) -> some View {
@@ -961,7 +985,7 @@ struct GameListView: View {
             .buttonStyle(.bordered)
         }
         .padding()
-        .background(cardMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+		.glassSurface(clear: true, cornerRadius: 18)
         .alert(settings.localized("Stop Emulation?"), isPresented: $showStopAlert) {
             Button(settings.localized("Cancel"), role: .cancel) { }
             Button(settings.localized("Stop"), role: .destructive) {
@@ -1001,7 +1025,7 @@ struct GameListView: View {
         }
         .frame(width: metrics.statusWidth, height: metrics.statusHeight)
         .padding(metrics.cardPadding)
-        .background(cardMaterial, in: RoundedRectangle(cornerRadius: metrics.cornerRadius, style: .continuous))
+		.glassSurface(clear: true, cornerRadius: metrics.cornerRadius)
         .alert(settings.localized("Stop Emulation?"), isPresented: $showStopAlert) {
             Button(settings.localized("Cancel"), role: .cancel) { }
             Button(settings.localized("Stop"), role: .destructive) {
@@ -1232,6 +1256,12 @@ struct GameListView: View {
 			} else if !allowFullMetadata {
 				if let existing = existingGames[entryID] {
 					metadata = existing.metadata
+				} else if let cached = GameLibrarySnapshot.shared.cachedMetadata(
+					for: entryID,
+					modificationDate: modificationDate,
+					size: size
+				) {
+					metadata = cached
 				} else {
 					metadata = ["fileTitle": (name as NSString).deletingPathExtension]
 				}
@@ -1291,8 +1321,10 @@ struct GameListView: View {
 
     private func downloadMissingCovers() {
         let targets = games.map(\.coverInfo)
-        Task { @MainActor in
+        coverWorkTask?.cancel()
+        coverWorkTask = Task { @MainActor in
             _ = await coverStore.downloadMissingCovers(for: targets)
+			guard !Task.isCancelled else { return }
             loadGames()
         }
     }
@@ -1325,8 +1357,10 @@ struct GameListView: View {
     }
 
     private func downloadCover(for game: ISOEntry) {
-        Task { @MainActor in
+        coverWorkTask?.cancel()
+        coverWorkTask = Task { @MainActor in
             _ = await coverStore.downloadMissingCovers(for: [game.coverInfo])
+			guard !Task.isCancelled else { return }
             loadGames()
         }
     }
@@ -1357,8 +1391,10 @@ struct GameListView: View {
 			return CoverGameInfo(name: game.name, fileURL: game.fileURL, metadata: metadata, hasCover: existingCover != nil)
 		}
 
-		Task { @MainActor in
+		coverWorkTask?.cancel()
+		coverWorkTask = Task { @MainActor in
 			let summary = await coverStore.downloadMissingCovers(for: targets, showResult: false)
+			guard !Task.isCancelled else { return }
 			if summary.downloaded > 0 {
 				loadGames()
 			}
@@ -1382,13 +1418,24 @@ struct GameListView: View {
 		let coverTargets = targets.map(\.coverInfo)
 		let serials = coverTargets.map { $0.metadata["serial"] ?? "" }.filter { !$0.isEmpty }.joined(separator: ",")
 		NSLog("[ARMSX2 iOS Covers] auto-download external missing covers count=%d serials=%@", targets.count, serials)
-		Task { @MainActor in
+		coverWorkTask?.cancel()
+		coverWorkTask = Task { @MainActor in
 			let summary = await coverStore.downloadMissingCovers(for: coverTargets, showResult: false)
+			guard !Task.isCancelled else { return }
 			if summary.downloaded > 0 {
 				loadGames()
 			}
 		}
 	}
+
+	private func releaseLibraryResourcesForGameplay() {
+		coverWorkTask?.cancel()
+		coverWorkTask = nil
+		games.removeAll(keepingCapacity: false)
+		externalCoverAutoDownloadAttemptedIDs.removeAll(keepingCapacity: false)
+		GameLibrarySnapshot.shared.releaseEntriesForGameplay()
+			CoverThumbnailCache.shared.releaseForGameplay()
+		}
 
 	private func toggleFavorite(_ game: ISOEntry) {
 		let key = game.bootName
@@ -1428,11 +1475,24 @@ struct GameListView: View {
 			return false
 		}
 
-		if runningGameName == game.bootName || runningGameName == game.name {
+		return Self.gameIdentifiersMatch(runningGameName, game.bootName)
+			|| Self.gameIdentifiersMatch(runningGameName, game.name)
+			|| game.fileURL.map { Self.gameIdentifiersMatch(runningGameName, $0.path) } == true
+	}
+
+	private static func gameIdentifiersMatch(_ first: String, _ second: String) -> Bool {
+		let normalizedFirst = (first.removingPercentEncoding ?? first)
+			.replacingOccurrences(of: "\\", with: "/")
+		let normalizedSecond = (second.removingPercentEncoding ?? second)
+			.replacingOccurrences(of: "\\", with: "/")
+		if normalizedFirst.caseInsensitiveCompare(normalizedSecond) == .orderedSame {
 			return true
 		}
 
-		return (runningGameName as NSString).lastPathComponent == game.name
+		let firstFileName = (normalizedFirst as NSString).lastPathComponent
+		let secondFileName = (normalizedSecond as NSString).lastPathComponent
+		return !firstFileName.isEmpty
+			&& firstFileName.caseInsensitiveCompare(secondFileName) == .orderedSame
 	}
 
 	/// Region flag emoji for a game's metadata, or nil when unknown so the

--- a/platforms/ios/app/src/main/swift/Views/LicenseView.swift
+++ b/platforms/ios/app/src/main/swift/Views/LicenseView.swift
@@ -34,6 +34,7 @@ private let licenses: [LicenseEntry] = [
     LicenseEntry(name: "plutosvg", license: "MIT", copyright: "© plutosvg contributors"),
     LicenseEntry(name: "rcheevos", license: "MIT", copyright: "© RetroAchievements contributors"),
     LicenseEntry(name: "discord-rpc", license: "MIT", copyright: "© Discord Inc."),
+    LicenseEntry(name: "PlayStation 3 XMB Waves Recreation", license: "MIT", copyright: "© 2025 Mart"),
 ]
 
 struct LicenseView: View {

--- a/platforms/ios/app/src/main/swift/Views/RootView.swift
+++ b/platforms/ios/app/src/main/swift/Views/RootView.swift
@@ -4,6 +4,17 @@
 import SwiftUI
 import UIKit
 
+private struct MenuTabIsActiveEnvironmentKey: EnvironmentKey {
+    static let defaultValue = true
+}
+
+extension EnvironmentValues {
+    var menuTabIsActive: Bool {
+        get { self[MenuTabIsActiveEnvironmentKey.self] }
+        set { self[MenuTabIsActiveEnvironmentKey.self] = newValue }
+    }
+}
+
 struct RootView: View {
     @State private var appState = AppState.shared
     @State private var settings = SettingsStore.shared
@@ -84,6 +95,7 @@ struct MenuTabView: View {
             // inside its NavigationStack ZStack, which must not be clipped by the
             // safe-area padding that the other tabs use.
             GameListView()
+                .environment(\.menuTabIsActive, selectedTab == 0)
                 .tabItem {
                     Label(settings.localized("Games"), systemImage: "gamecontroller")
                 }
@@ -92,6 +104,7 @@ struct MenuTabView: View {
             SafeAreaProtectedMenuTabContent {
                 BIOSListView()
             }
+                .environment(\.menuTabIsActive, selectedTab == 1)
                 .tabItem {
                     Label(settings.localized("BIOS"), systemImage: "cpu")
                 }
@@ -100,6 +113,7 @@ struct MenuTabView: View {
             SafeAreaProtectedMenuTabContent {
                 HelpView()
             }
+                .environment(\.menuTabIsActive, selectedTab == 2)
                 .tabItem {
                     Label(settings.localized("Help"), systemImage: "questionmark.circle")
                 }
@@ -110,6 +124,7 @@ struct MenuTabView: View {
                     SettingsRootView()
                 }
             }
+            .environment(\.menuTabIsActive, selectedTab == 3)
             .tabItem {
                 Label(settings.localized("Settings"), systemImage: "gearshape")
             }

--- a/platforms/ios/app/src/main/swift/Views/Settings/AppearanceSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/AppearanceSettingsView.swift
@@ -4,12 +4,30 @@
 import SwiftUI
 
 struct AppearanceSettingsView: View {
+    private enum PresentedEditor: String, Identifiable {
+        case colours
+
+        var id: String { rawValue }
+    }
+
     @State private var settings = SettingsStore.shared
+    @State private var dynamicPreferences = SettingsStore.shared.dynamicAppearancePreferences
+    @State private var paletteTarget: ThemePaletteTarget = .shared
+    @State private var presentedEditor: PresentedEditor?
+    @State private var isShowingBackgroundOnly = false
     @State private var showPrimaryPicker = false
     @State private var showLandscapePicker = false
+    @State private var isAppearanceVisible = false
+    @Environment(\.menuTabIsActive) private var menuTabIsActive
 
     var body: some View {
         Form {
+            DynamicBackgroundAppearanceSections(
+                preferences: $dynamicPreferences,
+                isPreviewActive: shouldRenderDynamicPreview,
+                showPaletteEditor: { presentedEditor = .colours }
+            )
+
             Section {
                 BackgroundAssetRow(
                     title: settings.localized("Primary Background"),
@@ -22,7 +40,7 @@ struct AppearanceSettingsView: View {
                 BackgroundAssetRow(
                     title: settings.localized("Landscape Background"),
                     asset: settings.backgroundLandscapeAsset,
-                    glyph: "rectangle.landscape",
+                    glyph: "rectangle",
                     caption: settings.localized("Optional. Used only when the device is held in landscape.")
                 ) { showLandscapePicker = true }
                 .modifier(BackgroundSourcePicker(isPresented: $showLandscapePicker, role: .landscape, existingAsset: { settings.backgroundLandscapeAsset }) { updateLandscape($0) })
@@ -51,7 +69,7 @@ struct AppearanceSettingsView: View {
                         Text(label(for: mode)).tag(mode)
                     }
                 } label: {
-                    Label(settings.localized("Landscape Fit Mode"), systemImage: "rectangle.landscape")
+                    Label(settings.localized("Landscape Fit Mode"), systemImage: "rectangle")
                 }
                 .onChange(of: settings.backgroundLandscapeFitMode) { _, _ in
                     UISelectionFeedbackGenerator().selectionChanged()
@@ -86,6 +104,29 @@ struct AppearanceSettingsView: View {
             }
         }
         .navigationTitle(settings.localized("Appearance"))
+        .sheet(item: $presentedEditor, onDismiss: paletteEditorDidDismiss) { _ in
+            ThemePaletteEditor(
+                target: $paletteTarget,
+                preferences: $dynamicPreferences,
+                isShowingBackgroundOnly: $isShowingBackgroundOnly,
+                dynamicBackground: dynamicPreferences.dynamicBackground,
+                onSaveAppearance: saveDynamicAppearance
+            )
+            .presentationDetents([.large])
+        }
+        .onAppear {
+            isAppearanceVisible = true
+            dynamicPreferences = settings.dynamicAppearancePreferences
+        }
+        .onDisappear {
+            isAppearanceVisible = false
+        }
+    }
+
+    private var shouldRenderDynamicPreview: Bool {
+        isAppearanceVisible
+            && menuTabIsActive
+            && presentedEditor == nil
     }
 
     @ViewBuilder
@@ -118,6 +159,15 @@ struct AppearanceSettingsView: View {
         case .fit: return settings.localized("Fit")
         case .stretch: return settings.localized("Stretch")
         }
+    }
+
+    private func saveDynamicAppearance() {
+        settings.dynamicAppearancePreferences = dynamicPreferences
+    }
+
+    private func paletteEditorDidDismiss() {
+        isShowingBackgroundOnly = false
+        dynamicPreferences = settings.dynamicAppearancePreferences
     }
 
     private func updatePrimary(_ asset: BackgroundAsset?) {


### PR DESCRIPTION
# ARMSX2 iOS Dynamic Backgrounds

Report date: 2026-07-18

## Report purpose

This report documents the complete local Dynamic Backgrounds change set intended for an ARMSX2 pull request. No pull request has been created. Every functional, lifecycle, resource-management, performance, and presentation item below is implemented by the changed Swift files listed in this report.

This report intentionally discusses only this change set. It does not include unrelated emulator-core findings, unrelated native resource ownership, speculative future work, or changes outside the packaged Swift sources.

## Repository base and pull-request target

- Repository: `https://github.com/ARMSX2/ARMSX2.git`
- Stable iOS source base: tag `iOS-2.4.1`
- Stable base commit: `a7f1c1b3e162ed1e3a049d3f328ac5d6167a84ac`
- GitHub default branch and intended PR target: `master`
- Verified `origin/master`: `112cd677b432d351dfe2b30a5e807da132afaa68`
- Merge base: `a7f1c1b3e162ed1e3a049d3f328ac5d6167a84ac`
- Upstream difference since the stable base: one Android GameDB file only
- Same-file overlap between upstream and this package: none

The ARMSX2 repository currently uses `master` as its default branch. The term “main branch” in the general sense therefore maps to the actual branch named `master` for this PR.

## Exact scope

The change set contains 20 Swift source files under:

`platforms/ios/app/src/main/swift/`

Source totals:

- 13 modified Swift files
- 7 new Dynamic Background Swift files
- 406 additions and 118 deletions in tracked files
- 11,820 lines in the seven new Dynamic Background files
- 12,226 total added lines when the new files are combined with the tracked additions
- 664,479 bytes across the exact 20-file Swift source payload
- No CMake changes
- No PCSX2 core changes
- No Objective-C or Objective-C++ changes
- No disc-reader changes
- No dependency changes
- No build-script changes
- No generated Xcode project or IPA inside the changed-files package

## Executive summary

This change integrates a complete Dynamic Background system into the iOS Appearance settings and the Games library. It adds twelve selectable animated styles, shared and ribbon palette systems, multi-color animation, saved custom colors, two-to-eight-stop custom gradients, optional dark-effect gradients, particle and face-button overlays, style-specific advanced controls, live preview, undo/redo, persistent preferences, Reduce Motion behavior, and a Metal implementation of the PlayStation 3 XMB recreation by Mart.

The change also connects the background system to tab, scene, and gameplay lifecycle state. Only the visible Games background or visible Appearance preview is mounted. Scene deactivation removes active rendering. Starting or resuming gameplay posts an early release notification before the existing root transition removes the menu hierarchy. Video, animated-image, Dynamic Background, XMB Metal, game-list, cover-download, cover-decode, and preview resources all receive explicit stop, cancellation, or release behavior.

The Games library presentation is updated to use Liquid Glass surfaces for game cards and Now Running cards. Backgrounds do not participate in hit testing. Running-game matching now handles full paths, file names, percent-encoded paths, slash styles, and case differences, allowing the running cover to receive its green shadow reliably.

## User-visible behavior

### Appearance integration

Appearance now contains the Dynamic Background controls directly at the top level:

- `Use Dynamic Background` toggle.
- `Background Style` picker.
- 16:9 live preview using the same renderer as the Games library.
- `Colours & Effects` entry showing the active Shared and Ribbons palette names.
- Existing Library Background, Fit Mode, video mute, and Background Dim controls remain in Appearance rather than a separate nested Style & Effects screen.
- Primary Background and Portrait Fit Mode use portrait glyphs.
- Landscape Background and Landscape Fit Mode use landscape-oriented rectangle glyphs.
- Background Dim defaults to 0% in both current settings and legacy background migration.

Dynamic Backgrounds are enabled by default. When enabled, they replace the imported static, animated, or video library background without deleting it. Disabling the toggle reveals the previously saved imported background again.

### Default appearance

The new default Dynamic Background configuration is:

- Dynamic Backgrounds: enabled.
- Style: `PlayStation 2 Menu by Henyckma`.
- Shared palette: `Azure Horizon`.
- Ribbons palette: `Azure Horizon`.
- PlayStation 2 Menu render rate: 15 FPS.
- Optional global particle overlay: disabled.
- Optional face-button overlay: disabled.
- Background Dim: 0%.

The first explicit selection of `PlayStation 3 XMB by Mart` intentionally initializes that style to Blue Shared Themes and Cyan Ribbons once. Subsequent selections preserve the user’s XMB choices. An explicitly chosen Original/month XMB gradient preset is also preserved.

## Dynamic Background styles

| Style | Implemented presentation | Frame/update source |
|---|---|---|
| Multicolor Ambient | Layered palette gradient, ambient fields, orbiting highlights, and optional overlays | SwiftUI `TimelineView`, 30 FPS target |
| Light Speed | Perspective star/light streak field converging on an animated vanishing point | SwiftUI `TimelineView`, 30 FPS target |
| Spatial Retro | Retro spatial geometry and symbol field using shared and ribbon colors | SwiftUI `TimelineView`, 30 FPS target |
| Towers Orbs | Tower geometry, moving orbs, glow, and palette shading | SwiftUI `TimelineView`, 24 FPS target |
| PlayStation 2 Menu by Henyckma | Animated 3D-style tower scene, camera orbit/yaw/roll, cloud coloring, and palette reflection | Configurable `TimelineView`; 15 FPS default |
| PlayStation 3 XMB by Mart | Metal gradient, wave spline, particles, material lighting, XMB presets, and Dynamic Palette backdrop composition | `MTKView`, 30 FPS; Dynamic Palette backdrop owns its separate SwiftUI timeline |
| Face Buttons | Animated PlayStation-style face-button symbols, light bands, motion, scale, and rotation | SwiftUI `TimelineView`, 30 FPS target |
| PlayStation Portable Blur | Soft blurred ribbon bands, glow/core layers, direction alternation, and vignette | SwiftUI `TimelineView`, 30 FPS target |
| PlayStation 3 Splines | Multi-strand spline ribbons with glow/core layers and particle field | SwiftUI `TimelineView`, 30 FPS target |
| PlayStation 4 Particles | Particle field plus PlayStation-style wave layers and glow/core controls | SwiftUI `TimelineView`, 30 FPS target |
| PlayStation 4 Waves | Multi-stop gradient, ambient glows, particles, waves, glow, and cores | SwiftUI `TimelineView`, 30 FPS target |
| PlayStation Ribbons | Animated panel/ribbon field, edges, glow, particles, and ambient lighting | SwiftUI `TimelineView`, 30 FPS target |

Every style uses the same `DynamicBackgroundTheme`, so a palette or effect change flows consistently through the selected background, optional particle overlay, and optional face-button overlay.

### Renderer cadence and optional work

The style switch constructs exactly one base renderer at a time. Its update cadence is bounded by the selected implementation:

- 30 FPS target: Multicolor Ambient, Light Speed, Spatial Retro, Face Buttons, PSP Blur, PS3 Splines, PS4 Particles, PS4 Waves, and PlayStation Ribbons.
- 24 FPS target: Towers Orbs.
- User-selectable 15–120 FPS: PlayStation 2 Menu, with 15 FPS as the default.
- 30 FPS `MTKView`: PlayStation 3 XMB by Mart.

The PS2 scene draws through an asynchronous SwiftUI Canvas. The other SwiftUI styles use their own `TimelineView`/Canvas hierarchy. These schedules are view-owned rather than retained `Timer` or `CADisplayLink` objects, so removing the selected renderer subtree removes its schedule.

Optional work is instantiated only when requested:

- The global particle overlay is disabled by default. Enabling it can add a separate 30 FPS Timeline/Canvas overlay; choosing Mart's XMB particle style uses a separate Metal surface.
- The face-button overlay is disabled by default. Enabling it can add its own 30 FPS renderer except when Face Buttons is already the base style.
- Particle counts are calculated for the chosen overlay and capped during drawing rather than creating an unbounded particle collection.
- XMB Dynamic Palette mode deliberately uses two different layers: a SwiftUI palette backdrop and a transparent Metal XMB foreground. They are not duplicate instances of the same renderer and both are removed by the same lifecycle gate.

## Palette and color system

### Color targets

The Colours editor has three horizontally swipeable targets:

1. `Shared Themes` controls broad background fields and base gradients.
2. `Ribbons` controls wave, ribbon, highlight, and foreground accents.
3. `Dynamic Settings` controls particles, overlays, motion, preview timing, and style-specific advanced values.

### Built-in Dynamic Palettes

Twenty Dynamic Palettes are included:

- Blue
- Violet
- Cyan
- Pink
- Gold
- Crimson
- Emerald
- Midnight
- Burgundy
- Graphite
- Black Noir
- Silver
- Slate
- Charcoal
- Navy
- Deep Teal
- Lavender
- Sunset
- Aurora
- Multicolor

### Built-in Plain Palettes

Twenty-four XMB-inspired Plain Palettes are included:

- Frosted Pearl and Lunar Graphite
- Gilded Sun and Antique Dusk
- Spring Meadow and Sage Midnight
- Sakura Bloom and Rose Twilight
- Clover Field and Forest Velvet
- Orchid Haze and Violet Nocturne
- Turquoise Lagoon and Tidal Abyss
- Azure Horizon and Ocean Midnight
- Amethyst Glow and Purple Eclipse
- Harvest Gold and Ember Night
- Bronze Autumn and Hearth Shadow
- Winter Coral and Cinder Red

### Multi-Color mode

Shared Themes and Ribbons can independently enable Multi-Color mode.

- Enabling Multi-Color chooses a related initial palette group.
- Tapping palette cards adds or removes them from the ordered selection.
- Selected cards show numbered badges indicating blend order.
- At least one palette is always retained.
- `Animate` blends from one selected palette to the next.
- Animation speed, smoothness, and per-index spread are configurable.
- Non-animated Multi-Color mode distributes selected palettes across background elements without time-based blending.

### Saved solid colors

The editor includes a Color Picker for creating a reusable solid color.

- `Save` stores the color and applies it to the active Shared Themes or Ribbons target.
- Saved colors appear as palette cards.
- A saved color can be applied with a tap.
- A context menu or accessibility action deletes it.
- Deleting an active custom color safely returns that target to its built-in palette.

### Custom gradient palettes

The custom palette UI replaces three fixed Start color controls with a continuous gradient editor.

- The palette gradient starts with three stops.
- Minus and Plus buttons resample the gradient to remove or add stops.
- Minimum: two stops.
- Maximum: eight stops.
- Each stop is directly editable with a Color Picker handle positioned on the gradient.
- Resampling interpolates the existing gradient so adding or removing a stop preserves the overall appearance.
- Saved custom palettes can be applied, selected, deleted, and reused like built-in palettes.

### Dark effect gradient

Each custom palette can contain an independent dark-effect gradient.

- Eye/Eye Slash toggles the dark effect without deleting its colors.
- Minus and Plus change the dark-effect gradient from two through eight stops.
- Disabled dark effects are dimmed and ignore hit testing.
- Global `Disable dark effects on palettes` overrides palette dark effects.
- `Dark gradient strength` scales the effect from 0% through 200%.

### Gradient geometry

Shared Themes expose these geometry controls:

- Palette tilt: −180° through +180°.
- X-axis offset: −100% through +100%.
- Y-axis offset: −100% through +100%.
- Gradient width: 0.25× through 3×.
- Gradient curvature: −100% through +100%.

Built-in and custom palette previews reflect the active tilt, offsets, width, and curvature.

## Colours editor behavior

The Colours editor is presented as a large sheet with a Liquid Glass header.

- `Cancel` restores the complete snapshot captured when the editor opened.
- `Apply` persists the complete Dynamic Appearance preferences.
- Undo and Redo cover palettes, custom colors, multi-color selections, particle settings, XMB preset intent, and saved custom palette JSON.
- Consecutive changes are grouped with a 300 ms history commit interval.
- Undo history is bounded to 64 snapshots.
- Horizontal swipes move between Shared Themes, Ribbons, and Dynamic Settings.
- A swipe is ignored while a slider is active or while full-background preview is showing.
- Changing a visual setting schedules a before/after full-screen preview.
- Slider interaction shows the background with a compact live value readout.
- Tapping the background returns to controls after the preview hold.
- Preview timing controls set how long the previous appearance and updated appearance are displayed.
- Closing the editor cancels debounce, preview, fade, and history tasks and clears all transient preview snapshots.

## Advanced Dynamic Settings

### Global particle overlay

The optional overlay supports:

- Enable/disable.
- Particle style: XMB3 Sparkles, PlayStation 3 XMB by Mart, PS1 Dust, PS4 Glow, PS5 Drift, or Mixed.
- Amount.
- Speed.
- Speed direction.
- Dispersion.
- Vertical spread.
- Vertical density.
- Outer dispersion.
- Size.
- Brightness.
- Opacity.
- Depth variation.
- Twinkle.
- Drift.
- Vertical level.

### Optional face-button overlay

Any style except the dedicated Face Buttons background can add a face-button overlay with:

- Enable/disable.
- Amount.
- Speed.
- Dispersion.
- Size.
- Opacity.
- Rotation.
- Pulse.

### Global presentation controls

- Widen portrait background.
- Preview-before-apply duration.
- Preview-after-apply duration.
- Dark-effect override and strength.
- Multi-color speed, smoothness, and spread.
- Shared gradient tilt, offsets, width, and curvature.

### Per-style controls

Each style has an expandable group and reset support. The implemented controls include:

- Individual motion-speed multipliers for all twelve styles.
- PlayStation 2 Menu FPS, scene speed, yaw speed, roll speed, camera orbit, and tower-color behavior.
- Face Buttons motion speed and light-band visibility.
- PSP Blur ribbon/glow/core visibility, alternating direction, count, position, amplitude, detail, phase, widths, blur, opacity, background intensity, ambient glow, and vignette.
- PS3 Splines spline/particle visibility, counts, position, spacing, amplitudes, phase, glow/core opacity and width, blur, particle behavior, background intensity, and vignette.
- PS4 Particles particle/wave visibility, wave glow/core visibility, particle geometry, wave geometry, phase, glow/core material values, background intensity, and vignette.
- PS4 Waves ambient glow/particle/wave visibility, wave glow/core visibility, particle geometry, wave geometry, phase, glow/core values, ambient glow scale/intensity, and vignette.
- PlayStation Ribbons panel/glow/edge/particle visibility, panel geometry, phase, fill/glow/edge values, particle drift/spread/size/opacity, ambient glow, and vignette.
- PS3 XMB gradient source, original RGB, top/bottom gradient multipliers, particle geometry, wave simulation, perturbation, reverse-pipeline controls, material, Fresnel, detail, free-form deformation scales/offsets, and amplitudes.

## PlayStation 3 XMB by Mart details

The XMB implementation is a native Metal renderer built from Mart’s MIT-licensed recreation and is attributed in the in-app license list.

### Gradient sources

The XMB background supports:

- Shared Themes + Ribbons.
- Original RGB sliders.
- Day and Night presets for every month from January through December.

The explicit-preset flag distinguishes a deliberate Original/month selection from automatic Shared Theme behavior, so applying a palette does not overwrite an explicit preset.

### Dynamic Palette behavior

When XMB uses `Shared Themes + Ribbons` and the selected Shared Theme is dynamic:

1. `PlayStation4WavesBackground` renders the animated multi-stop palette backdrop with its wave layer disabled.
2. The XMB Metal surface renders in `foregroundOnly` mode over that backdrop.
3. XMB waves and particles retain their Metal implementation and Ribbons colors.

For Plain Palettes, Original RGB, and monthly presets, the Metal surface renders the complete XMB background directly.

The redundant outer XMB `TimelineView` remains removed. The Metal renderer resolves changing palette colors immediately before each Metal frame. In the Dynamic Palette composition, the SwiftUI backdrop and Metal foreground own separate rendering responsibilities; the SwiftUI timeline does not drive or reconstruct the `MTKView` each frame.

### Metal resources

The XMB renderer owns:

- `MTKView` and drawable lifecycle.
- Metal command queue.
- Background, wave, and particle render-pipeline states.
- Wave vertex and index buffers.
- Particle seed buffer.
- R32 floating-point spline displacement texture.
- CPU spline simulation buffers and displacement array.
- Runtime/default Metal shader library.

Concrete renderer allocations include three render-pipeline states, a command queue, wave vertex/index buffers built at a 100-sample wave resolution, a particle buffer rebuilt only when the requested count changes, and a 256 × 64 `r32Float` displacement texture. The CPU spline state owns descriptor, runtime, coefficient, table, kernel, control, and displacement arrays. XMB particle count is clamped from 10 through 4,000 and defaults to 600.

For a full-background/foreground XMB frame, the simulation updates its spline state, converts the 16,384-value displacement field for upload, updates the Metal texture, and then encodes the applicable background, wave, and particle passes. Particle-only overlay surfaces skip the full background/spline work that they do not need.

The `MTKView` targets 30 FPS. Palette colors are resolved in `draw(in:)`, while `updateUIView` is reserved for meaningful settings/theme changes.

## Accessibility and system-state behavior

- Reduce Motion replaces every animated Dynamic Background with a still palette field and glow.
- The Appearance preview explains that a still preview is shown when Reduce Motion is enabled.
- Imported GIF/APNG/video backgrounds also fall back to still-image/poster presentation under Reduce Motion.
- Increased contrast or Reduce Transparency still enforces the existing minimum background dim needed for readability.
- Background layers are accessibility-hidden where appropriate.
- Background layers disable hit testing, so scrolling, game-card taps, favorite buttons, and context menus receive input rather than the background.

## Persistence and validation

Dynamic Appearance preferences are stored as one versioned Codable value containing:

- Selected style.
- Shared built-in/custom palette.
- Shared Multi-Color state and ordered palettes.
- Ribbons built-in/custom palette.
- Ribbons Multi-Color state and ordered palettes.
- All particle, overlay, gradient, preview, and per-style settings.
- First-XMB-selection state.
- Explicit-XMB-preset state.

Persistence keys added or used by this change include:

- `ARMSX2iOSDynamicBackgroundsEnabled`
- `ARMSX2iOSDynamicAppearancePreferences`
- `ARMSX2iOSDynamicSavedPaletteColors`
- `ARMSX2iOSDynamicExpandedNestedGroups`

Debug validation now round-trips `DynamicAppearancePreferences` through encoding and decoding for every Dynamic Background style.

## Imported background coexistence

The imported Library Background system remains available and now coexists with Dynamic Backgrounds:

- Dynamic Background enabled: render the selected Dynamic Background.
- Dynamic Background disabled: render the saved portrait/landscape imported media.
- Imported media remains stored while Dynamic Backgrounds are enabled.
- Portrait and landscape assets remain independent.
- Portrait and landscape fit modes remain independent.
- Static image, animated image, and video sources remain supported.
- Video mute remains configurable.
- Background Dim applies over the active source and defaults to 0%.

## Game-library presentation changes in this package

- Game grid cards use clear Liquid Glass on iOS 26+.
- Cover Flow cards use clear Liquid Glass on iOS 26+.
- Now Running cards use the same Liquid Glass surface treatment.
- Earlier material/outline card backgrounds are replaced by `glassSurface`.
- Pre-iOS-26 systems fall back to `ultraThinMaterial` rounded rectangles.
- The running game’s cover receives a green drop shadow.
- Running state no longer depends only on one exact string comparison.
- Running identifiers normalize percent encoding, slash direction, case, full paths, and file-name components.
- Favorite buttons remain independent buttons inside each game card.
- Context menus remain attached to the complete card.
- Background layers have hit testing disabled to preserve scrolling and tapping.

## Lifecycle architecture

### Render gating

The final render decision is a sequence of independent gates:

1. `MenuTabView` publishes whether each tab is selected through `menuTabIsActive`.
2. `GameListView` mounts its library background only when Games is the selected tab.
3. `AppearanceSettingsView` mounts its preview only while Appearance is visible, the Settings tab is selected, and the Colours editor is not already presenting its own preview.
4. `BackgroundContainerView` chooses Dynamic Background or imported media.
5. `DynamicBackgroundRendererView` mounts the selected renderer only while scene rendering is enabled.
6. Scene deactivation removes the renderer; scene activation allows it to be recreated.
7. Gameplay release disables the renderer before the existing root transition removes the complete menu hierarchy.

This makes the Games background and Appearance preview mutually exclusive during normal use. It also prevents a background hidden behind another tab from continuing its timeline, video, animated-image, or Metal work.

### Menu-to-gameplay flow

The existing root switch between `MenuTabView` and `GameScreenView` is unchanged. This change adds deterministic cleanup around that transition:

1. A game boot, BIOS-only boot, auto-boot, or Return to Game request calls the new menu-resource release helper.
2. `AppState` posts `ARMSX2iOSReleaseMenuBackgroundResources` before changing to gameplay.
3. `BackgroundContainerView` sets rendering disabled and releases its video poster state.
4. `DynamicBackgroundRendererView` removes the selected Dynamic Background subtree.
5. Video and animated UIKit views receive the release notification and perform immediate teardown.
6. The existing screen-state transition removes `MenuTabView` and mounts `GameScreenView`.
7. `GameListView.onDisappear` detects the playing state and releases library/cover resources.
8. XMB `dismantleUIView` pauses the `MTKView`, releases drawables, detaches its renderer, and releases shader-library ownership.

The release notification is issued for:

- Normal game boot.
- BIOS-only boot.
- Auto-boot notification.
- Return to a suspended/running game.

### Back-to-menu flow

When the app returns to the menu:

1. The existing root switch recreates `MenuTabView` and `GameListView`.
2. `GameListView.onAppear` activates a new cover-cache session.
3. External-library state reloads.
4. Cached game entries are restored when available and the library list is rebuilt.
5. Lightweight persisted metadata is reused for unchanged files.
6. Cover thumbnails decode again on demand into the new cache generation.
7. The selected Games background is recreated only if Games is active.

## Detailed resource-management report

### Background container

New ownership state: `isRenderingEnabled`.

Release behavior added:

- Scene will deactivate → set rendering disabled and clear poster `UIImage`.
- Scene did activate → enable rendering again.
- Gameplay release → set rendering disabled and clear poster `UIImage`.
- Disabling rendering removes Dynamic, image, animated, and video branches from the view tree.

Result: the active background subtree is removed rather than left covered by another UI or gameplay surface.

### Dynamic SwiftUI/Canvas renderers

Allocation behavior:

- Only the selected style is created.
- Style identity changes recreate only the renderer needed for the new style.
- Optional particle and face-button overlays are created only when enabled.

Release behavior:

- Removing `DynamicBackgroundContentView` destroys the style’s `TimelineView`, Canvas hierarchy, local arrays, and transient SwiftUI state.
- Tab gating removes the Games renderer when another tab is selected.
- Preview gating removes the Appearance renderer when hidden or when the editor owns the preview.
- Scene and gameplay gating remove the renderer subtree.

Result: no intentional second Games/Appearance Dynamic Background runs in steady state.

### Video background

Resources owned:

- `AVQueuePlayer`
- `AVPlayerLooper`
- `AVPlayerLayer`
- Current source URL
- Notification observers

Explicit teardown added to both `UIViewRepresentable.dismantleUIView` and `deinit`:

- Pause the player.
- Remove all observers.
- Remove the player layer from its superlayer.
- Set player, looper, layer, and current URL to `nil`.
- Mark a gameplay-released view so a late SwiftUI update cannot configure or resume it.

Scene behavior added:

- Pause on scene deactivation.
- Resume only on scene activation when not gameplay-released and not in Low Power Mode.
- Fully tear down on gameplay release.

Result: video decode, playback, looping, observation, and layer resources stop before emulator startup and cannot restart from a stale update.

### Animated image background

Resources owned:

- Decoded frame array.
- Current `UIImage` displayed by the internal image view.
- `CADisplayLink`.
- Timing accumulators.
- Notification observers.
- Detached utility-priority frame loader.

Cancellation behavior added:

- Parent `.task(id:)` cancellation forwards to the detached loader through `withTaskCancellationHandler`.
- The frame loader checks `Task.isCancelled` between frames.
- A cancelled parent drops the returned result before assigning it to SwiftUI state.

Explicit teardown added:

- Invalidate and nil the display link.
- Remove all decoded frames without keeping array capacity.
- Clear the displayed image.
- Remove observers.
- Run from `dismantleUIView`, gameplay release, and `deinit`.
- Mark gameplay release so a stale configure/resume call is ignored.

Result: animation wakeups stop, decoded frame references are released, the visible image is released, and decode cancellation propagates before gameplay.

### XMB Metal renderer

Explicit `MTKView` dismantling performs:

- Clear the delegate.
- Pause the view.
- Switch to set-needs-display behavior so continuous drawing stops.
- Release current drawables.
- Detach and release the renderer.
- Set the view’s Metal device to `nil`.

Releasing the renderer releases its command queue, pipeline states, buffers, spline texture, CPU arrays, spline simulation state, theme, and particle state through ARC after outstanding GPU ownership completes.

Shader library behavior:

- A compiled/default `MTLLibrary` is cached while XMB renderers are active.
- Each successfully attached renderer increments `activeRendererCount`.
- Each detached renderer decrements the count exactly once.
- The cache is set to `nil` when the final renderer detaches.
- A failed renderer creation releases an otherwise unused cached library.
- Multiple simultaneous XMB surfaces, such as a main XMB renderer and optional XMB particle overlay, safely share the library until both detach.

Frame scheduling behavior:

- The XMB Metal surface is driven by its `MTKView` at 30 FPS.
- Wave time, particle time, Dynamic Palette color, gradient uniforms, and wave color update in `draw(in:)`.
- SwiftUI `updateUIView` only supplies changed theme/settings values.
- The removed outer timeline no longer invalidates the Metal representable every frame.
- Dynamic Palette backdrops have their own SwiftUI renderer because they are a separate visual layer; the XMB Metal surface renders foreground only in that composition.

Result: Metal resources are released when their last visible consumer disappears, and Metal theme animation does not require redundant per-frame SwiftUI invalidation of the same surface.

### Cover-download tasks

Before the change, the relevant cover-download calls started tasks without retaining them for gameplay cleanup.

The change adds one owned `coverWorkTask`:

- Starting a new manual or automatic cover operation cancels the previous owned operation.
- Gameplay release cancels the task and sets the reference to `nil`.
- `CoverStore` checks cancellation between games and between candidate URLs.
- Call sites check cancellation after awaiting a download before reloading the game list.

Result: tracked cover work stops cooperatively and does not intentionally trigger a library reload after gameplay cleanup.

### Cover-thumbnail decode and cache

The thumbnail cache remains bounded by:

- 768 objects.
- 96 MiB total cost.
- Cost estimated as decoded pixel width × height × four bytes.

This change adds a locked cache-session state:

- `NSLock` serializes accepting state, generation, lookup, insertion, activation, and gameplay release.
- `activateForMenu()` opens a new session and advances generation when returning from gameplay.
- `releaseForGameplay()` advances generation, disables lookup/insertion, and removes every cached image while holding the state lock.
- Every decode captures the generation in which it began.
- A decode may insert only if cache insertion is still enabled and its generation still matches.

Decode cancellation added:

- Detached ImageIO work checks cancellation before creating the source.
- Cancellation is checked after the ImageIO thumbnail operation.
- Parent cancellation propagates to the detached decode task.
- The SwiftUI caller checks cancellation before assigning the image.
- Fallback full-image loading also drops its result if cancellation arrives.

Race prevented by the generation gate:

1. A cover decode begins in menu generation N.
2. Gameplay release advances to N+1, disables acceptance, and clears the cache.
3. The older decode finishes.
4. Its insertion is rejected because N no longer matches N+1.
5. Back to Menu activates another generation; the old decode still cannot enter that new session.

Result: a released cache remains released during gameplay, including when an already-running decode completes late.

### Game-list and snapshot resources

On gameplay disappearance, the change explicitly:

- Cancels and clears the owned cover task.
- Removes the displayed `games` array without retaining capacity.
- Removes the external-cover attempted-ID set without retaining capacity.
- Removes ordered snapshot entries without retaining capacity.
- Removes the snapshot’s ID-to-entry dictionary without retaining capacity.
- Releases the cover-thumbnail cache session.

The lightweight metadata cache is intentionally retained. It stores metadata with modification date and size validation and is persisted separately from displayed entry/cover objects.

On return, unchanged files can reuse that metadata even when no in-memory `ISOEntry` survived gameplay. This rebuilds covers and titles without requiring the released entry arrays to stay alive.

Result: high-volume menu objects and decoded covers are released for gameplay, while compact metadata needed for a safe, fast menu reconstruction remains available.

### State intentionally retained during gameplay

The change distinguishes active resources from small configuration/reconstruction data. It intentionally retains:

- Versioned Dynamic Appearance preferences in `SettingsStore`/`UserDefaults`.
- Built-in palette/style definitions and embedded shader-source constants.
- The lightweight game metadata cache, including modification date and file-size validation data.
- Imported-background file references and user-selected fit/mute settings.

These retained values do not own a running timeline, display link, player, drawable, cover bitmap cache, or background decode process. They allow the menu to restore the selected appearance and rebuild cover entries without keeping its active presentation hierarchy alive during gameplay.

### Appearance preview and editor tasks

Transient tasks owned by the editor:

- Preview debounce.
- Before/after preview timing.
- Preview fade cleanup.
- Undo-history grouping.

On editor disappearance, Apply, or Cancel, the change cancels these tasks and clears:

- Pending original/updated themes.
- Active updated theme.
- Preview theme snapshot.
- Preview flags.
- Active slider title/value.
- Preview opacity and background-only mode.

Result: a dismissed editor cannot later reopen a preview, apply a delayed snapshot, or keep the preview renderer alive.

## Before-and-after improvements

| Area | Before this change | After this change | Direct effect |
|---|---|---|---|
| Dynamic backgrounds | No integrated Dynamic Background system | Twelve styles integrated into Appearance and Games | Adds code-rendered/Metal animated backgrounds |
| Default appearance | Imported media background with 35% source default dim | Dynamic PS2 style, Azure Horizon palettes, 0% default dim | New appearance is visible without extra setup |
| Background selection | Imported static/animated/video only | Toggle switches between saved imported media and Dynamic renderer | Imported media is preserved while Dynamic mode is used |
| Games-tab activity | Background mounting was not tied to selected-tab state | `menuTabIsActive` gates Games background | No hidden Games background behind another tab |
| Appearance preview | No Dynamic preview | Same renderer, mounted only while Appearance is visible/active | Accurate preview without permanent duplicate renderer |
| Scene inactivity | Background branches were not centrally removed by scene state | Container and Dynamic renderer disable on scene deactivation | Stops timeline/Canvas/Metal/video/animation work while inactive |
| Gameplay release trigger | Existing root switch had no early background-release notification | Boot/BIOS/auto-boot/resume post release before gameplay state | Teardown begins before emulator startup peak |
| Video dismantling | Playback could rely on pause/deinit and retained player graph until later | Dismantle fully clears player, looper, layer, URL, and observers | Releases video decode/playback graph deterministically |
| Animated dismantling | Dismantle stopped display link but retained frames/image until later | Dismantle clears display link, decoded frames, image, and observers | Releases decoded animation memory deterministically |
| Detached animation loader | Parent cancellation did not explicitly cancel detached loader | Cancellation handler forwards cancellation; per-frame checks added | Decode stops cooperatively during teardown |
| Cover work ownership | Cover tasks were not retained for gameplay cleanup | One tracked task is cancelled/replaced/released | Prevents intended post-cleanup reload work |
| Cover download loops | No loop-level cancellation checks | Cancellation checks between games and candidate URLs | Faster cooperative stop |
| Thumbnail decode | Decode could finish after the view task was cancelled | Cancellation propagates through detached ImageIO work | Reduces late decode work and state assignment |
| Thumbnail cache release | No locked menu generation protected release from late insertion | Locked generation and acceptance gate plus full clear | Old decode cannot repopulate gameplay or later-menu cache |
| Game-list storage | Display arrays and snapshot entries relied on hierarchy deallocation timing | Arrays, sets, and snapshot entry maps explicitly discard capacity | Frees menu collection storage before/during gameplay |
| Back to Menu metadata | Released entries could require reduced/fallback metadata reconstruction | Validated lightweight metadata survives and is reused | Covers/titles reload without retaining cover images or entry arrays |
| XMB scheduling | Initial integration could combine outer SwiftUI timeline invalidation with MTK drawing | Metal animation resolves in `draw(in:)`; outer timeline removed | Avoids duplicate invalidation of the Metal representable |
| XMB shader library | Runtime library cache could outlive visible surfaces | Active-renderer reference count clears final cache | Releases compiled library after final XMB surface |
| Editor delayed work | New preview/history tasks could outlive sheet presentation | All editor tasks and transient snapshots cancel/clear on teardown | No delayed preview/history activity after dismissal |
| Game-card surfaces | Material cards and running outlines | Clear Liquid Glass cards and green running-cover shadow | Consistent iOS 26 presentation and running-state feedback |
| Background input | Background layer could participate in hit testing | Background explicitly disables hit testing | Game scrolling, taps, favorite, and menus receive gestures |

## Gameplay impact analysis

### CPU impact

At the gameplay transition, changed code stops or removes:

- Dynamic Background `TimelineView` updates.
- Canvas drawing for the active style and overlays.
- XMB CPU spline updates.
- XMB per-frame palette resolution.
- `CADisplayLink` callbacks for animated imported backgrounds.
- Video playback/loop scheduling.
- Tracked cover-download iteration.
- Cancelled cover-thumbnail ImageIO work when cancellation is observed.
- Appearance preview timing/history work if that hierarchy is being dismissed.

Impact: emulator startup and gameplay no longer intentionally share CPU time with a visible or hidden menu background, animated wallpaper, video wallpaper, or tracked cover workflow.

### GPU impact

At the gameplay transition, changed code removes or releases:

- SwiftUI/Canvas background drawing.
- Dynamic overlay drawing.
- XMB continuous `MTKView` submission.
- XMB drawables.
- XMB renderer and its Metal pipeline/buffer/texture references.
- Video player layer.
- Static/animated background image presentation.
- Liquid Glass game-card hierarchy when the existing root switch removes the menu.

Impact: the emulator becomes the only intentionally active game-rendering hierarchy after the menu root disappears.

### Memory impact

Explicitly releasable changed resources include:

- Up to the configured 96 MiB cover-thumbnail cache cost.
- Displayed `games` collection and released backing capacity.
- Ordered snapshot entries and ID dictionary.
- External-cover attempted-ID set and backing capacity.
- Animated background frame array and displayed image.
- Video player, looper, layer, URL, and observer graph.
- Background poster image.
- XMB renderer, command queue, pipeline states, buffers, texture, arrays, and final cached shader library.
- Dynamic renderer view-local state and Canvas/Timeline hierarchy.
- Preview theme snapshots and editor tasks.

Compact metadata remains by design; decoded covers and display entries do not.

Impact: menu-specific decoded media and rendering objects are removed before or as gameplay starts, improving memory headroom for emulator allocations.

This is deterministic reference release, not a claim that iOS must immediately reduce the process footprint by the exact configured cache cost. ARC, `NSCache`, Metal/driver completion, and system allocators decide when returned pages become visible in process statistics. The code-level improvement is that the menu no longer intentionally owns those resources after the release path completes.

### Task and I/O impact

- Cover tasks are owned and cancelled.
- Cover loops observe cancellation.
- Animated decode cancellation reaches the detached loader.
- Thumbnail decode cancellation reaches detached ImageIO work.
- Generation validation blocks stale cache insertion even if cancellation arrives too late to stop the underlying decode immediately.
- Returning to the menu uses cached metadata for unchanged files instead of retaining the entire visible library across gameplay.

Impact: fewer menu tasks remain eligible to complete during boot, and released cover data cannot be silently recreated behind gameplay.

### Start-game timeline

Before the first gameplay frame, changed code now performs this sequence:

1. Broadcast menu-background release.
2. Stop/remove active background renderer.
3. Tear down video or animated UIKit owner if present.
4. Switch the existing root from menu to gameplay.
5. Cancel cover task.
6. Empty game/snapshot entry collections.
7. Disable and clear cover cache.
8. Dismantle XMB Metal surface if selected.

This sequence moves cleanup ahead of, or directly alongside, emulator startup instead of waiting only for eventual object deinitialization.

## Usage examples

### Example 1 — choose the default PS2 background

1. Open Settings → Appearance.
2. Leave `Use Dynamic Background` enabled.
3. Choose `PlayStation 2 Menu by Henyckma` under Background Style.
4. Open `Colours & Effects`.
5. Choose `Azure Horizon` for Shared Themes and Ribbons.
6. Open Dynamic Settings and leave PlayStation 2 Menu FPS at 15.
7. Tap Apply.

Result: Games uses the PS2 scene at the lower default render rate with Azure Horizon coloring.

### Example 2 — return to a saved video wallpaper

1. Import portrait and/or landscape video under Library Background.
2. Configure Mute Video and each fit mode.
3. Turn `Use Dynamic Background` off.

Result: the imported video is shown again; enabling Dynamic Background later does not delete it.

### Example 3 — create a five-stop palette

1. Open Colours & Effects → Shared Themes.
2. In Custom palette, press Plus twice to change three stops to five.
3. Choose a color for each circular handle.
4. Configure the Dark effect gradient or disable it with the eye button.
5. Tap Save palette.
6. Tap Apply.

Result: the saved multi-stop gradient becomes the Shared Theme and is available for reuse.

### Example 4 — animate several palette families

1. Open Shared Themes.
2. Enable Multi-Color.
3. Tap palette cards in the desired order; numbered badges show that order.
4. Enable Animate.
5. Open Dynamic Settings and adjust Multi-Color speed, smoothness, and spread.

Result: backgrounds blend through the selected palette families over time.

### Example 5 — use XMB Dynamic Palettes

1. Choose `PlayStation 3 XMB by Mart`.
2. In Dynamic Settings → PlayStation 3 XMB by Mart → Background, select `Shared Themes + Ribbons`.
3. Choose a Dynamic Palette under Shared Themes.
4. Choose the desired Ribbons accent.

Result: an animated Dynamic Palette backdrop renders behind the Metal XMB wave and particles.

### Example 6 — use an authentic monthly XMB preset

1. Choose `PlayStation 3 XMB by Mart`.
2. Open its Background settings.
3. Select a month’s Day or Night preset.
4. Apply palette changes to Ribbons if desired.

Result: the explicit month preset remains selected while foreground XMB accents can still be customized.

### Example 7 — tune orientation-specific imported media

1. Turn Dynamic Background off.
2. Set a Primary Background for portrait and fallback use.
3. Optionally set a Landscape Background.
4. Choose Fill, Fit, or Stretch independently for Portrait and Landscape.
5. Set Background Dim, which now starts at 0% for a new/default configuration.

Result: each orientation uses its own media and fit behavior.

### Example 8 — compare a visual change before applying

1. Open Colours & Effects.
2. Change a palette or move an effect slider.
3. The editor temporarily shows the previous background and then the updated background.
4. While moving a slider, read the current setting/value in the glass readout.
5. Use Undo/Redo to compare changes.
6. Tap Cancel to restore the opening snapshot or Apply to persist everything.

### Example 9 — use Reduce Motion

1. Enable Reduce Motion in iOS Accessibility settings.
2. Open Appearance or Games with Dynamic Background enabled.

Result: ARMSX2 displays a still palette field instead of the animated style while preserving the selected colors and effects.

## Internal integration examples

### Render the persisted selection

```swift
DynamicBackgroundRendererView(
    preferences: settings.dynamicAppearancePreferences
)
```

The renderer constructs a `DynamicBackgroundTheme` from the stored Shared, Ribbons, Multi-Color, custom palette, and Dynamic Settings values.

### Select a style from code

```swift
var preferences = settings.dynamicAppearancePreferences
preferences.dynamicBackground = .playStation4Waves
settings.dynamicAppearancePreferences = preferences
```

Assigning preferences persists the Codable value through `SettingsStore`.

### Build a theme-specific background

```swift
DynamicBackgroundContentView(
    style: preferences.dynamicBackground,
    theme: DynamicBackgroundTheme(
        sharedPalette: preferences.sharedPalette,
        sharedCustomColor: preferences.sharedCustomColor,
        sharedMultiColor: preferences.sharedMultiColor,
        ribbonPalette: preferences.ribbonPalette,
        ribbonCustomColor: preferences.ribbonCustomColor,
        ribbonMultiColor: preferences.ribbonMultiColor,
        particleSettings: preferences.particleSettings
    )
)
```

### Apply the reusable Liquid Glass surface

```swift
content
    .glassSurface(clear: true, cornerRadius: 18)
```

On iOS 26 this applies clear Liquid Glass. Older supported systems use an ultra-thin material fallback.

## File-by-file change report

| File | Change contained in the PR |
|---|---|
| `Models/AppState.swift` | Adds the menu-background release notification and invokes it for game boot, BIOS boot, auto-boot, and Return to Game |
| `Models/BackgroundStorage.swift` | Changes migrated/default background dim from 35% to 0% |
| `Models/BackgroundValidation.swift` | Adds Codable round-trip validation for Dynamic Appearance preferences across every style |
| `Models/CoverStore.swift` | Adds cancellation checks across game and candidate-URL download loops |
| `Models/SettingsStore.swift` | Adds Dynamic Background enabled state and versioned preferences persistence; changes dim defaults/fallback to 0% |
| `Views/AnimatedLibraryBackgroundView.swift` | Propagates decode cancellation and fully tears down display link, frames, image, and observers |
| `Views/Background/BackgroundContainerView.swift` | Chooses Dynamic versus imported media and gates rendering for scene/gameplay lifecycle |
| `Views/Background/VideoBackgroundView.swift` | Adds deterministic representable/player teardown and scene/gameplay behavior |
| `Views/CoverThumbnailView.swift` | Adds cancellation-aware ImageIO decode and locked generation-gated cache sessions |
| `Views/GameListView.swift` | Gates Games background, disables background hit testing, releases library/cover resources for gameplay, restores metadata-backed covers, and applies glass/running-state presentation |
| `Views/LicenseView.swift` | Adds Mart’s PlayStation 3 XMB recreation attribution |
| `Views/RootView.swift` | Adds selected-tab environment state for Games, BIOS, Help, and Settings |
| `Views/Settings/AppearanceSettingsView.swift` | Integrates Dynamic Background controls/preview/editor directly into Appearance and adds preview visibility gating |
| `Views/Background/Dynamic/DynamicBackgroundPresentation.swift` | Adds renderer presentation, Reduce Motion fallback, Appearance sections, preview, style selection, and Liquid Glass abstraction |
| `Views/Background/Dynamic/DynamicBackgrounds.swift` | Implements twelve styles, XMB Metal renderer/simulation/surface, Dynamic Palette XMB composition, and drawing behavior |
| `Views/Background/Dynamic/DynamicColours.swift` | Implements palette field, built-in/custom/multi-color UI, two-to-eight-stop gradient editors, dark effect, preview, undo/redo, and editor task lifecycle |
| `Views/Background/Dynamic/DynamicEffects.swift` | Implements shared theme resolution, gradient transformations, dark effects, optional particle overlay, and shared utilities |
| `Views/Background/Dynamic/DynamicPalettes.swift` | Defines built-in palettes, XMB palettes, relationships, saved solid/gradient palette coding, and animated palette color resolution |
| `Views/Background/Dynamic/DynamicSettings.swift` | Defines all persistent settings/defaults and global/per-style advanced control UI |
| `Views/Background/Dynamic/PlayStation3XMBByMartShaderLibrary.swift` | Provides XMB Metal shaders plus active-renderer-counted runtime library caching/release |

## Source manifest

### Modified files

- `platforms/ios/app/src/main/swift/Models/AppState.swift`
- `platforms/ios/app/src/main/swift/Models/BackgroundStorage.swift`
- `platforms/ios/app/src/main/swift/Models/BackgroundValidation.swift`
- `platforms/ios/app/src/main/swift/Models/CoverStore.swift`
- `platforms/ios/app/src/main/swift/Models/SettingsStore.swift`
- `platforms/ios/app/src/main/swift/Views/AnimatedLibraryBackgroundView.swift`
- `platforms/ios/app/src/main/swift/Views/Background/BackgroundContainerView.swift`
- `platforms/ios/app/src/main/swift/Views/Background/VideoBackgroundView.swift`
- `platforms/ios/app/src/main/swift/Views/CoverThumbnailView.swift`
- `platforms/ios/app/src/main/swift/Views/GameListView.swift`
- `platforms/ios/app/src/main/swift/Views/LicenseView.swift`
- `platforms/ios/app/src/main/swift/Views/RootView.swift`
- `platforms/ios/app/src/main/swift/Views/Settings/AppearanceSettingsView.swift`

### New files

- `platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicBackgroundPresentation.swift`
- `platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicBackgrounds.swift`
- `platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicColours.swift`
- `platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicEffects.swift`
- `platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicPalettes.swift`
- `platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicSettings.swift`
- `platforms/ios/app/src/main/swift/Views/Background/Dynamic/PlayStation3XMBByMartShaderLibrary.swift`

## Build validation

Validation completed with the repository’s iOS IPA script:

```sh
cd platforms/ios
./scripts/build-ios-ipa.sh
```

Validated environment/result:

- Xcode 26.6, build 17F113.
- iPhoneOS 26.5 SDK.
- Release device build.
- arm64.
- iOS 17.0 deployment target.
- Swift compilation succeeded.
- Embedded/runtime Metal shader source compiled through the Swift build.
- Application linked successfully.
- `** BUILD SUCCEEDED **`.
- Unsigned IPA produced at `platforms/ios/build-ios-xcode/ARMSX2-iOS-unsigned.ipa`.
- IPA size: 23,617,843 bytes.
- IPA SHA-256: `89f85e2fa459a6bcb8bfe896bf97f2241f66a0ae7559816b4bc5ab985fafcaca`.
- IPA archive test: 367 entries, 47,708,915 uncompressed bytes, no ZIP integrity errors.
- Build log completed after the newest changed Swift source and explicitly compiled all seven new Dynamic files plus the thirteen modified Swift files.
- Build log error count: zero. Warnings remain build diagnostics, not build failures.
- `git diff --check` passed.

This validation proves that the current changed source compiles, links, packages, and produces an internally valid unsigned IPA. It does not claim a physical-device runtime test that was not captured by the build log.

## Pull-request description draft

### Summary

Integrates Dynamic Backgrounds into iOS Appearance and the Games library. Adds twelve customizable SwiftUI/Canvas/Metal styles, shared and ribbon palettes, Multi-Color animation, saved custom colors and gradients, configurable dark effects, particles, face-button overlays, advanced per-style controls, live preview, undo/redo, persistent settings, Reduce Motion support, and the MIT-licensed PlayStation 3 XMB recreation by Mart.

### Appearance and usage

- Dynamic Backgrounds are enabled by default.
- PlayStation 2 Menu by Henyckma is the default style at 15 FPS.
- Azure Horizon is the standard Shared and Ribbons palette.
- XMB intentionally initializes Blue/Cyan on its first selection and preserves explicit Original/month presets.
- Imported portrait/landscape image, animation, and video backgrounds remain saved and reappear when Dynamic Backgrounds are disabled.
- Background Dim now defaults to 0%.
- Appearance provides a gated live preview and a Colours & Effects editor with custom two-to-eight-stop palette/dark-effect gradients.

### Lifecycle, resources, and gameplay performance

- Games and Appearance background renderers are mutually gated by tab/visibility state.
- Backgrounds stop when the scene becomes inactive.
- Game, BIOS, auto-boot, and Return to Game paths post an early menu-background release.
- Video teardown releases player, looper, layer, URL, and observers.
- Animated teardown invalidates display link and releases frames/image/observers; detached decoding observes cancellation.
- Tracked cover downloads are cancelled for gameplay.
- Thumbnail decode observes cancellation and uses a locked generation gate so late work cannot repopulate the released 96 MiB cache.
- Displayed game entries, snapshot entries, and external-cover attempt sets discard their backing storage for gameplay.
- Lightweight validated metadata is retained to reconstruct covers after Back to Menu without retaining decoded covers across gameplay.
- XMB pauses/releases its MTK view and drawables, releases its renderer, and clears the compiled shader-library cache after the final XMB surface detaches.
- XMB Metal animation is driven by `MTKView` instead of an outer per-frame SwiftUI invalidation loop.

### Related library presentation

- Game covers and Now Running cards use clear Liquid Glass on iOS 26 with an ultra-thin material fallback.
- Background hit testing is disabled so cards remain scrollable and tappable.
- Running-game path matching is normalized and the active cover receives a green shadow.

### Scope

All packaged changes are Swift files under `platforms/ios/app/src/main/swift/`. The change includes no CMake, emulator-core, disc-reader, Objective-C++, dependency, or build-script modifications.

### Validation

- Release device build completed successfully with `platforms/ios/scripts/build-ios-ipa.sh`.
- Unsigned IPA was produced successfully.
- `git diff --check` passed.

### Description of Changes
ARMSX2 iOS Dynamic Backgrounds - The big update.

### Did you use AI to help find, test, or implement this issue or feature?
Yes, to integrate PlayStation 3 XMB by Mart javascript code into swift and generate this PR document.