### PR TITLE
android: export recent games list to shared storage

### DIFF
--- a/platforms/android/app/src/main/java/com/armsx2/data/library/GameLibraryRepository.kt
+++ b/platforms/android/app/src/main/java/com/armsx2/data/library/GameLibraryRepository.kt
@@ -99,6 +99,35 @@ class GameLibraryRepository(private val context: Context) {
                 JSONArray(current).toString()
             )
         }
+        exportRecentGamesPublic(current, game)
+    }
+
+    /**
+     * Mirrors [markPlayed]'s `recentGameUris` list to a plain JSON file under the app's
+     * data root (the shared-storage folder the user picked, e.g. .../ARMSX2/recent_games.json,
+     * or the app-private externalFilesDir when no folder was chosen). `recentGameUris` itself
+     * lives in app-private SharedPreferences, unreachable to any other app without root — this
+     * gives companion tools (launchers, RetroAchievements offline caches, etc.) the same "what
+     * was played recently" data the same way they already read gamesettings/ and memcards/
+     * from this folder, no root or debuggable build required.
+     */
+    private fun exportRecentGamesPublic(orderedUris: List<String>, justPlayed: GameInfo) {
+        val root = MainActivityRuntime.systemDirPosix()
+            ?: context.getExternalFilesDir(null)?.absolutePath
+            ?: return
+        val byUri = (loadCached().games + justPlayed).associateBy { it.uri.toString() }
+        val array = JSONArray()
+        orderedUris.forEach { uriString ->
+            val g = byUri[uriString] ?: return@forEach
+            array.put(JSONObject().apply {
+                put("uri", g.uri.toString())
+                put("title", g.title)
+                put("serial", g.serial ?: JSONObject.NULL)
+                put("ext", g.extension)
+                put("platform", g.platform.key)
+            })
+        }
+        runCatching { File(root, "recent_games.json").writeText(array.toString()) }
     }
 
     private fun scanDocumentTree(


### PR DESCRIPTION
## Summary
- `markPlayed` currently only persists the recently-played list (`recentGameUris`) to app-private SharedPreferences (`ARMSX2`), which no other app can read without root or a debuggable build.
- Mirrors that list to a plain `recent_games.json` file in the app's data root (the shared-storage folder chosen during setup, next to `gamesettings/`, `memcards/`, etc. — or the app-private `externalFilesDir` when no folder was chosen), so companion tools can read "recently played" the same way they already read other files from that folder.
- Each entry carries `uri`, `title`, `serial`, `ext`, `platform` — the same fields already used for the games cache — ordered most-recent-first, capped at 12 like the existing list.

## Test plan
- [ ] Launch a game, confirm `recent_games.json` appears in the configured data root with the played game as the first entry.
- [ ] Launch a second game, confirm the file updates and re-orders with both entries present (capped at 12).
- [ ] Confirm existing `recentGameUris` / "Recently Played" shelf behavior is unchanged.