### PR TITLE
iOS: fix graphics settings that never applied, and repair two dead guard tests

### DIFF
--- a/bin/resources-overlay/armsx2_overrides.yaml
+++ b/bin/resources-overlay/armsx2_overrides.yaml
@@ -886,14 +886,20 @@ SLES-53559:
     halfPixelOffset: 5
     nativeScaling: 2
 SLES-53616:
+  speedHacks:
+    mvuFlag: 0 # Fixes texture flickering caused by the VU Flag Hack.
   gameFixes:
   - VUSyncHack
   - FullVU0SyncHack
 SLES-53617:
+  speedHacks:
+    mvuFlag: 0 # Fixes texture flickering caused by the VU Flag Hack.
   gameFixes:
   - VUSyncHack
   - FullVU0SyncHack
 SLES-53618:
+  speedHacks:
+    mvuFlag: 0 # Fixes texture flickering caused by the VU Flag Hack.
   gameFixes:
   - VUSyncHack
   - FullVU0SyncHack
@@ -1242,6 +1248,8 @@ SLPM-66419:
     nativeScaling: 1
     roundSprite: 1
 SLPM-66473:
+  speedHacks:
+    mvuFlag: 0 # Fixes texture flickering caused by the VU Flag Hack.
   gameFixes:
   - VUSyncHack
   - FullVU0SyncHack
@@ -1306,6 +1314,8 @@ SLPM-74241:
     hwDownloadMode: 3
     nativeScaling: 2
 SLPM-74243:
+  speedHacks:
+    mvuFlag: 0 # Fixes texture flickering caused by the VU Flag Hack.
   gameFixes:
   - VUSyncHack
   - FullVU0SyncHack
@@ -1523,6 +1533,8 @@ SLUS-21087:
     halfPixelOffset: 5
     hwDownloadMode: 3
 SLUS-21106:
+  speedHacks:
+    mvuFlag: 0 # Fixes texture flickering caused by the VU Flag Hack.
   gameFixes:
   - VUSyncHack
   - FullVU0SyncHack

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1020,7 +1020,11 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 		GSConfig.UserHacks_TextureInsideRt != old_config.UserHacks_TextureInsideRt ||
 		GSConfig.UserHacks_CPUSpriteRenderBW != old_config.UserHacks_CPUSpriteRenderBW ||
 		GSConfig.UserHacks_CPUCLUTRender != old_config.UserHacks_CPUCLUTRender ||
-		GSConfig.UserHacks_GPUTargetCLUTMode != old_config.UserHacks_GPUTargetCLUTMode)
+		GSConfig.UserHacks_GPUTargetCLUTMode != old_config.UserHacks_GPUTargetCLUTMode ||
+		// Native scaling is the one geometry hack that outlives the draw: it swaps a
+		// target's texture for a downscaled one and pins m_scale to 1. Those targets
+		// stay downscaled after it's switched off, so they have to go.
+		GSConfig.UserHacks_NativeScaling != old_config.UserHacks_NativeScaling)
 	{
 		if (GSConfig.UserHacks_ReadTCOnClose)
 			g_gs_renderer->ReadbackTextureCache();

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
@@ -1364,82 +1364,6 @@ static NSString* ARMSX2SanitizedSkinFileName(NSString* name)
     return sanitized;
 }
 
