### PR TITLE
iOS: fix per-game stick inversion, background tab toggle, and iOS 18 JIT crashes

### DIFF
--- a/common/Darwin/DarwinMisc.cpp
+++ b/common/Darwin/DarwinMisc.cpp
@@ -763,20 +763,67 @@ bool DarwinMisc::ValidateJITAlive()
 		return false;
 	}
 
-	// Check 2: RW alias still writable? Write a canary, read it back.
+	// Check 2: JIT code memory still writable? Write a canary, read it back.
+	//
+	// Under a dual-mapping (g_code_rw_offset != 0) g_code_rw_base is the RW
+	// alias — writable by construction, and a dead alias is exactly what this
+	// probe detects. Under an identity mapping (offset == 0) the base IS the
+	// live RX code page (the EE dispatcher sits at arena offset 0 once the VM
+	// has prewarmed), so the store needs a real write scope: a bare store
+	// faults with KERN_PROTECTION_FAILURE on the main thread (boot-gate crash,
+	// 2026-07-25). In Legacy mode flip just the first page RW and back via
+	// mprotect, treating a failed flip as "grant died" (alive=0) instead of
+	// letting the write SIGBUS; in the MAP_JIT toggle mode use the per-thread
+	// Begin/EndCodeWrite. Every caller runs while the VM is parked (the
+	// keepalive timer skips when the VM thread is active), so briefly dropping
+	// execute on that page cannot race JIT execution.
 	if (g_code_rw_base != 0 && g_code_rw_size > 0)
 	{
 		volatile u8* canary = reinterpret_cast<volatile u8*>(g_code_rw_base);
+#ifdef ARCH_ARM64
+		const bool identity = (g_code_rw_offset == 0);
+		const bool legacy_scope = identity && GetJitMode() == JitMode::Legacy && s_legacy_code_base;
+		if (legacy_scope)
+		{
+			if (!LegacyProtectCodeRange(reinterpret_cast<void*>(g_code_rw_base), 1,
+					PROT_READ | PROT_WRITE, "keepalive_rw"))
+			{
+				std::fprintf(stderr, "@@JIT_KEEPALIVE@@ alive=0 reason=legacy_mprotect_rw_failed\n");
+				std::fflush(stderr);
+				return false;
+			}
+		}
+		else if (identity)
+			HostSys::BeginCodeWrite();
+#endif
 		const u8 saved = *canary;
 		*canary = 0x42;
 		const u8 readback = *canary;
 		*canary = saved; // restore so we don't corrupt the first code byte
+#ifdef ARCH_ARM64
+		bool reprotect_ok = true;
+		if (legacy_scope)
+		{
+			reprotect_ok = LegacyProtectCodeRange(reinterpret_cast<void*>(g_code_rw_base), 1,
+				PROT_READ | PROT_EXEC, "keepalive_rx");
+		}
+		else if (identity)
+			HostSys::EndCodeWrite();
+#endif
 		if (readback != 0x42)
 		{
 			std::fprintf(stderr, "@@JIT_KEEPALIVE@@ alive=0 reason=rw_alias_dead readback=0x%02x\n", readback);
 			std::fflush(stderr);
 			return false;
 		}
+#ifdef ARCH_ARM64
+		if (!reprotect_ok)
+		{
+			std::fprintf(stderr, "@@JIT_KEEPALIVE@@ alive=0 reason=legacy_mprotect_rx_failed\n");
+			std::fflush(stderr);
+			return false;
+		}
+#endif
 	}
 
 	std::fprintf(stderr, "@@JIT_KEEPALIVE@@ alive=1 cs_debugged=1 canary=ok\n");

--- a/common/Darwin/DarwinMisc.cpp
+++ b/common/Darwin/DarwinMisc.cpp
@@ -749,6 +749,15 @@ bool DarwinMisc::IsJITAvailable()
 #endif
 }
 
+// Set by the platform layer at scene connect, before the worker that allocates
+// the arena exists, so the canary below can tell whether anything JIT is live.
+static bool (*s_jit_activity_query)() = nullptr;
+
+void DarwinMisc::SetJITActivityQuery(bool (*query)())
+{
+	s_jit_activity_query = query;
+}
+
 bool DarwinMisc::ValidateJITAlive()
 {
 #if TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
@@ -764,21 +773,24 @@ bool DarwinMisc::ValidateJITAlive()
 	}
 
 	// Check 2: JIT code memory still writable? Write a canary, read it back.