-static void ARMSX2ApplyLiveGSBoolSetting(const char* section, const char* key, bool value)
-{
-    if (std::strcmp(section, "EmuCore/GS") != 0)
-        return;
-
-#define APPLY_OSD_BOOL(name) \
-    do { \
-        if (std::strcmp(key, #name) == 0) { \
-            EmuConfig.GS.name = value; \
-            GSConfig.name = value; \
-            return; \
-        } \
-    } while (0)
-
-    APPLY_OSD_BOOL(OsdShowFPS);
-    APPLY_OSD_BOOL(OsdShowVPS);
-    APPLY_OSD_BOOL(OsdShowSpeed);
-    APPLY_OSD_BOOL(OsdShowCPU);
-    APPLY_OSD_BOOL(OsdShowGPU);
-    APPLY_OSD_BOOL(OsdShowResolution);
-    APPLY_OSD_BOOL(OsdShowGSStats);
-    APPLY_OSD_BOOL(OsdShowIndicators);
-    APPLY_OSD_BOOL(OsdShowSettings);
-    APPLY_OSD_BOOL(OsdShowInputs);
-    APPLY_OSD_BOOL(OsdShowFrameTimes);
-    APPLY_OSD_BOOL(OsdShowVersion);
-    APPLY_OSD_BOOL(OsdShowHardwareInfo);
-    APPLY_OSD_BOOL(OsdShowVideoCapture);
-    APPLY_OSD_BOOL(OsdShowInputRec);
-    APPLY_OSD_BOOL(DumpReplaceableTextures);
-    APPLY_OSD_BOOL(DumpReplaceableMipmaps);
-    APPLY_OSD_BOOL(DumpTexturesWithFMVActive);
-    APPLY_OSD_BOOL(DumpDirectTextures);
-    APPLY_OSD_BOOL(DumpPaletteTextures);
-    APPLY_OSD_BOOL(LoadTextureReplacements);
-    APPLY_OSD_BOOL(LoadTextureReplacementsAsync);
-    APPLY_OSD_BOOL(PrecacheTextureReplacements);
-
-    if (std::strcmp(key, "hw_mipmap") == 0) {
-        EmuConfig.GS.HWMipmap = value;
-        GSConfig.HWMipmap = value;
-        return;
-    }
-
-#undef APPLY_OSD_BOOL
-}
-
-static void ARMSX2ApplyLiveGSIntSetting(const char* section, const char* key, int value)
-{
-    if (std::strcmp(section, "EmuCore/GS") != 0)
-        return;
-
-    if (std::strcmp(key, "OsdPerformancePos") == 0) {
-        const int clamped = std::clamp(value, static_cast<int>(OsdOverlayPos::None), static_cast<int>(OsdOverlayPos::TopRight));
-        EmuConfig.GS.OsdPerformancePos = static_cast<OsdOverlayPos>(clamped);
-        GSConfig.OsdPerformancePos = static_cast<OsdOverlayPos>(clamped);
-    } else if (std::strcmp(key, "OsdMessagesPos") == 0) {
-        // Toggles the transient OSD message queue (shader-compilation, save,
-        // settings-applied, etc.) without touching performance counters or the
-        // separate SwiftUI alert path used for critical errors.
-        const int clamped = std::clamp(value, static_cast<int>(OsdOverlayPos::None), static_cast<int>(OsdOverlayPos::TopRight));
-        EmuConfig.GS.OsdMessagesPos = static_cast<OsdOverlayPos>(clamped);
-        GSConfig.OsdMessagesPos = static_cast<OsdOverlayPos>(clamped);
-    } else if (std::strcmp(key, "texture_preloading") == 0) {
-        const int clamped = std::clamp(value, 0, static_cast<int>(TexturePreloadingLevel::Full));
-        EmuConfig.GS.TexturePreloading = static_cast<TexturePreloadingLevel>(clamped);
-        GSConfig.TexturePreloading = static_cast<TexturePreloadingLevel>(clamped);
-    } else if (std::strcmp(key, "UserHacks_SkipDraw_Start") == 0) {
-        EmuConfig.GS.SkipDrawStart = value;
-        GSConfig.SkipDrawStart = value;
-    } else if (std::strcmp(key, "UserHacks_SkipDraw_End") == 0) {
-        EmuConfig.GS.SkipDrawEnd = std::max(EmuConfig.GS.SkipDrawStart, value);
-        GSConfig.SkipDrawEnd = EmuConfig.GS.SkipDrawEnd;
-    }
-}
-
 static void ARMSX2ApplyLiveTargetSpeedSetting(std::function<void()> update, const char* section, const char* key, float value)
 {
     const std::string sectionName(section ? section : "");
@@ -1514,40 +1438,23 @@ static bool ARMSX2ShouldBlockRetroAchievementsHardcoreBoolSetting(const char* se
     return false;
 }
 
+// Emulation-speed scalars only. EmuCore/GS is not handled here: every graphics
+// setting reloads through the Setting<T> hook -> applyGraphicsSettingsNow.
 static void ARMSX2ApplyLiveFloatSetting(const char* section, const char* key, float value)
 {
-    if (std::strcmp(section, "Framerate") == 0) {
-        const float clamped = std::isfinite(value) ? std::clamp(value, 0.05f, 10.0f) : 1.0f;
-        if (std::strcmp(key, "NominalScalar") == 0) {
-            const float normalized = ARMSX2NormalizeIOSNominalScalar(value);
-            if (std::fabs(normalized - clamped) > 0.001f)
-                NSLog(@"[ARMSX2Bridge] clamping unsupported NominalScalar %.3f -> %.3f", clamped, normalized);
-            ARMSX2ApplyLiveTargetSpeedSetting([normalized]() { EmuConfig.EmulationSpeed.NominalScalar = normalized; }, section, key, normalized);
-        } else if (std::strcmp(key, "TurboScalar") == 0)
-            ARMSX2ApplyLiveTargetSpeedSetting([clamped]() { EmuConfig.EmulationSpeed.TurboScalar = clamped; }, section, key, clamped);
-        else if (std::strcmp(key, "SlomoScalar") == 0)
-            ARMSX2ApplyLiveTargetSpeedSetting([clamped]() { EmuConfig.EmulationSpeed.SlomoScalar = clamped; }, section, key, clamped);
-        else
-            return;
-        return;
-    }
-
-    if (std::strcmp(section, "EmuCore/GS") != 0)
+    if (std::strcmp(section, "Framerate") != 0)
         return;
 
-    if (std::strcmp(key, "FramerateNTSC") == 0) {
-        ARMSX2ApplyLiveTargetSpeedSetting([value]() { EmuConfig.GS.FramerateNTSC = value; }, section, key, value);
-        return;
-    }
-    if (std::strcmp(key, "FrameratePAL") == 0) {
-        ARMSX2ApplyLiveTargetSpeedSetting([value]() { EmuConfig.GS.FrameratePAL = value; }, section, key, value);
-        return;
-    }
-    if (std::strcmp(key, "upscale_multiplier") == 0) {
-        const float clamped = std::clamp(value, 0.25f, 8.0f);
-        EmuConfig.GS.UpscaleMultiplier = clamped;
-        GSConfig.UpscaleMultiplier = clamped;
-        return;
+    const float clamped = std::isfinite(value) ? std::clamp(value, 0.05f, 10.0f) : 1.0f;
+    if (std::strcmp(key, "NominalScalar") == 0) {
+        const float normalized = ARMSX2NormalizeIOSNominalScalar(value);
+        if (std::fabs(normalized - clamped) > 0.001f)
+            NSLog(@"[ARMSX2Bridge] clamping unsupported NominalScalar %.3f -> %.3f", clamped, normalized);
+        ARMSX2ApplyLiveTargetSpeedSetting([normalized]() { EmuConfig.EmulationSpeed.NominalScalar = normalized; }, section, key, normalized);
+    } else if (std::strcmp(key, "TurboScalar") == 0) {
+        ARMSX2ApplyLiveTargetSpeedSetting([clamped]() { EmuConfig.EmulationSpeed.TurboScalar = clamped; }, section, key, clamped);
+    } else if (std::strcmp(key, "SlomoScalar") == 0) {
+        ARMSX2ApplyLiveTargetSpeedSetting([clamped]() { EmuConfig.EmulationSpeed.SlomoScalar = clamped; }, section, key, clamped);
     }
 }
 
@@ -3490,7 +3397,6 @@ static std::string ARMSX2PerGameSettingsPath(const std::string& serial, u32 crc)
     }
     g_p44_settings_interface->SetIntValue(section.UTF8String, key.UTF8String, value);
     ARMSX2ScheduleINISave();
-    ARMSX2ApplyLiveGSIntSetting(section.UTF8String, key.UTF8String, value);
 }
 
 + (void)setINIBool:(nonnull NSString *)section key:(nonnull NSString *)key value:(BOOL)value {
@@ -3499,7 +3405,6 @@ static std::string ARMSX2PerGameSettingsPath(const std::string& serial, u32 crc)
         value = NO;
     g_p44_settings_interface->SetBoolValue(section.UTF8String, key.UTF8String, value);
     ARMSX2ScheduleINISave();
-    ARMSX2ApplyLiveGSBoolSetting(section.UTF8String, key.UTF8String, value);
 }
 
 + (void)setINIFloat:(nonnull NSString *)section key:(nonnull NSString *)key value:(float)value {
@@ -3536,6 +3441,11 @@ static std::string ARMSX2PerGameSettingsPath(const std::string& serial, u32 crc)
 
     // ApplySettings owns EmuConfig and resets the JIT caches, and MTGS::ApplySettings pushes to
     // the single-producer ring — both the CPU thread's, and this runs on the UI thread.
+    //
+    // The push looks redundant (ApplySettings ends in CheckForGSConfigChanges, which pushes
+    // for us) but it is not: applyOsdPreset and setPerformanceOverlayVisible still write
+    // EmuConfig.GS from the UI thread, so the reload can find nothing changed and skip its
+    // own push. Keep this until they stop doing that.
     Host::RunOnCPUThread([]() {
         VMManager::ApplySettings();
         if (MTGS::IsOpen())

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
@@ -3072,27 +3072,38 @@ static std::string ARMSX2PerGameSettingsPath(const std::string& serial, u32 crc)
 // Toggle overlay visibility via position (None vs TopRight).
 // Individual OSD flags are controlled by preset in SettingsStore, not here.
 + (void)setPerformanceOverlayVisible:(BOOL)visible {
+    // Hidden in the config means the user never picked a corner, so give them one.
+    OsdOverlayPos pos = OsdOverlayPos::None;
     if (visible) {
-        GSConfig.OsdPerformancePos = EmuConfig.GS.OsdPerformancePos;
-        // If user had None in config, default to TopRight
-        if (GSConfig.OsdPerformancePos == OsdOverlayPos::None) {
-            GSConfig.OsdPerformancePos = OsdOverlayPos::TopRight;
-            EmuConfig.GS.OsdPerformancePos = OsdOverlayPos::TopRight;
-        }
-    } else {
-        GSConfig.OsdPerformancePos = OsdOverlayPos::None;
-        EmuConfig.GS.OsdPerformancePos = OsdOverlayPos::None;
+        pos = EmuConfig.GS.OsdPerformancePos;
+        if (pos == OsdOverlayPos::None)
+            pos = OsdOverlayPos::TopRight;
     }
 
     if (g_p44_settings_interface) {
-        g_p44_settings_interface->SetIntValue("EmuCore/GS", "OsdPerformancePos",
-            static_cast<int>(EmuConfig.GS.OsdPerformancePos));
+        g_p44_settings_interface->SetIntValue("EmuCore/GS", "OsdPerformancePos", static_cast<int>(pos));
         g_p44_settings_interface->Save();
     }
+
+    // GSConfig belongs to the GS thread and EmuConfig to the CPU thread; this is
+    // called from the UI. Both live in a bitfield, so an off-thread write can drop
+    // a neighbouring flag -- including the ones that decide whether GSUpdateConfig
+    // tears the device down.
+    Host::RunOnCPUThread([pos]() {
+        EmuConfig.GS.OsdPerformancePos = pos;
+        GSConfig.OsdPerformancePos = pos;
+    });
 }
 
 + (BOOL)isPerformanceOverlayVisible {
-    return GSConfig.OsdPerformancePos != OsdOverlayPos::None;
+    // Read the INI, not GSConfig: the setter writes the INI now and hands the
+    // config update to the CPU thread, so GSConfig lags a toggle by a hop and a
+    // UI read-back would bounce the switch.
+    if (g_p44_settings_interface) {
+        return g_p44_settings_interface->GetIntValue("EmuCore/GS", "OsdPerformancePos",
+            static_cast<int>(OsdOverlayPos::None)) != static_cast<int>(OsdOverlayPos::None);
+    }
+    return EmuConfig.GS.OsdPerformancePos != OsdOverlayPos::None;
 }
 
 + (nonnull NSDictionary<NSString *, id> *)deviceStatsForAccessibility {
@@ -3147,72 +3158,46 @@ static std::string ARMSX2PerGameSettingsPath(const std::string& serial, u32 crc)
 
 // Apply OSD preset — sets ALL GSConfig flags to match the preset
 + (void)applyOsdPreset:(int)preset {
-    // Clear everything first
-    GSConfig.OsdShowFPS = false;
-    GSConfig.OsdShowSpeed = false;
-    GSConfig.OsdShowVPS = false;
-    GSConfig.OsdShowCPU = false;
-    GSConfig.OsdShowGPU = false;
-    GSConfig.OsdShowResolution = false;
-    GSConfig.OsdShowGSStats = false;
-    GSConfig.OsdShowFrameTimes = false;
-    GSConfig.OsdShowVersion = false;
-    GSConfig.OsdShowHardwareInfo = false;
-    GSConfig.OsdShowIndicators = false;
-    GSConfig.OsdShowSettings = false;
-    GSConfig.OsdShowInputs = false;
-    GSConfig.OsdShowVideoCapture = false;
-    GSConfig.OsdShowInputRec = false;
+    // 1 simple: clean player readout; device stats are Swift-side.
+    // 2 detail: performance and renderer diagnostics.
+    // 3 full: closest to Android's full stats section. 0 is off.
+    const bool simple = (preset == 1);
+    const bool detail = (preset == 2);
+    const bool full = (preset == 3);
 
-    switch (preset) {
-    case 1: // simple: clean player readout; device stats are Swift-side
-        GSConfig.OsdShowFPS = true;
-        GSConfig.OsdShowSpeed = true;
-        GSConfig.OsdShowCPU = true;
-        GSConfig.OsdShowVersion = true;
-        break;
-    case 2: // detail: performance and renderer diagnostics
-        GSConfig.OsdShowFPS = true;
-        GSConfig.OsdShowVPS = true;
-        GSConfig.OsdShowSpeed = true;
-        GSConfig.OsdShowCPU = true;
-        GSConfig.OsdShowGPU = true;
-        GSConfig.OsdShowResolution = true;
-        GSConfig.OsdShowIndicators = true;
-        GSConfig.OsdShowVersion = true;
-        break;
-    case 3: // full: closest to Android's full stats section
-        GSConfig.OsdShowFPS = true;
-        GSConfig.OsdShowVPS = true;
-        GSConfig.OsdShowSpeed = true;
-        GSConfig.OsdShowCPU = true;
-        GSConfig.OsdShowGPU = true;
-        GSConfig.OsdShowResolution = true;
-        GSConfig.OsdShowGSStats = true;
-        GSConfig.OsdShowFrameTimes = true;
-        GSConfig.OsdShowVersion = true;
-        GSConfig.OsdShowHardwareInfo = true;
-        GSConfig.OsdShowIndicators = true;
-        GSConfig.OsdShowSettings = true;
-        GSConfig.OsdShowInputs = true;
-        break;
-    default: // 0 = off
-        break;
-    }
+    const bool fps = simple || detail || full;
+    const bool vps = detail || full;
+    const bool speed = simple || detail || full;
+    const bool cpu = simple || detail || full;
+    const bool gpu = detail || full;
+    const bool resolution = detail || full;
+    const bool indicators = detail || full;
+    const bool version = simple || detail || full;
+    const bool gsStats = full;
+    const bool frameTimes = full;
+    const bool hardwareInfo = full;
+    const bool settings = full;
+    const bool inputs = full;
 
-    EmuConfig.GS.OsdShowFPS = GSConfig.OsdShowFPS;
-    EmuConfig.GS.OsdShowVPS = GSConfig.OsdShowVPS;
-    EmuConfig.GS.OsdShowSpeed = GSConfig.OsdShowSpeed;
-    EmuConfig.GS.OsdShowCPU = GSConfig.OsdShowCPU;
-    EmuConfig.GS.OsdShowGPU = GSConfig.OsdShowGPU;
-    EmuConfig.GS.OsdShowResolution = GSConfig.OsdShowResolution;
-    EmuConfig.GS.OsdShowGSStats = GSConfig.OsdShowGSStats;
-    EmuConfig.GS.OsdShowFrameTimes = GSConfig.OsdShowFrameTimes;
-    EmuConfig.GS.OsdShowVersion = GSConfig.OsdShowVersion;
-    EmuConfig.GS.OsdShowHardwareInfo = GSConfig.OsdShowHardwareInfo;
-    EmuConfig.GS.OsdShowIndicators = GSConfig.OsdShowIndicators;
-    EmuConfig.GS.OsdShowSettings = GSConfig.OsdShowSettings;
-    EmuConfig.GS.OsdShowInputs = GSConfig.OsdShowInputs;
+    // Same ownership problem as setPerformanceOverlayVisible: these are bitfield
+    // members of the CPU and GS threads' configs, written here from the UI.
+    Host::RunOnCPUThread([=]() {
+        EmuConfig.GS.OsdShowFPS = GSConfig.OsdShowFPS = fps;
+        EmuConfig.GS.OsdShowVPS = GSConfig.OsdShowVPS = vps;
+        EmuConfig.GS.OsdShowSpeed = GSConfig.OsdShowSpeed = speed;
+        EmuConfig.GS.OsdShowCPU = GSConfig.OsdShowCPU = cpu;
+        EmuConfig.GS.OsdShowGPU = GSConfig.OsdShowGPU = gpu;
+        EmuConfig.GS.OsdShowResolution = GSConfig.OsdShowResolution = resolution;
+        EmuConfig.GS.OsdShowGSStats = GSConfig.OsdShowGSStats = gsStats;
+        EmuConfig.GS.OsdShowFrameTimes = GSConfig.OsdShowFrameTimes = frameTimes;
+        EmuConfig.GS.OsdShowVersion = GSConfig.OsdShowVersion = version;
+        EmuConfig.GS.OsdShowHardwareInfo = GSConfig.OsdShowHardwareInfo = hardwareInfo;
+        EmuConfig.GS.OsdShowIndicators = GSConfig.OsdShowIndicators = indicators;
+        EmuConfig.GS.OsdShowSettings = GSConfig.OsdShowSettings = settings;
+        EmuConfig.GS.OsdShowInputs = GSConfig.OsdShowInputs = inputs;
+        GSConfig.OsdShowVideoCapture = false;
+        GSConfig.OsdShowInputRec = false;
+    });
 }
 
 + (int)emulatorVolumePercent {
@@ -3443,9 +3428,9 @@ static std::string ARMSX2PerGameSettingsPath(const std::string& serial, u32 crc)
     // the single-producer ring — both the CPU thread's, and this runs on the UI thread.
     //
     // The push looks redundant (ApplySettings ends in CheckForGSConfigChanges, which pushes
-    // for us) but it is not: applyOsdPreset and setPerformanceOverlayVisible still write
-    // EmuConfig.GS from the UI thread, so the reload can find nothing changed and skip its
-    // own push. Keep this until they stop doing that.
+    // for us) but it is not: applyOsdPreset and setPerformanceOverlayVisible still pre-write
+    // EmuConfig.GS, so the reload can find nothing changed and skip its own push. They are
+    // queued onto this same thread now, so ordering is defined, but the pre-write remains.
     Host::RunOnCPUThread([]() {
         VMManager::ApplySettings();
         if (MTGS::IsOpen())

--- a/platforms/ios/app/src/main/swift/Models/Setting.swift
+++ b/platforms/ios/app/src/main/swift/Models/Setting.swift
@@ -11,25 +11,39 @@ import Foundation
 /// `SettingsStore.init()` is running; the graphics-pipeline closures still go
 /// through `requestGraphicsApplyGuarded()` (which no-ops while INI is loading)
 /// as a guard, should that ever change.
+///
+/// Every `EmuCore/GS` setting gets that apply hook by default. Opting in per
+/// setting is how the sprite hacks, the user hacks and the OSD flags ended up
+/// writing the INI and never reaching the running VM: a new setting inherits
+/// whatever the one above it happened to declare. Boot-only keys opt out.
 struct Setting<Value> {
     let section: String
     let key: String
     let defaultValue: Value
     let suppressible: Bool
     let writer: (String, String, Value) -> Void
-    let onSet: ((Value) -> Void)?
+    let onSet: (@MainActor (Value) -> Void)?
 
     init(section: String,
          key: String,
          default defaultValue: Value,
          suppressible: Bool = true,
+         bootOnly: Bool = false,
          writer: @escaping (String, String, Value) -> Void,
-         onSet: ((Value) -> Void)? = nil) {
+         onSet: (@MainActor (Value) -> Void)? = nil) {
         self.section = section
         self.key = key
         self.defaultValue = defaultValue
         self.suppressible = suppressible
         self.writer = writer
-        self.onSet = onSet
+        if let onSet {
+            self.onSet = onSet
+        } else if section == "EmuCore/GS" && !bootOnly {
+            // Resolved when the closure runs, never here -- touching
+            // SettingsStore.shared during init re-enters its swift_once.
+            self.onSet = { _ in SettingsStore.shared.requestGraphicsApplyGuarded() }
+        } else {
+            self.onSet = nil
+        }
     }
 }

--- a/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
@@ -138,7 +138,8 @@ final class SettingsStore {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.12, execute: workItem)
     }
 
-    /// Used by the graphics `Setting<T>` onSet closures. Swift skips property
+    /// Used by every graphics writer: the `Setting<T>` onSet closures, the few
+    /// keys written from a plain `didSet`, and `setGSBoolHack`. Swift skips property
     /// observers during init, so they don't fire while loading from the INI;
     /// this no-ops while `suppressINIWrites` is true as a guard against that
     /// ever changing.
@@ -469,6 +470,7 @@ final class SettingsStore {
             guard !suppressINIWrites else { return }
             ARMSX2Bridge.setINIFloat("EmuCore/GS", key: "FramerateNTSC", value: ntscFramerate)
             applyFrameLimiterSettings()
+            requestGraphicsApplyGuarded()
         }
     }
     let _palFramerateConfig = Setting<Float>(
@@ -644,9 +646,13 @@ final class SettingsStore {
         ARMSX2Bridge.isMetalFXSupported()
     }
 
+    // Boot-only on purpose: a live switch is a restart option, so applying it
+    // would send GSUpdateConfig down GSreopen and tear the Metal device down
+    // under the running game. The picker says "Requires restart".
     let _rendererConfig = Setting<Int>(
         section: "EmuCore/GS", key: "Renderer", default: 17,
         suppressible: false,
+        bootOnly: true,
         writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(v)) })
     var renderer: Int = 17 { didSet {
         guard !(_rendererConfig.suppressible && suppressINIWrites) else { return }
@@ -656,8 +662,7 @@ final class SettingsStore {
     let _upscaleMultiplierConfig = Setting<Float>(
         section: "EmuCore/GS", key: "upscale_multiplier", default: 1.0,
         suppressible: false,
-        writer: ARMSX2Bridge.setINIFloat,
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: ARMSX2Bridge.setINIFloat)
     var upscaleMultiplier: Float = 1.0 { didSet {
         guard !(_upscaleMultiplierConfig.suppressible && suppressINIWrites) else { return }
         _upscaleMultiplierConfig.writer(_upscaleMultiplierConfig.section, _upscaleMultiplierConfig.key, upscaleMultiplier)
@@ -676,8 +681,7 @@ final class SettingsStore {
     let _textureFilteringConfig = Setting<Int>(
         section: "EmuCore/GS", key: "filter", default: 2,
         suppressible: false,
-        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(v)) },
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(v)) })
     var textureFiltering: Int = 2 { didSet {
         guard !(_textureFilteringConfig.suppressible && suppressINIWrites) else { return }
         _textureFilteringConfig.writer(_textureFilteringConfig.section, _textureFilteringConfig.key, textureFiltering)
@@ -686,8 +690,7 @@ final class SettingsStore {
     let _backThreadModeConfig = Setting<Int>(
         section: "EmuCore/GS", key: "GSBackThreadMode", default: 0,
         suppressible: false,
-        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(v)) },
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(v)) })
     var backThreadMode: Int = 0 { didSet {
         guard !(_backThreadModeConfig.suppressible && suppressINIWrites) else { return }
         _backThreadModeConfig.writer(_backThreadModeConfig.section, _backThreadModeConfig.key, backThreadMode)
@@ -705,8 +708,7 @@ final class SettingsStore {
     let _fxaaConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "fxaa", default: false,
         suppressible: false,
-        writer: ARMSX2Bridge.setINIBool,
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: ARMSX2Bridge.setINIBool)
     var fxaa: Bool = false { didSet {
         guard !(_fxaaConfig.suppressible && suppressINIWrites) else { return }
         _fxaaConfig.writer(_fxaaConfig.section, _fxaaConfig.key, fxaa)
@@ -715,8 +717,7 @@ final class SettingsStore {
     let _casModeConfig = Setting<Int>(
         section: "EmuCore/GS", key: "CASMode", default: 0,
         suppressible: false,
-        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(v)) },
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(v)) })
     var casMode: Int = 0 { didSet {
         guard !(_casModeConfig.suppressible && suppressINIWrites) else { return }
         _casModeConfig.writer(_casModeConfig.section, _casModeConfig.key, casMode)
@@ -725,8 +726,7 @@ final class SettingsStore {
     let _casSharpnessConfig = Setting<Int>(
         section: "EmuCore/GS", key: "CASSharpness", default: 50,
         suppressible: false,
-        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(v)) },
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(v)) })
     var casSharpness: Int = 50 { didSet {
         guard !(_casSharpnessConfig.suppressible && suppressINIWrites) else { return }
         _casSharpnessConfig.writer(_casSharpnessConfig.section, _casSharpnessConfig.key, casSharpness)
@@ -735,8 +735,7 @@ final class SettingsStore {
     let _interlaceModeConfig = Setting<Int>(
         section: "EmuCore/GS", key: "deinterlace_mode", default: 7,
         suppressible: false,
-        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(v)) },
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(v)) })
     var interlaceMode: Int = 7 { didSet {
         guard !(_interlaceModeConfig.suppressible && suppressINIWrites) else { return }
         _interlaceModeConfig.writer(_interlaceModeConfig.section, _interlaceModeConfig.key, interlaceMode)
@@ -745,8 +744,7 @@ final class SettingsStore {
     let _aspectRatioConfig = Setting<Int>(
         section: "EmuCore/GS", key: "AspectRatio", default: 1,
         suppressible: false,
-        writer: { s, k, v in ARMSX2Bridge.setINIString(s, key: k, value: SettingsStore.aspectRatioName(for: v)) },
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: { s, k, v in ARMSX2Bridge.setINIString(s, key: k, value: SettingsStore.aspectRatioName(for: v)) })
     var aspectRatio: Int = 1 { didSet {
         guard !(_aspectRatioConfig.suppressible && suppressINIWrites) else { return }
         _aspectRatioConfig.writer(_aspectRatioConfig.section, _aspectRatioConfig.key, aspectRatio)
@@ -773,8 +771,7 @@ final class SettingsStore {
     let _trilinearFilteringConfig = Setting<Int>(
         section: "EmuCore/GS", key: "TriFilter", default: -1,
         suppressible: false,
-        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(v)) },
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(v)) })
     var trilinearFiltering: Int = -1 { didSet {
         guard !(_trilinearFilteringConfig.suppressible && suppressINIWrites) else { return }
         _trilinearFilteringConfig.writer(_trilinearFilteringConfig.section, _trilinearFilteringConfig.key, trilinearFiltering)
@@ -834,6 +831,7 @@ final class SettingsStore {
                 return
             }
             ARMSX2Bridge.setINIInt("EmuCore/GS", key: "UserHacks_TCOffsetX", value: Int32(textureOffsetX))
+            requestGraphicsApplyGuarded()
         }
     }
     // clamps to -4096...4096
@@ -845,6 +843,7 @@ final class SettingsStore {
                 return
             }
             ARMSX2Bridge.setINIInt("EmuCore/GS", key: "UserHacks_TCOffsetY", value: Int32(textureOffsetY))
+            requestGraphicsApplyGuarded()
         }
     }
     // clamps to 0...5000
@@ -856,6 +855,7 @@ final class SettingsStore {
                 return
             }
             ARMSX2Bridge.setINIInt("EmuCore/GS", key: "UserHacks_SkipDraw_Start", value: Int32(skipDrawStart))
+            requestGraphicsApplyGuarded()
         }
     }
     // clamps to 0...5000
@@ -867,6 +867,7 @@ final class SettingsStore {
                 return
             }
             ARMSX2Bridge.setINIInt("EmuCore/GS", key: "UserHacks_SkipDraw_End", value: Int32(skipDrawEnd))
+            requestGraphicsApplyGuarded()
         }
     }
     let _loadTextureReplacementsConfig = Setting<Bool>(
@@ -1039,8 +1040,7 @@ final class SettingsStore {
     let _maxAnisotropyConfig = Setting<Int>(
         section: "EmuCore/GS", key: "MaxAnisotropy", default: 0,
         suppressible: false,
-        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(SettingsStore.clamped(v, to: 0...16))) },
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(SettingsStore.clamped(v, to: 0...16))) })
     var maxAnisotropy: Int = 0 { didSet {
         guard !(_maxAnisotropyConfig.suppressible && suppressINIWrites) else { return }
         _maxAnisotropyConfig.writer(_maxAnisotropyConfig.section, _maxAnisotropyConfig.key, maxAnisotropy)
@@ -1058,8 +1058,7 @@ final class SettingsStore {
     let _tvShaderConfig = Setting<Int>(
         section: "EmuCore/GS", key: "TVShader", default: 0,
         suppressible: false,
-        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(SettingsStore.clamped(v, to: 0...7))) },
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(SettingsStore.clamped(v, to: 0...7))) })
     var tvShader: Int = 0 { didSet {
         guard !(_tvShaderConfig.suppressible && suppressINIWrites) else { return }
         _tvShaderConfig.writer(_tvShaderConfig.section, _tvShaderConfig.key, tvShader)
@@ -1070,8 +1069,7 @@ final class SettingsStore {
     let _upscalerConfig = Setting<Int>(
         section: "EmuCore/GS", key: "Upscaler", default: 0,
         suppressible: false,
-        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(v)) },
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(v)) })
     var upscaler: Int = 0 { didSet {
         guard !(_upscalerConfig.suppressible && suppressINIWrites) else { return }
         _upscalerConfig.writer(_upscalerConfig.section, _upscalerConfig.key, upscaler)
@@ -1085,10 +1083,14 @@ final class SettingsStore {
         gsBoolHacks[key] ?? false
     }
 
+    /// The single write funnel for those hacks. They live in a dictionary rather
+    /// than a Setting<T>, so the default EmuCore/GS apply hook cannot reach them;
+    /// this is their equivalent. Everything that changes one goes through here.
     func setGSBoolHack(_ key: String, _ value: Bool) {
         gsBoolHacks[key] = value
         guard !suppressINIWrites else { return }
         ARMSX2Bridge.setINIBool("EmuCore/GS", key: key, value: value)
+        requestGraphicsApplyGuarded()
     }
 
     private static func loadGSBoolHacks() -> [String: Bool] {
@@ -1103,8 +1105,7 @@ final class SettingsStore {
     let _pcrtcOffsetsConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "pcrtc_offsets", default: false,
         suppressible: false,
-        writer: ARMSX2Bridge.setINIBool,
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: ARMSX2Bridge.setINIBool)
     var pcrtcOffsets: Bool = false { didSet {
         guard !(_pcrtcOffsetsConfig.suppressible && suppressINIWrites) else { return }
         _pcrtcOffsetsConfig.writer(_pcrtcOffsetsConfig.section, _pcrtcOffsetsConfig.key, pcrtcOffsets)
@@ -1113,8 +1114,7 @@ final class SettingsStore {
     let _pcrtcOverscanConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "pcrtc_overscan", default: false,
         suppressible: false,
-        writer: ARMSX2Bridge.setINIBool,
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: ARMSX2Bridge.setINIBool)
     var pcrtcOverscan: Bool = false { didSet {
         guard !(_pcrtcOverscanConfig.suppressible && suppressINIWrites) else { return }
         _pcrtcOverscanConfig.writer(_pcrtcOverscanConfig.section, _pcrtcOverscanConfig.key, pcrtcOverscan)
@@ -1123,8 +1123,7 @@ final class SettingsStore {
     let _pcrtcAntiBlurConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "pcrtc_antiblur", default: true,
         suppressible: false,
-        writer: ARMSX2Bridge.setINIBool,
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: ARMSX2Bridge.setINIBool)
     var pcrtcAntiBlur: Bool = true { didSet {
         guard !(_pcrtcAntiBlurConfig.suppressible && suppressINIWrites) else { return }
         _pcrtcAntiBlurConfig.writer(_pcrtcAntiBlurConfig.section, _pcrtcAntiBlurConfig.key, pcrtcAntiBlur)
@@ -1133,8 +1132,7 @@ final class SettingsStore {
     let _disableInterlaceOffsetConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "disable_interlace_offset", default: false,
         suppressible: false,
-        writer: ARMSX2Bridge.setINIBool,
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: ARMSX2Bridge.setINIBool)
     var disableInterlaceOffset: Bool = false { didSet {
         guard !(_disableInterlaceOffsetConfig.suppressible && suppressINIWrites) else { return }
         _disableInterlaceOffsetConfig.writer(_disableInterlaceOffsetConfig.section, _disableInterlaceOffsetConfig.key, disableInterlaceOffset)
@@ -1143,8 +1141,7 @@ final class SettingsStore {
     let _skipDuplicateFramesConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "SkipDuplicateFrames", default: true,
         suppressible: false,
-        writer: ARMSX2Bridge.setINIBool,
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: ARMSX2Bridge.setINIBool)
     var skipDuplicateFrames: Bool = true { didSet {
         guard !(_skipDuplicateFramesConfig.suppressible && suppressINIWrites) else { return }
         _skipDuplicateFramesConfig.writer(_skipDuplicateFramesConfig.section, _skipDuplicateFramesConfig.key, skipDuplicateFrames)
@@ -1163,8 +1160,7 @@ final class SettingsStore {
     let _integerScalingConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "IntegerScaling", default: false,
         suppressible: false,
-        writer: ARMSX2Bridge.setINIBool,
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: ARMSX2Bridge.setINIBool)
     var integerScaling: Bool = false { didSet {
         guard !(_integerScalingConfig.suppressible && suppressINIWrites) else { return }
         _integerScalingConfig.writer(_integerScalingConfig.section, _integerScalingConfig.key, integerScaling)
@@ -1175,8 +1171,7 @@ final class SettingsStore {
     let _shadeBoostConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "ShadeBoost", default: false,
         suppressible: false,
-        writer: ARMSX2Bridge.setINIBool,
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: ARMSX2Bridge.setINIBool)
     var shadeBoost: Bool = false { didSet {
         guard !(_shadeBoostConfig.suppressible && suppressINIWrites) else { return }
         _shadeBoostConfig.writer(_shadeBoostConfig.section, _shadeBoostConfig.key, shadeBoost)
@@ -1185,8 +1180,7 @@ final class SettingsStore {
     let _shadeBoostBrightnessConfig = Setting<Int>(
         section: "EmuCore/GS", key: "ShadeBoost_Brightness", default: 50,
         suppressible: false,
-        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(SettingsStore.clamped(v, to: 1...100))) },
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(SettingsStore.clamped(v, to: 1...100))) })
     var shadeBoostBrightness: Int = 50 { didSet {
         guard !(_shadeBoostBrightnessConfig.suppressible && suppressINIWrites) else { return }
         _shadeBoostBrightnessConfig.writer(_shadeBoostBrightnessConfig.section, _shadeBoostBrightnessConfig.key, shadeBoostBrightness)
@@ -1195,8 +1189,7 @@ final class SettingsStore {
     let _shadeBoostContrastConfig = Setting<Int>(
         section: "EmuCore/GS", key: "ShadeBoost_Contrast", default: 50,
         suppressible: false,
-        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(SettingsStore.clamped(v, to: 1...100))) },
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(SettingsStore.clamped(v, to: 1...100))) })
     var shadeBoostContrast: Int = 50 { didSet {
         guard !(_shadeBoostContrastConfig.suppressible && suppressINIWrites) else { return }
         _shadeBoostContrastConfig.writer(_shadeBoostContrastConfig.section, _shadeBoostContrastConfig.key, shadeBoostContrast)
@@ -1205,8 +1198,7 @@ final class SettingsStore {
     let _shadeBoostSaturationConfig = Setting<Int>(
         section: "EmuCore/GS", key: "ShadeBoost_Saturation", default: 50,
         suppressible: false,
-        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(SettingsStore.clamped(v, to: 1...100))) },
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(SettingsStore.clamped(v, to: 1...100))) })
     var shadeBoostSaturation: Int = 50 { didSet {
         guard !(_shadeBoostSaturationConfig.suppressible && suppressINIWrites) else { return }
         _shadeBoostSaturationConfig.writer(_shadeBoostSaturationConfig.section, _shadeBoostSaturationConfig.key, shadeBoostSaturation)
@@ -1215,8 +1207,7 @@ final class SettingsStore {
     let _shadeBoostGammaConfig = Setting<Int>(
         section: "EmuCore/GS", key: "ShadeBoost_Gamma", default: 50,
         suppressible: false,
-        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(SettingsStore.clamped(v, to: 1...100))) },
-        onSet: { _ in SettingsStore.shared.requestGraphicsApplyGuarded() })
+        writer: { s, k, v in ARMSX2Bridge.setINIInt(s, key: k, value: Int32(SettingsStore.clamped(v, to: 1...100))) })
     var shadeBoostGamma: Int = 50 { didSet {
         guard !(_shadeBoostGammaConfig.suppressible && suppressINIWrites) else { return }
         _shadeBoostGammaConfig.writer(_shadeBoostGammaConfig.section, _shadeBoostGammaConfig.key, shadeBoostGamma)
@@ -2695,8 +2686,7 @@ final class SettingsStore {
         tvShader = 0
         upscaler = 0
         for option in Self.gsBoolHackOptions {
-            gsBoolHacks[option.key] = false
-            ARMSX2Bridge.setINIBool("EmuCore/GS", key: option.key, value: false)
+            setGSBoolHack(option.key, false)
         }
         // Screen / PCRTC and Shade Boost
         pcrtcOffsets = false

--- a/platforms/ios/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
@@ -5,9 +5,17 @@ import SwiftUI
 
 struct GraphicsSettingsView: View {
     @State private var settings = SettingsStore.shared
+    @State private var appState = AppState.shared
     @State private var showShaderCacheClearConfirm = false
     @State private var shaderCacheResult: String?
     @State private var showShaderCacheResult = false
+
+    // Returning to the menu only pauses the VM, so a game can still be loaded
+    // while this screen is open. Switching renderer then sends the next settings
+    // apply through a full GS teardown under that game.
+    private var gameIsLoaded: Bool {
+        appState.runningGameName != nil
+    }
 
     private var manualAdvancedHacks: Bool {
         !settings.enableGameDBHardwareFixes
@@ -59,6 +67,12 @@ struct GraphicsSettingsView: View {
                     Text(settings.localized("Software")).tag(13)
                     Text(settings.localized("Null (No Output)")).tag(11)
 #endif
+                }
+                .disabled(gameIsLoaded)
+                if gameIsLoaded {
+                    Text(settings.localized("Close the running game to change the renderer."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 #if targetEnvironment(macCatalyst)
                 Text(settings.localized("Metal is required for the Mac Catalyst build. Requires restart."))

--- a/platforms/ios/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
@@ -243,6 +243,13 @@ struct GraphicsSettingsView: View {
                 Text(settings.localized("GameDB Graphics Fixes are safest for most games. Manual Advanced Hacks disable those automatic graphics fixes and allow the sprite, texture-offset, and Skipdraw values below. Reset/relaunch may be needed."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                // MaskUpscalingHacks() zeroes these unless the multiplier is above 1, so the
+                // toggles read on and do nothing.
+                if settings.upscaleMultiplier <= 1.0 {
+                    Text(settings.localized("Half-pixel Offset, Round Sprite, Align Sprite, Merge Sprite, Wild Arms Offset and the texture offsets only apply above 1x Internal Resolution. At 1x or below they are ignored."))
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
 
                 Picker(settings.localized("Trilinear Filtering"), selection: $settings.trilinearFiltering) {
                     Text(settings.localized("Automatic / Default")).tag(-1)
@@ -288,7 +295,7 @@ struct GraphicsSettingsView: View {
 
                 ClampedIntField(title: settings.localized("Skipdraw Start"), value: skipDrawStartBinding, range: SettingsStore.skipDrawRange, isEnabled: manualAdvancedHacks)
                 ClampedIntField(title: settings.localized("Skipdraw End"), value: skipDrawEndBinding, range: SettingsStore.skipDrawRange, isEnabled: manualAdvancedHacks)
-                Text(settings.localized("For Skipdraw 1, use Start 1 and End 1. Changes apply after reset/relaunch."))
+                Text(settings.localized("For Skipdraw 1, use Start 1 and End 1. Applies immediately."))
                     .font(.caption)
                     .foregroundStyle(.orange)
             }

--- a/platforms/ios/scripts/tests/test_ios_metal_barriers.py
+++ b/platforms/ios/scripts/tests/test_ios_metal_barriers.py
@@ -2,13 +2,15 @@ import unittest
 from pathlib import Path
 
 
-ROOT = Path(__file__).resolve().parents[2]
+# Repo root. The Metal renderer used to be vendored under platforms/ios; it is
+# shared core now, so everything below is relative to the top of the tree.
+ROOT = Path(__file__).resolve().parents[4]
 
 
 class IOSMetalBarrierTests(unittest.TestCase):
     def test_ios_does_not_advertise_unsupported_texture_barriers(self):
         implementation = (
-            ROOT / "app/src/main/cpp/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm"
+            ROOT / "pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm"
         ).read_text(encoding="utf-8")
 
         self.assertRegex(

--- a/platforms/ios/scripts/tests/test_ios_true_crime.py
+++ b/platforms/ios/scripts/tests/test_ios_true_crime.py
@@ -3,7 +3,9 @@ import unittest
 from pathlib import Path
 
 
-ROOT = Path(__file__).resolve().parents[2]
+# Repo root. This fix used to live in an iOS-only copy of GameIndex.yaml; our
+# GameDB changes go in the overlay now, which is merged over upstream's.
+ROOT = Path(__file__).resolve().parents[4]
 
 
 class TrueCrimeGameDBTests(unittest.TestCase):
@@ -18,7 +20,7 @@ class TrueCrimeGameDBTests(unittest.TestCase):
 
     def test_all_new_york_city_entries_disable_vu_flag_hack(self):
         game_index = (
-            ROOT / "app/src/main/assets/resources/GameIndex.yaml"
+            ROOT / "bin/resources-overlay/armsx2_overrides.yaml"
         ).read_text(encoding="utf-8")
 
         for serial in self.SERIALS:


### PR DESCRIPTION
## Graphics settings didn't take effect until you restarted

Someone reported that turning on Align Sprite or Merge Sprite sticks — you turn it back off and the picture stays the same. That's real, and it wasn't just those two.

A graphics setting only reached the running game if it had been individually wired up to say so, and most never were. The value saved correctly, the UI read it back correctly, and nothing ever told the emulator. 33 settings were in that state: the sprite hacks, half-pixel offset, round sprite, native scaling, blending accuracy, dithering, texture-inside-RT, the CPU sprite and CLUT hacks, and the whole "hardware fixes" list (GPU palette conversion, CPU framebuffer conversion, disable depth emulation, draw buffering and the rest). All of them only kicked in once you changed some *other* setting that happened to be wired up, or rebooted the game.

The handful that were wired up weren't really working either. They were being applied in a way that made the renderer think nothing had changed, so it skipped the cleanup that's supposed to go with them — texture cache purges being the main one. Hardware mipmapping and texture preloading both did this, and the GPU stat in the OSD was switched on without ever starting the timer behind it.

Rather than add the missing settings to a list — the list is what rotted, since every new setting quietly joined the broken side — graphics settings now get this behaviour by default. A new one can't be added in the broken state.

Two things deliberately left as they were:

- **Renderer still needs a restart.** Applying it live tears down the graphics device underneath a running game. It already said "Requires restart"; it now also greys out while a game is loaded, because returning to the menu only pauses the game rather than closing it, so you could previously change it with one still loaded.
- **Native scaling now clears the texture cache when you change it.** It's the one of these that leaves a lasting mark — it swaps in a downscaled copy of what's being drawn, and those stayed downscaled after switching it off. That's the original "it stays that way" complaint, one layer down. The other sprite hacks only affect the frame being drawn, so they don't need it.

Also worth knowing: several of these hacks do nothing below 2x resolution — the emulator ignores them there. The UI didn't mention it, so they'd read as on and do nothing. It says so now. The Skipdraw help text claimed its changes need a reset; they don't.

## Two guard tests had quietly died

`test_ios_metal_barriers.py` and `test_ios_true_crime.py` have been failing to even open their files since the iOS frontend moved onto the shared core — both still looked for things under the old iOS-only paths. A test that errors out reads as passing coverage when you glance at it, which is worse than not having it.

Repointing the second one turned up a real regression. It checks that True Crime: New York City has the VU flag hack disabled, which fixes texture flickering in that game. That fix is gone. The iOS build used to ship its own copy of the game database with it, and when that was merged into the shared one, only part of the entry came across — the flag-hack line was dropped. It's been missing ever since, and the test that would have caught it broke in the same change, so nobody saw it. Restored.

## Testing

Device build clean. Both guard tests pass again. Not yet watched on device — the settings that changed most are the OSD presets and the performance overlay toggle.