-	//
-	// Under a dual-mapping (g_code_rw_offset != 0) g_code_rw_base is the RW
-	// alias — writable by construction, and a dead alias is exactly what this
-	// probe detects. Under an identity mapping (offset == 0) the base IS the
-	// live RX code page (the EE dispatcher sits at arena offset 0 once the VM
-	// has prewarmed), so the store needs a real write scope: a bare store
-	// faults with KERN_PROTECTION_FAILURE on the main thread (boot-gate crash,
-	// 2026-07-25). In Legacy mode flip just the first page RW and back via
-	// mprotect, treating a failed flip as "grant died" (alive=0) instead of
-	// letting the write SIGBUS; in the MAP_JIT toggle mode use the per-thread
-	// Begin/EndCodeWrite. Every caller runs while the VM is parked (the
-	// keepalive timer skips when the VM thread is active), so briefly dropping
-	// execute on that page cannot race JIT execution.
+	// Under a dual-mapping the base is the RW alias and a dead alias is exactly
+	// what this detects. Under an identity mapping it is the live RX dispatcher
+	// page, so Legacy flips just that page RW and back via mprotect, treating a
+	// failed flip as "grant died" (alive=0) instead of letting the store SIGBUS;
+	// the MAP_JIT toggle mode uses the per-thread Begin/EndCodeWrite.
 	if (g_code_rw_base != 0 && g_code_rw_size > 0)
 	{
+		// Never touch a page a JIT thread might be executing: the Legacy flip
+		// drops execute on the dispatcher page, and the store rewrites its
+		// first instruction in every mode. A running VM is proof enough that
+		// the grant works, so skip the probe and say so in the log.
+		if (s_jit_activity_query && s_jit_activity_query())
+		{
+			std::fprintf(stderr, "@@JIT_KEEPALIVE@@ alive=1 cs_debugged=1 canary=skipped-vm-active\n");
+			std::fflush(stderr);
+			return true;
+		}
+
 		volatile u8* canary = reinterpret_cast<volatile u8*>(g_code_rw_base);
 #ifdef ARCH_ARM64
 		const bool identity = (g_code_rw_offset == 0);

--- a/common/Darwin/DarwinMisc.h
+++ b/common/Darwin/DarwinMisc.h
@@ -112,6 +112,11 @@ struct CPUClass {
     /// Returns false if iOS has revoked the JIT grant since boot.
     bool ValidateJITAlive();
 
+    /// Registered by the platform layer. Returns true while any thread may be
+    /// executing or emitting JIT code; ValidateJITAlive skips its arena canary
+    /// while that holds, since the probe touches the live dispatcher page.
+    void SetJITActivityQuery(bool (*query)());
+
     // [P43] iOS 26 Dual-Mapping JIT
     enum class JitMode {
         Simulator,    // MAP_JIT + pthread_jit_write_protect_np

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -28,17 +28,31 @@ GSDevice* MakeGSDeviceMTL()
 	return new GSDeviceMTL();
 }
 
+static GSAdapterInfo GetMetalAdapterInfo(id<MTLDevice> dev)
+{
+	GSAdapterInfo ai;
+	ai.name = [[dev name] UTF8String];
+	ai.max_texture_size = GSMTLDevice::GetMaxTextureSize(dev);
+	ai.max_upscale_multiplier = GSGetMaxUpscaleMultiplier(ai.max_texture_size);
+	return ai;
+}
+
 std::vector<GSAdapterInfo> GetMetalAdapterList()
 { @autoreleasepool {
 	std::vector<GSAdapterInfo> list;
-	auto devs = MRCTransfer(MTLCopyAllDevices());
-	for (id<MTLDevice> dev in devs.Get())
+	// MTLCopyAllDevices only exists on iOS 18. We ship down to 17, where there's a
+	// single GPU and nothing to enumerate anyway.
+	if (@available(macOS 10.11, iOS 18.0, *))
 	{
-		GSAdapterInfo ai;
-		ai.name = [[dev name] UTF8String];
-		ai.max_texture_size = GSMTLDevice::GetMaxTextureSize(dev);
-		ai.max_upscale_multiplier = GSGetMaxUpscaleMultiplier(ai.max_texture_size);
-		list.push_back(std::move(ai));
+		auto devs = MRCTransfer(MTLCopyAllDevices());
+		for (id<MTLDevice> dev in devs.Get())
+			list.push_back(GetMetalAdapterInfo(dev));
+	}
+	else
+	{
+		auto dev = MRCTransfer(MTLCreateSystemDefaultDevice());
+		if (dev.Get())
+			list.push_back(GetMetalAdapterInfo(dev.Get()));
 	}
 	return list;
 }}
@@ -1091,11 +1105,15 @@ bool GSDeviceMTL::Create(GSVSyncMode vsync_mode, bool allow_present_throttle)
 		return false;
 
 	NSString* ns_adapter_name = [NSString stringWithUTF8String:GSConfig.Adapter.c_str()];
-	auto devs = MRCTransfer(MTLCopyAllDevices());
-	for (id<MTLDevice> dev in devs.Get())
+	// No device enumeration below iOS 18 — fall through to the default device.
+	if (@available(macOS 10.11, iOS 18.0, *))
 	{
-		if ([[dev name] isEqualToString:ns_adapter_name])
-			m_dev = GSMTLDevice(MRCRetain(dev));
+		auto devs = MRCTransfer(MTLCopyAllDevices());
+		for (id<MTLDevice> dev in devs.Get())
+		{
+			if ([[dev name] isEqualToString:ns_adapter_name])
+				m_dev = GSMTLDevice(MRCRetain(dev));
+		}
 	}
 	if (!m_dev.dev)
 	{

--- a/pcsx2/MacOSStubs.cpp
+++ b/pcsx2/MacOSStubs.cpp
@@ -132,6 +132,10 @@ void PCAPAdapter::reloadSettings() {}
 // On iOS, CocoaTools.mm is excluded from the build. Provide stubs for the
 // functions referenced by iOS-compiled core code (DynamicLibrary, WindowInfo,
 // Pcsx2Config, etc.). iOS uses UIKit/Foundation, not Cocoa/AppKit.
+//
+// CreateMetalLayer, DestroyMetalLayer and GetBundlePath are deliberately absent:
+// the app's HostImpls.mm implements them for real. Defining them here too gave the
+// linker two of each and it picked one on its own.
 #include "common/CocoaTools.h"
 #include "common/WindowInfo.h"
 #include <optional>
@@ -139,11 +143,8 @@ void PCAPAdapter::reloadSettings() {}
 
 namespace CocoaTools
 {
-	bool CreateMetalLayer(WindowInfo* wi) { return false; }
-	void DestroyMetalLayer(WindowInfo* wi) {}
 	std::optional<float> GetViewRefreshRate(const WindowInfo& wi) { return std::nullopt; }
 	void MarkHelpMenu(void* menu) {}
-	std::optional<std::string> GetBundlePath() { return std::nullopt; }
 	std::optional<std::string> GetNonTranslocatedBundlePath() { return std::nullopt; }
 	std::optional<std::string> MoveToTrash(std::string_view file) { return std::nullopt; }
 	bool DelayedLaunch(std::string_view file) { return false; }

--- a/pcsx2/arm64/AsmHelpers.cpp
+++ b/pcsx2/arm64/AsmHelpers.cpp
@@ -191,6 +191,43 @@ u8* armEndBlock()
 	return armAsmPtr;
 }
 
+// Patch one instruction word at `site`, handling W^X itself instead of
+// trusting the caller to hold a write scope — link sites in earlier blocks
+// sit in windows armStartBlock never opened, which is a SIGBUS on iOS
+// Legacy mode. Pages inside the open emit window are stored to directly
+// (the previous block's link site often shares a page with the current
+// block's start, and RX-flipping that mid-emit would kill the compile);
+// anything else gets its own page-granular Begin/EndCodeWriteRange.
+// Aligned 4-byte stores are atomic on AArch64, and mprotect is fine from
+// the Mach exception-handler thread, so the fastmem-fault path can use it.
+void armPatchCodeWord(void* site, u32 instr)
+{
+	u8* const rx_site = static_cast<u8*>(site);
+
+	bool in_open_window = false;
+	if (s_arm_block_start)
+	{
+		static const uintptr_t page_mask = []() {
+			size_t page_size = HostSys::GetRuntimePageSize();
+			if (page_size == 0)
+				page_size = 4096;
+			return ~(static_cast<uintptr_t>(page_size) - 1);
+		}();
+
+		const uintptr_t site_page = reinterpret_cast<uintptr_t>(rx_site) & page_mask;
+		const uintptr_t first_page = reinterpret_cast<uintptr_t>(s_arm_block_start) & page_mask;
+		const uintptr_t last_page =
+			(reinterpret_cast<uintptr_t>(s_arm_block_start) + s_arm_block_write_size - 1) & page_mask;
+		in_open_window = (site_page >= first_page && site_page <= last_page);
+	}
+
+	if (!in_open_window)
+		HostSys::BeginCodeWriteRange(rx_site, sizeof(u32));
+	*reinterpret_cast<volatile u32*>(armGetWritableCodePtr(rx_site)) = instr;
+	if (!in_open_window)
+		HostSys::EndCodeWriteRange(rx_site, sizeof(u32));
+}
+
 void armDisassembleAndDumpCode(const void* ptr, size_t size)
 {
 #ifdef INCLUDE_DISASSEMBLER
@@ -254,13 +291,7 @@ void armEmitJmpPtr(void* code_address, const void* target, bool flush_icache)
 	pxAssertRel((off & 3) == 0, "armEmitJmpPtr: branch offset not 4-byte aligned");
 	const intptr_t imm26 = off >> 2;
 	pxAssertRel(imm26 >= -(1 << 25) && imm26 < (1 << 25), "armEmitJmpPtr: branch offset out of B imm26 range");
-	// code_address is the RX alias; under iOS dual-mapping the store must go
-	// through the RW mirror. Begin/EndCodeWrite covers the toggle modes
-	// (refcounted, so it nests inside an open emit scope).
-	HostSys::BeginCodeWrite();
-	*reinterpret_cast<volatile u32*>(armGetWritableCodePtr(static_cast<u8*>(code_address))) =
-		0x14000000u | (static_cast<u32>(imm26) & 0x03FFFFFFu);
-	HostSys::EndCodeWrite();
+	armPatchCodeWord(code_address, 0x14000000u | (static_cast<u32>(imm26) & 0x03FFFFFFu));
 	if (flush_icache)
 		HostSys::FlushInstructionCache(code_address, 4);
 }

--- a/pcsx2/arm64/AsmHelpers.h
+++ b/pcsx2/arm64/AsmHelpers.h
@@ -144,6 +144,11 @@ u8* armEndBlock();
 void armDisassembleAndDumpCode(const void* ptr, size_t size);
 void armEmitJmp(const void* ptr, bool force_inline = false);
 void armEmitCall(const void* ptr, bool force_inline = false);
+// Store one instruction word into code memory, opening its own W^X scope when
+// the target lies outside the open emit window. Use for anything that patches
+// code outside the block being emitted — link sites, entry stubs, fastmem
+// backpatch. No cache maintenance: callers own the flush policy.
+void armPatchCodeWord(void* site, u32 instr);
 // In-place patch: overwrite the 4-byte B at `code_address` with a branch to
 // `target`. Used by EE block chaining to rewrite a link site (not tied to the
 // current emit cursor). `code_address` must already hold a single B instruction.

--- a/pcsx2/arm64/BaseblockEx-arm64.h
+++ b/pcsx2/arm64/BaseblockEx-arm64.h
@@ -64,7 +64,7 @@
 #include <map>
 
 #include "common/HostSys.h"
-#include "arm64/AsmHelpers.h" // armGetWritableCodePtr (iOS dual-map W^X)
+#include "arm64/AsmHelpers.h" // armPatchCodeWord (self-scoped W^X code patching)
 #include "x86/BaseblockEx.h"  // BASEBLOCK, BASEBLOCKEX, BaseBlockArray, recLUT_SetPage
 
 class Arm64BaseBlocks
@@ -123,20 +123,18 @@ protected:
 		return (call ? 0x94000000u : 0x14000000u) | (static_cast<u32>(imm26) & 0x03FFFFFFu);
 	}
 
-	// Store only, no cache maintenance. Valid ONLY for a site inside the
-	// block currently being emitted: that buffer has not been executed yet,
-	// and armEndBlock() issues one whole-range flush over it before it can
-	// be. (AetherSX2 does the same — its Link() performs no flush at all,
-	// leaving it to the single range flush in armEndBlock.)
-	// Never use this on code that is already live; use PatchAtomic.
+	// Store only, no cache maintenance. Fine for a site inside the block
+	// currently being emitted (that buffer has not been executed yet, and
+	// armEndBlock() issues one whole-range flush over it), and for the
+	// New() repoint loop, whose callers flush via FlushPatchedSites.
+	// Never use this on code that is already live without a flush; use
+	// PatchAtomic.
 	static void PatchWord(uptr site, u32 instr)
 	{
-		// 4-byte aligned word stores are atomic on AArch64. `site` is the RX
-		// address; under iOS dual-map W^X the store goes through the RW alias
-		// (identity elsewhere). Callers hold an open Begin/EndCodeWrite scope
-		// for the toggle modes; on Darwin the "signal handler" caller is
-		// really the Mach exception-handler thread, so that scope is safe.
-		*reinterpret_cast<volatile u32*>(armGetWritableCodePtr(reinterpret_cast<u8*>(site))) = instr;
+		// armPatchCodeWord owns the W^X handling — sites outside the open
+		// emit window get their own page-granular write scope. Nothing on
+		// the New()/Remove() paths holds one.
+		armPatchCodeWord(reinterpret_cast<u8*>(site), instr);
 	}
 
 	// (HostSys::FlushInstructionCache, not the raw builtin: on Darwin the

--- a/pcsx2/arm64/RecStubs.cpp
+++ b/pcsx2/arm64/RecStubs.cpp
@@ -360,14 +360,13 @@ void vtlb_DynBackpatchLoadStore(uptr code_address, u32 code_size, u32 guest_pc, 
 	pxAssertRel(branch_imm26 >= -0x2000000 && branch_imm26 <= 0x1FFFFFF,
 		"Backpatch thunk too far from faulting instruction for B instruction");
 
-	HostSys::BeginCodeWrite();
-	// iOS dual-map W^X: the faulting instruction lives at an RX address; the
-	// store goes through the RW alias (identity elsewhere). The branch
-	// displacement above was computed against the RX address, which is what
-	// the CPU executes.
-	u32* patch_ptr = reinterpret_cast<u32*>(armGetWritableCodePtr(reinterpret_cast<u8*>(code_address)));
-	*patch_ptr = 0x14000000u | (static_cast<u32>(branch_imm26) & 0x03FFFFFFu);
-	HostSys::EndCodeWrite();
+	// armPatchCodeWord handles W^X (page-granular scope on iOS Legacy mode,
+	// RW alias under dual-mapping) — an arena-wide Begin/EndCodeWrite here
+	// would RX-flip any emit window open on another thread on its way out.
+	// The branch displacement above was computed against the RX address,
+	// which is what the CPU executes.
+	armPatchCodeWord(reinterpret_cast<u8*>(code_address),
+		0x14000000u | (static_cast<u32>(branch_imm26) & 0x03FFFFFFu));
 
 	// Flush icache at the patch point too.
 	HostSys::FlushInstructionCache(reinterpret_cast<void*>(code_address), 4);

--- a/pcsx2/arm64/iR3000A-arm64.cpp
+++ b/pcsx2/arm64/iR3000A-arm64.cpp
@@ -1225,20 +1225,18 @@ static __fi u32 psxRecClearMem(u32 pc)
 
 static void recClearIOP(u32 Addr, u32 Size)
 {
-	// On macOS/Apple Silicon the IOP code cache is MAP_JIT (per-thread W^X).
-	// recClearIOP is IOP SMC detection: every qualifying store in IopMem.cpp (plus
-	// DMA/SIF/BIOS-HLE) funnels here via psxCpu->Clear while the IOP thread is
-	// *executing* recompiled code, i.e. execute-protected with no emit scope open.
-	// psxRecClearMem's recBlocks.Remove() patches compiled block entry points
-	// (Arm64BaseBlocks::Remove -> PatchAtomic) inside that cache, so we must flip
-	// to write mode first or the patch faults (ESR 0x9200004f, byte-write
-	// permission). Refcounted (nests safely), no-op on Linux. Mirrors the EE
-	// recClear fix (b54fbcdad).
-	HostSys::BeginCodeWrite();
+	// IOP SMC detection: every qualifying store funnels here via psxCpu->Clear
+	// (IopMem.cpp, DMA/SIF/BIOS-HLE, and the out-of-line store stubs'
+	// iopStoreClearHit). The only code writes underneath are
+	// Arm64BaseBlocks::Remove()'s entry stubs, and those open their own
+	// per-site W^X scope (armPatchCodeWord) — SetFnptr targets are heap data.
+	// The arena-wide Begin/EndCodeWrite this used to hold was both wasteful
+	// (a whole-arena mprotect pair per covered store in iOS Legacy mode) and
+	// hazardous: Legacy range windows bypass the refcount, so the paired
+	// EndCodeWrite RX-flipped any emit window open on another thread.
 	u32 end = Addr + Size * 4;
 	for (u32 i = Addr; i < end; i += PSXREC_CLEARM(i))
 		;
-	HostSys::EndCodeWrite();
 }
 
 // Called from the JIT RAM-store fast-path stubs when the stored-to granule

--- a/pcsx2/arm64/iR5900-arm64.cpp
+++ b/pcsx2/arm64/iR5900-arm64.cpp
@@ -1790,8 +1790,10 @@ static void recPatchIslandB(u8* site, const u8* target)
 {
 	const intptr_t imm26 = (reinterpret_cast<intptr_t>(target) - reinterpret_cast<intptr_t>(site)) >> 2;
 	pxAssertRel(imm26 >= -(1 << 25) && imm26 < (1 << 25), "Cold-exit island out of B imm26 range");
-	// iOS dual-map W^X: store via the RW alias; displacement/flush stay on RX.
-	*reinterpret_cast<volatile u32*>(armGetWritableCodePtr(site)) = 0x14000000u | (static_cast<u32>(imm26) & 0x03FFFFFFu);
+	// armPatchCodeWord opens its own W^X scope: the islands live in the hot
+	// block, whose window armEndBlock() already closed by the time the cold
+	// session patches them.
+	armPatchCodeWord(site, 0x14000000u | (static_cast<u32>(imm26) & 0x03FFFFFFu));
 	HostSys::FlushInstructionCache(site, 4);
 }
 
@@ -1828,10 +1830,11 @@ static void recEmitColdSideExits()
 	pxAssert(armGetCurrentCodePointer() < SysMemory::GetEERecEnd());
 	s_coldPtr = armEndBlock();
 
-	HostSys::BeginCodeWrite();
+	// Each island patch opens its own write scope (armPatchCodeWord); an
+	// arena-wide Begin/EndCodeWrite here would RX-flip a concurrently open
+	// MTVU emit window in Legacy mode on its way out.
 	for (int k = 0; k < n; k++)
 		recPatchIslandB(s_sideExitIslands[k], coldStart[k]);
-	HostSys::EndCodeWrite();
 
 	g_branch = 1;
 }
@@ -2672,14 +2675,14 @@ static void recClear(u32 addr, u32 size)
 	if (blockidx == -1)
 		return;
 
-	// macOS/Apple Silicon (no-op elsewhere): recClear runs from the EE
-	// page-fault handler (fastmem backpatch + SMC via mmap_ClearCpuBlock) and
-	// from runtime SMC on the executing CPU thread — both enter with the
-	// MAP_JIT code cache in execute-protected (W^X) mode. The SetFnptr writes
-	// and Arm64BaseBlocks::Remove() stub patches below target that region, so
-	// a write faults (SIGBUS) unless we flip the thread to write mode first.
-	// Refcounted, so it nests harmlessly when reached from an open emit scope.
-	HostSys::BeginCodeWrite();
+	// No write scope here: the only code writes below are Remove()'s entry
+	// stubs, and those open their own per-site scope (armPatchCodeWord).
+	// SetFnptr/recLUT targets are ordinary heap data. The arena-wide
+	// Begin/EndCodeWrite this used to hold was worse than useless on iOS
+	// Legacy mode — the range-window emit scope bypasses the refcount, so
+	// when recClear runs mid-compile (the stale-overlap walk in
+	// recRecompile) the paired EndCodeWrite RX-flipped the open emit window
+	// and the next emitted instruction faulted.
 
 	// Track the EE-address span of all blocks we touch so the post-walk
 	// tail can reset interior BLOCKs across the *full* extent of the
@@ -2743,8 +2746,6 @@ static void recClear(u32 addr, u32 size)
 	// into the middle of a freshly-recompiled block.
 	if (upperextent > lowerextent)
 		iopClearRecLUT(GETBLOCK(lowerextent), upperextent - lowerextent);
-
-	HostSys::EndCodeWrite();
 }
 
 static void iopClearRecLUT(BASEBLOCK* base, int count)

--- a/pcsx2/arm64/microVU_Branch-arm64.inl
+++ b/pcsx2/arm64/microVU_Branch-arm64.inl
@@ -457,6 +457,18 @@ void normJumpCompile(mV, microFlagCycles& mFC, bool isEvilJump)
 // constructed once per mVUreset over the whole post-dispatcher cache range.
 static thread_local ptrdiff_t s_mVUblockStartOffset = 0;
 
+// The write scope covers exactly the persistent MA's buffer span
+// [x86start, physical region end]: every byte a session emits lands in
+// there. Range form, not the whole-arena BeginCodeWrite: in iOS Legacy
+// mode the whole-arena EndCodeWrite RX-flips the entire arena on close,
+// which killed any EE emit window open on the other thread (Legacy range
+// windows bypass the refcount). Toggle modes fall through to the same
+// refcounted whole-region toggle as before; dual-mapping is a no-op.
+static size_t mVUcodeCacheWriteSpan(microVU& mVU)
+{
+	return static_cast<size_t>(mVU.prog.x86end - mVU.prog.x86start) + (mVUcacheSafeZone * _1mb);
+}
+
 static void mVUopenCodeCache(microVU& mVU)
 {
 	// Nested call (same thread re-enters before its outer close): no-op.
@@ -465,7 +477,7 @@ static void mVUopenCodeCache(microVU& mVU)
 
 	pxAssert(mVU.jitAsm); // mVUreset must have built it.
 
-	HostSys::BeginCodeWrite();
+	HostSys::BeginCodeWriteRange(mVU.prog.x86start, mVUcodeCacheWriteSpan(mVU));
 	// armAsmPtr MUST equal the MA's buffer base (= mVU.prog.x86start) for
 	// armGetCurrentCodePointer() to return the real write position:
 	//   armGetCurrentCodePointer() = armAsmPtr + armAsm->GetCursorOffset()
@@ -519,7 +531,7 @@ static void mVUcloseCodeCache(microVU& mVU)
 	mVUPersist::EndEpisode(mVU, codeStart + codeSize);
 
 	armAsm = nullptr; // unbind; do not delete (persistent)
-	HostSys::EndCodeWrite();
+	HostSys::EndCodeWriteRange(mVU.prog.x86start, mVUcodeCacheWriteSpan(mVU));
 	if (codeSize > 0)
 	{
 		HostSys::FlushInstructionCache(codeStart, codeSize);

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.h
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.h
@@ -275,6 +275,12 @@ typedef void (^ARMSX2RetroAchievementsCompletion)(BOOL success, NSString * _Nonn
 + (void)setPerGameINIFloatForCurrentGame:(nonnull NSString *)section key:(nonnull NSString *)key value:(float)value NS_SWIFT_NAME(setPerGameINIFloatForCurrentGame(_:key:value:));
 + (void)deletePerGameINIValueForCurrentGame:(nonnull NSString *)section key:(nonnull NSString *)key NS_SWIFT_NAME(deletePerGameINIValueForCurrentGame(_:key:));
 
+// Identity the accessors above key on, or "" when there isn't one. The current-game
+// variant only reads VM state; the ISO variant opens the disc image, so keep it
+// off render paths.
++ (nonnull NSString *)perGameIdentityKeyForCurrentGame;
++ (nonnull NSString *)perGameIdentityKeyForISO:(nonnull NSString *)isoName NS_SWIFT_NAME(perGameIdentityKey(forISO:));
+
 // Runtime speed control
 + (int)limiterMode;
 + (void)setLimiterMode:(int)mode;

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
@@ -1693,7 +1693,11 @@ static void ARMSX2ApplyPerGameSettingsOverrides(NSMutableDictionary<NSString*, i
         si.ContainsValue("EmuCore/Speedhacks", "EECycleRate") ||
         si.ContainsValue("EmuCore", "EnableFastBoot") ||
         si.ContainsValue("SPU2/Output", "StandardVolume") ||
-        si.ContainsValue("SPU2/Output", "FastForwardVolume");
+        si.ContainsValue("SPU2/Output", "FastForwardVolume") ||
+        si.ContainsValue("ARMSX2iOS/UI", "InvertLeftStickX") ||
+        si.ContainsValue("ARMSX2iOS/UI", "InvertLeftStickY") ||
+        si.ContainsValue("ARMSX2iOS/UI", "InvertRightStickX") ||
+        si.ContainsValue("ARMSX2iOS/UI", "InvertRightStickY");
 
     result[@"enabled"] = @(hasKnownOverride);
     const bool hasStandardVolumeOverride = si.ContainsValue("SPU2/Output", "StandardVolume");
@@ -3781,6 +3785,22 @@ static std::string ARMSX2PerGameSettingsPath(const std::string& serial, u32 crc)
     VMManager::ReloadGameSettings();
     if (MTGS::IsOpen())
         MTGS::ApplySettings();
+}
+
++ (nonnull NSString *)perGameIdentityKeyForCurrentGame {
+    std::string serial;
+    u32 crc = 0;
+    if (!ARMSX2PerGameIdentityForCurrentGame(&serial, &crc))
+        return @"";
+    return [NSString stringWithFormat:@"%s_%08X", serial.c_str(), (unsigned int)crc];
+}
+
++ (nonnull NSString *)perGameIdentityKeyForISO:(nonnull NSString *)isoName {
+    std::string serial;
+    u32 crc = 0;
+    if (!ARMSX2PerGameIdentityForISO(isoName, &serial, &crc))
+        return @"";
+    return [NSString stringWithFormat:@"%s_%08X", serial.c_str(), (unsigned int)crc];
 }
 
 + (int)limiterMode

--- a/platforms/ios/app/src/main/cpp/IOS/HostImpls.mm
+++ b/platforms/ios/app/src/main/cpp/IOS/HostImpls.mm
@@ -751,27 +751,27 @@ namespace FileSystem {
 namespace CocoaTools {
     void InhibitAppNap(const std::string&) {}
     void UninhibitAppNap() {}
-    std::string GetBundlePath() { return [[NSBundle mainBundle].bundlePath UTF8String]; }
+    // Signature must match common/CocoaTools.h (not included here, it's mostly
+    // macOS-only). Return types aren't mangled, so a mismatch still links and
+    // callers read garbage off the stack.
+    std::optional<std::string> GetBundlePath() { return std::string([[NSBundle mainBundle].bundlePath UTF8String]); }
     
-    void* CreateMetalLayer(WindowInfo* wi) {
-        if (!Host::g_sdl_window) return nullptr;
-        
-        // Return existing layer if we already have it
-        if (wi->surface_handle) {
-            return SDL_Metal_GetLayer((SDL_MetalView)wi->surface_handle);
-        }
-        
+    bool CreateMetalLayer(WindowInfo* wi) {
+        if (!Host::g_sdl_window) return false;
+
+        // Already have one
+        if (wi->surface_handle) return true;
+
         // Create the Metal view
         SDL_MetalView view = SDL_Metal_CreateView(Host::g_sdl_window);
         if (!view) {
             Console.Error("SDL_Metal_CreateView failed: %s", SDL_GetError());
-            return nullptr;
+            return false;
         }
-        
-        void* layer = SDL_Metal_GetLayer(view);
+
         wi->surface_handle = view; // Store view handle to destroy later
-        Console.WriteLn("Created Metal Layer: %p from View: %p", layer, view);
-        return layer;
+        Console.WriteLn("Created Metal Layer: %p from View: %p", SDL_Metal_GetLayer(view), view);
+        return true;
     }
     
     void DestroyMetalLayer(WindowInfo* wi) {

--- a/platforms/ios/app/src/main/cpp/IOS/SceneDelegate.mm
+++ b/platforms/ios/app/src/main/cpp/IOS/SceneDelegate.mm
@@ -59,12 +59,19 @@
 #import "IOS/ARMSX2GameView.h"
 #import "IOS/PCSX2SceneDelegate.h"
 
+// Defined below, next to the VM worker state it reads.
+static bool ARMSX2JITWorkerBusy();
+
 @implementation PCSX2SceneDelegate
 
 #pragma mark - Scene connection & bootstrap
 - (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions {
     if (![scene isKindOfClass:[UIWindowScene class]]) return;
-    
+
+    // Let ValidateJITAlive see VM/worker state before any of its callers can
+    // run (they are all scene-driven, so this is always first).
+    DarwinMisc::SetJITActivityQuery(&ARMSX2JITWorkerBusy);
+
     UIWindowScene *windowScene = (UIWindowScene *)scene;
     
     // --- SDL Initialization ---
@@ -621,6 +628,21 @@ static std::atomic<bool> s_jitExpired{false};
 static std::atomic<bool> s_vmInitComplete{false};
 static std::atomic<bool> s_vmThreadShouldExit{false};
 static std::atomic<bool> s_idleVMPrewarmResolved{false};
+
+// True while some thread may be executing or emitting JIT code: the VM is
+// running, or the worker is still inside CPUThreadInitialize. ValidateJITAlive
+// skips its arena canary while this holds — the didBecomeActive prewarm re-runs
+// the keepalive on every app switch, and flipping the dispatcher page under a
+// live CPU thread is an instant Instruction Abort.
+static bool ARMSX2JITWorkerBusy()
+{
+    if (s_vmThreadActive.load(std::memory_order_relaxed))
+        return true;
+    // Before the worker exists the arena doesn't either (the canary is
+    // already skipped on g_code_rw_base==0), so "init not complete" only
+    // bites while CPUThreadInitialize is actually in flight.
+    return !s_vmInitComplete.load(std::memory_order_relaxed);
+}
 
 static void ARMSX2ResolveIdleVMPrewarm()
 {

--- a/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
@@ -1569,19 +1569,43 @@ final class SettingsStore {
         _invertRightStickYConfig.writer(_invertRightStickYConfig.section, _invertRightStickYConfig.key, invertRightStickY)
     }}
 
-    /// Effective axis inversion for a stick, resolving a per-game override (current game INI)
-    /// before the global default. Read live at the stick input choke point.
+    static let stickInversionKeys = ["InvertLeftStickX", "InvertLeftStickY", "InvertRightStickX", "InvertRightStickY"]
+    /// Per-game overrides for the game the cache was built from. Only the overridden keys
+    /// are stored, so a change to a global still takes effect without rebuilding.
+    @ObservationIgnored private var stickInversionOverrides: [String: Bool] = [:]
+    @ObservationIgnored private var stickInversionOverridesGame = ""
+
+    /// Effective axis inversion for a stick: the per-game override if there is one, else the
+    /// global. Called once per stick sample, so it must not touch the filesystem — the
+    /// per-game INI is read only when the running game changes or an override is written.
     func stickInversion(for side: StickSide) -> (x: Bool, y: Bool) {
-        // Passing the global as the default covers "no override", "no per-game file"
-        // and "no running game" in one read. A separate ContainsValue probe would
-        // parse the INI twice on every stick sample.
-        func resolve(_ key: String, global: Bool) -> Bool {
-            ARMSX2Bridge.getPerGameINIBoolForCurrentGame(Self.stickInversionSection, key: key, defaultValue: global)
+        let game = ARMSX2Bridge.perGameIdentityKeyForCurrentGame()
+        if game != stickInversionOverridesGame {
+            stickInversionOverridesGame = game
+            stickInversionOverrides = game.isEmpty ? [:] : Self.loadedStickInversionOverrides()
         }
         switch side {
-        case .left: return (resolve("InvertLeftStickX", global: invertLeftStickX), resolve("InvertLeftStickY", global: invertLeftStickY))
-        case .right: return (resolve("InvertRightStickX", global: invertRightStickX), resolve("InvertRightStickY", global: invertRightStickY))
+        case .left:
+            return (stickInversionOverrides["InvertLeftStickX"] ?? invertLeftStickX,
+                    stickInversionOverrides["InvertLeftStickY"] ?? invertLeftStickY)
+        case .right:
+            return (stickInversionOverrides["InvertRightStickX"] ?? invertRightStickX,
+                    stickInversionOverrides["InvertRightStickY"] ?? invertRightStickY)
         }
+    }
+
+    /// Call after writing or clearing a per-game inversion key so the next sample picks it up.
+    func reloadStickInversionOverrides() {
+        stickInversionOverridesGame = ARMSX2Bridge.perGameIdentityKeyForCurrentGame()
+        stickInversionOverrides = stickInversionOverridesGame.isEmpty ? [:] : Self.loadedStickInversionOverrides()
+    }
+
+    private static func loadedStickInversionOverrides() -> [String: Bool] {
+        var overrides: [String: Bool] = [:]
+        for key in stickInversionKeys where ARMSX2Bridge.hasPerGameINIValueForCurrentGame(stickInversionSection, key: key) {
+            overrides[key] = ARMSX2Bridge.getPerGameINIBoolForCurrentGame(stickInversionSection, key: key, defaultValue: false)
+        }
+        return overrides
     }
     let _appLanguageConfig = Setting<AppLanguage>(
         section: "ARMSX2iOS/UI", key: "AppLanguage", default: .system,

--- a/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
@@ -1572,11 +1572,11 @@ final class SettingsStore {
     /// Effective axis inversion for a stick, resolving a per-game override (current game INI)
     /// before the global default. Read live at the stick input choke point.
     func stickInversion(for side: StickSide) -> (x: Bool, y: Bool) {
+        // Passing the global as the default covers "no override", "no per-game file"
+        // and "no running game" in one read. A separate ContainsValue probe would
+        // parse the INI twice on every stick sample.
         func resolve(_ key: String, global: Bool) -> Bool {
-            if ARMSX2Bridge.hasPerGameINIValueForCurrentGame(Self.stickInversionSection, key: key) {
-                return ARMSX2Bridge.getPerGameINIBoolForCurrentGame(Self.stickInversionSection, key: key, defaultValue: global)
-            }
-            return global
+            ARMSX2Bridge.getPerGameINIBoolForCurrentGame(Self.stickInversionSection, key: key, defaultValue: global)
         }
         switch side {
         case .left: return (resolve("InvertLeftStickX", global: invertLeftStickX), resolve("InvertLeftStickY", global: invertLeftStickY))

--- a/platforms/ios/app/src/main/swift/Views/PerGameSettingsPanel.swift
+++ b/platforms/ios/app/src/main/swift/Views/PerGameSettingsPanel.swift
@@ -334,6 +334,8 @@ struct PerGameSettingsPanel: View {
     }
 
     /// Encodes the current editable per-game state so Save can be gated on real changes.
+    /// Virtual Pad values are left out on purpose: that tab writes as you edit it, so
+    /// there is never anything of its own left for Save to commit.
     private func perGameFingerprint() -> String {
         let fixes = SettingsStore.gameFixOptions.map { "\($0.key):\(perGameFixes[$0.key] ?? -1)" }.joined(separator: ",")
         return "\(enabled)|\(upscaleMultiplier)|\(aspectRatio)|\(textureFiltering)|\(hardwareMipmapping)|\(blendingAccuracy)|\(interlaceMode)|\(trilinearFiltering)|\(halfPixelOffset)|\(roundSprite)|\(alignSpriteOverride)|\(alignSprite)|\(mergeSpriteOverride)|\(mergeSprite)|\(wildArmsOffsetOverride)|\(wildArmsOffset)|\(textureOffsetXOverride)|\(textureOffsetX)|\(textureOffsetYOverride)|\(textureOffsetY)|\(skipDrawStartOverride)|\(skipDrawStart)|\(skipDrawEndOverride)|\(skipDrawEnd)|\(volumeOverride)|\(volumePercent)|\(eeCoreType)|\(mtvu)|\(eeCycleRate)|\(eeCycleSkip)|\(fastBoot)|\(enableCheats)|\(enablePatches)|\(enableGameFixes)|\(enableGameDBHardwareFixes)|\(perGameAAT)|\(perGameTextureInsideRt)|\(perGameRenderer)|\(perGameFXAA)|\(perGameUpscaler)|\(perGameShadeBoost)|\(perGameTVShader)|\(perGameCASMode)|\(perGameMaxAnisotropy)|\(perGameCASSharpness)|\(perGamePCRTCOffsets)|\(perGameIntegerScaling)|\(perGameSkipDupFrames)|\(perGamePCRTCOverscan)|\(perGamePCRTCAntiBlur)|\(perGameDisableInterlaceOffset)|\(perGameWidescreen)|\(perGameNoInterlace)|\(perGameShadeBoostBrightness)|\(perGameShadeBoostContrast)|\(perGameShadeBoostSaturation)|\(perGameShadeBoostGamma)|\(perGameDithering)|\(perGameFastForwardVolume)|\(perGameIOP)|\(perGameVU0)|\(perGameVU1)|\(perGameHWDownloadMode)|\(perGameCPUCLUT)|\(perGameGPUTargetCLUT)|\(perGameVsyncQueue)|\(perGameLoadTextureReplacements)|\(perGameLoadTextureReplacementsAsync)|\(perGamePrecacheTextureReplacements)|\(perGameSyncToHostRefresh)|\(perGameBufferMS)|\(perGameOutputLatencyMS)|\(perGameEEFpuRound)|\(perGameVU0Round)|\(perGameVU1Round)|\(perGameEEClamp)|\(perGameVUClamp)|\(raEnabledOverride)|\(raHardcoreOverride)|\(perGameFramePacingPreset)|\(perGameFrameLimiter)|\(perGameTargetFPS)|\(fixes)"
@@ -703,7 +705,9 @@ struct PerGameSettingsPanel: View {
             padLayoutIdentity: $padLayoutIdentity,
             showPadLayoutEditor: $showPadLayoutEditor,
             layoutPresets: layoutPresets,
-            skinLibrary: skinLibrary
+            skinLibrary: skinLibrary,
+            savesToRunningGame: savesToRunningGame,
+            iso: game.bootName
         )
     }
 

--- a/platforms/ios/app/src/main/swift/Views/PerGameSettingsPanel.swift
+++ b/platforms/ios/app/src/main/swift/Views/PerGameSettingsPanel.swift
@@ -361,9 +361,24 @@ struct PerGameSettingsPanel: View {
 
     /// Clears every per-game override by disabling the master toggle and saving; the
     /// save path deletes all per-game keys so the global values apply on next boot.
+    /// Virtual Pad state isn't part of that path — layout and skin live in the preset
+    /// store, stick inversion is written as you edit it — so clear those by hand here.
     private func resetAllOverrides() {
+        if let padLayoutIdentity {
+            layoutPresets.clearVPadOverrides(for: padLayoutIdentity)
+        }
+        clearStickInversionOverrides()
         enabled = false
         save()
+    }
+
+    private func clearStickInversionOverrides() {
+        for key in SettingsStore.stickInversionKeys {
+            Self.clearPerGameValue("ARMSX2iOS/UI", key, useCurrent: savesToRunningGame, iso: game.bootName)
+        }
+        if savesToRunningGame {
+            settings.reloadStickInversionOverrides()
+        }
     }
 
     /// Whether OPH Flag Hack is effectively on for this game: a per-game override of 1, or
@@ -707,7 +722,8 @@ struct PerGameSettingsPanel: View {
             layoutPresets: layoutPresets,
             skinLibrary: skinLibrary,
             savesToRunningGame: savesToRunningGame,
-            iso: game.bootName
+            iso: game.bootName,
+            hasGameSettingsIdentity: hasGameSettingsIdentity
         )
     }
 

--- a/platforms/ios/app/src/main/swift/Views/RootView.swift
+++ b/platforms/ios/app/src/main/swift/Views/RootView.swift
@@ -134,11 +134,10 @@ struct MenuTabView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .tint(.blue)
 #else
+            // Render every tab directly, no if/else on the background toggle.
+            // Swapping view trees made SwiftUI recreate the NavigationStack,
+            // snapping back to root and breaking the neighbouring tabs.
             TabView(selection: tabSelection) {
-                // Games tab is NOT wrapped in SafeAreaProtectedMenuTabContent — it
-                // renders its own edge-to-edge custom wallpaper (BackgroundContainerView)
-                // inside its NavigationStack ZStack, which must not be clipped by the
-                // safe-area padding that the other tabs use.
                 GameListView()
                     .environment(\.menuTabIsActive, selectedTab == 0)
                     .tabItem {
@@ -146,47 +145,22 @@ struct MenuTabView: View {
                     }
                     .tag(0)
 
-                // When a tab's background is active it owns its edge-to-edge MenuBackgroundLayer
-                // inside its own NavigationStack (matching GameListView), so it must NOT be wrapped
-                // in SafeAreaProtectedMenuTabContent — the padding would clip the wallpaper.
-                Group {
-                    if biosBackgroundActive {
-                        BIOSListView()
-                    } else {
-                        SafeAreaProtectedMenuTabContent { BIOSListView() }
+                BIOSListView()
+                    .environment(\.menuTabIsActive, selectedTab == 1)
+                    .tabItem {
+                        Label(settings.localized("BIOS"), systemImage: "cpu")
                     }
-                }
-                .environment(\.menuTabIsActive, selectedTab == 1)
-                .tabItem {
-                    Label(settings.localized("BIOS"), systemImage: "cpu")
-                }
-                .tag(1)
+                    .tag(1)
 
-                Group {
-                    if helpBackgroundActive {
-                        HelpView()
-                    } else {
-                        SafeAreaProtectedMenuTabContent { HelpView() }
+                HelpView()
+                    .environment(\.menuTabIsActive, selectedTab == 2)
+                    .tabItem {
+                        Label(settings.localized("Help"), systemImage: "questionmark.circle")
                     }
-                }
-                .environment(\.menuTabIsActive, selectedTab == 2)
-                .tabItem {
-                    Label(settings.localized("Help"), systemImage: "questionmark.circle")
-                }
-                .tag(2)
+                    .tag(2)
 
-                Group {
-                    if settingsBackgroundActive {
-                        NavigationStack {
-                            SettingsRootView()
-                        }
-                    } else {
-                        SafeAreaProtectedMenuTabContent {
-                            NavigationStack {
-                                SettingsRootView()
-                            }
-                        }
-                    }
+                NavigationStack {
+                    SettingsRootView()
                 }
                 .environment(\.menuTabIsActive, selectedTab == 3)
                 .tabItem {

--- a/platforms/ios/app/src/main/swift/Views/Settings/PerGame/PadTab.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/PerGame/PadTab.swift
@@ -9,6 +9,8 @@ struct PadTab: View {
 
     let layoutPresets: PadLayoutPresetStore
     let skinLibrary: VPadSkinLibraryStore
+    let savesToRunningGame: Bool
+    let iso: String
 
     @State private var inversionDrafts: [String: Int] = [:]
     private let inversionKeys = ["InvertLeftStickX", "InvertLeftStickY", "InvertRightStickX", "InvertRightStickY"]
@@ -74,7 +76,7 @@ struct PadTab: View {
                         layoutPresets.clearVPadOverrides(for: padLayoutIdentity)
                         inversionDrafts = [:]
                         for key in inversionKeys {
-                            ARMSX2Bridge.deletePerGameINIValueForCurrentGame(inversionSection, key: key)
+                            clearInversionOverride(key)
                         }
                     } label: {
                         Label("Reset All VPad Overrides", systemImage: "arrow.counterclockwise")
@@ -101,7 +103,7 @@ struct PadTab: View {
                 } header: {
                     Text("Stick Inversion")
                 } footer: {
-                    Text("Overrides the global stick inversion for this game only.")
+                    Text("Overrides the global stick inversion for this game only. Everything on this page saves as you change it, so Save and Cancel don't apply here.")
                 }
             }
         }
@@ -121,21 +123,55 @@ struct PadTab: View {
     private func loadInversionDrafts() {
         var drafts: [String: Int] = [:]
         for key in inversionKeys {
-            if ARMSX2Bridge.hasPerGameINIValueForCurrentGame(inversionSection, key: key) {
-                drafts[key] = ARMSX2Bridge.getPerGameINIBoolForCurrentGame(inversionSection, key: key, defaultValue: false) ? 1 : 0
+            if hasInversionOverride(key) {
+                drafts[key] = inversionOverride(key) ? 1 : 0
             }
         }
         inversionDrafts = drafts
     }
 
+    // Commits on pick, like the layout and skin pickers. Nothing in this tab is
+    // staged, so none of it feeds the panel's Save fingerprint.
     private func applyInversion(_ key: String, value: Int) {
         var drafts = inversionDrafts
         drafts[key] = value
         inversionDrafts = drafts
         if value == -1 {
+            clearInversionOverride(key)
+        } else {
+            setInversionOverride(key, value == 1)
+        }
+    }
+
+    // The panel opens both in-game and from the library. The "current game" bridge
+    // variants resolve their identity from the running VM and silently no-op without
+    // one, so the library path has to address the per-game INI by ISO instead.
+
+    private func hasInversionOverride(_ key: String) -> Bool {
+        savesToRunningGame
+            ? ARMSX2Bridge.hasPerGameINIValueForCurrentGame(inversionSection, key: key)
+            : ARMSX2Bridge.hasPerGameINIValue(inversionSection, key: key, forISO: iso)
+    }
+
+    private func inversionOverride(_ key: String) -> Bool {
+        savesToRunningGame
+            ? ARMSX2Bridge.getPerGameINIBoolForCurrentGame(inversionSection, key: key, defaultValue: false)
+            : ARMSX2Bridge.getPerGameINIBool(inversionSection, key: key, defaultValue: false, forISO: iso)
+    }
+
+    private func setInversionOverride(_ key: String, _ value: Bool) {
+        if savesToRunningGame {
+            ARMSX2Bridge.setPerGameINIBoolForCurrentGame(inversionSection, key: key, value: value)
+        } else {
+            ARMSX2Bridge.setPerGameINIBool(inversionSection, key: key, value: value, forISO: iso)
+        }
+    }
+
+    private func clearInversionOverride(_ key: String) {
+        if savesToRunningGame {
             ARMSX2Bridge.deletePerGameINIValueForCurrentGame(inversionSection, key: key)
         } else {
-            ARMSX2Bridge.setPerGameINIBoolForCurrentGame(inversionSection, key: key, value: value == 1)
+            ARMSX2Bridge.deletePerGameINIValue(inversionSection, key: key, forISO: iso)
         }
     }
 

--- a/platforms/ios/app/src/main/swift/Views/Settings/PerGame/PadTab.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/PerGame/PadTab.swift
@@ -11,9 +11,10 @@ struct PadTab: View {
     let skinLibrary: VPadSkinLibraryStore
     let savesToRunningGame: Bool
     let iso: String
+    let hasGameSettingsIdentity: Bool
 
     @State private var inversionDrafts: [String: Int] = [:]
-    private let inversionKeys = ["InvertLeftStickX", "InvertLeftStickY", "InvertRightStickX", "InvertRightStickY"]
+    private let inversionKeys = SettingsStore.stickInversionKeys
     private let inversionSection = "ARMSX2iOS/UI"
 
     var body: some View {
@@ -88,7 +89,9 @@ struct PadTab: View {
                 }
             }
 
-            if padLayoutIdentity != nil {
+            // Inversion lands in the per-game INI, which is keyed on the game's CRC —
+            // without one the pickers would move and write nowhere.
+            if hasGameSettingsIdentity {
                 Section {
                     ForEach(inversionKeys, id: \.self) { key in
                         Picker(inversionLabel(for: key), selection: Binding<Int>(
@@ -162,6 +165,7 @@ struct PadTab: View {
     private func setInversionOverride(_ key: String, _ value: Bool) {
         if savesToRunningGame {
             ARMSX2Bridge.setPerGameINIBoolForCurrentGame(inversionSection, key: key, value: value)
+            SettingsStore.shared.reloadStickInversionOverrides()
         } else {
             ARMSX2Bridge.setPerGameINIBool(inversionSection, key: key, value: value, forISO: iso)
         }
@@ -170,6 +174,7 @@ struct PadTab: View {
     private func clearInversionOverride(_ key: String) {
         if savesToRunningGame {
             ARMSX2Bridge.deletePerGameINIValueForCurrentGame(inversionSection, key: key)
+            SettingsStore.shared.reloadStickInversionOverrides()
         } else {
             ARMSX2Bridge.deletePerGameINIValue(inversionSection, key: key, forISO: iso)
         }


### PR DESCRIPTION
## Per-game stick inversion wasn't saving

Turning on inverted stick from the in-game Virtual Pad settings looked like it worked, then reverted back to global the next time you checked. Turned out the panel was always writing to the *currently running game's* save file, but when you open Per-Game Settings from the library (no game running yet), there's no "currently running game" to write to — so the toggle just silently did nothing.

Fixed it to write to the right place whether you're in the library or in-game. While in there I also fixed "Reset All Overrides" not actually resetting the stick inversion, made the stick-inversion lookup a lot cheaper (it was re-reading a settings file on every single stick movement), and made sure the toggles don't show up at all for a game that hasn't been launched yet, since there's nowhere for them to save.

## Background toggle was breaking tab navigation

If you had a custom background enabled and flipped the "show background" toggle for the BIOS/Help/Settings tabs, the tab would snap back to its root screen and mess up navigation on the other tabs too. SwiftUI was tearing down and rebuilding the whole tab when the toggle changed. Now every tab renders the same way regardless of the toggle, so nothing gets rebuilt.

## Crashes on iOS 18 (LiveContainer / SideStore)

This was the big one — multiple rounds of crash reports from testers on iOS 18, all coming from how the JIT protects its own memory when running outside a normal app install.

- Boot could crash almost immediately because of how the recompiler patches jump targets in code it already generated — writing to memory that iOS had locked back to read-only in between.
- A "is the JIT still alive" background check could crash on boot for the same reason.
- After that got fixed, the same check turned around and crashed the game whenever you switched apps or backgrounded — it was running its check on the exact same memory the game's code was actively executing from.

All three are the same root problem (iOS 18's stricter memory protection) hitting three different code paths. Two testers confirmed booting and switching apps both work now after each round.

## Small stuff

- Fixed two build warnings that were actually real bugs: one crashed on iOS 17 (used an iOS 18-only API without a fallback), the other was two functions in the codebase silently fighting over the same name, which could corrupt memory in a way nobody would ever notice until it randomly broke.