### PR TITLE
iOS: fix the skin downloader and give the browser a proper set of states

### DIFF
--- a/platforms/ios/app/src/main/swift/Models/InitialContentBootstrap.swift
+++ b/platforms/ios/app/src/main/swift/Models/InitialContentBootstrap.swift
@@ -179,7 +179,7 @@ final class InitialContentBootstrap {
 
         configureDefaultBIOS()
         let appliedPresets = applyPresetFiles(named: preparation.presetNames)
-        let skinImport = importSkinArchives(preparation.skinArchives)
+        let skinImport = await importSkinArchives(preparation.skinArchives)
         NotificationCenter.default.post(name: Self.didChangeNotification, object: nil)
 
         let gameImport = await Task.detached(priority: .utility) {
@@ -261,7 +261,7 @@ final class InitialContentBootstrap {
         return applied
     }
 
-    private func importSkinArchives(_ sourceURLs: [URL]) -> InitialSkinImportResult {
+    private func importSkinArchives(_ sourceURLs: [URL]) async -> InitialSkinImportResult {
         let skinLibrary = VPadSkinLibraryStore.shared
         let layoutPresets = PadLayoutPresetStore.shared
         var result = InitialSkinImportResult()
@@ -280,7 +280,7 @@ final class InitialContentBootstrap {
                 result.skipped += 1
             } else {
                 do {
-                    let importResult = try skinLibrary.importSkinArchive(
+                    let importResult = try await skinLibrary.importSkinArchive(
                         from: sourceURL,
                         layoutPresets: layoutPresets
                     )

--- a/platforms/ios/app/src/main/swift/Models/PadLayoutPresetStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/PadLayoutPresetStore.swift
@@ -374,6 +374,33 @@ final class PadLayoutPresetStore: @unchecked Sendable {
         persist()
     }
 
+    /// Reinstalling a skin mints a new id, so per-game picks have to follow it
+    /// across instead of being cleared.
+    func repointSkinAssignments(from oldID: String, to newID: String) {
+        gameAssignments = gameAssignments.compactMapValues { assignment in
+            var updated = assignment
+            if updated.skinID == oldID {
+                updated.skinID = newID
+            }
+            return updated.isEmpty ? nil : updated
+        }
+        persist()
+    }
+
+    func repointLayoutPresetAssignments(from oldID: String, to newID: String) {
+        if globalPresetID == oldID {
+            globalPresetID = newID
+        }
+        gameAssignments = gameAssignments.compactMapValues { assignment in
+            var updated = assignment
+            if updated.layoutPresetID == oldID {
+                updated.layoutPresetID = newID
+            }
+            return updated.isEmpty ? nil : updated
+        }
+        persist()
+    }
+
     func clearVPadOverrides(for identity: PadLayoutGameIdentity) {
         gameAssignments.removeValue(forKey: identity.id)
         persist()

--- a/platforms/ios/app/src/main/swift/Models/SkinCatalog.swift
+++ b/platforms/ios/app/src/main/swift/Models/SkinCatalog.swift
@@ -34,8 +34,7 @@ enum SkinCatalogError: LocalizedError {
     }
 }
 
-/// Fetches the community skin catalog (manifest.json) from the ARMSX2 skins repo
-/// and filters to iOS-ready skins (those with an `iosLayout` field).
+/// Fetches the community skin catalog (manifest.json) from the ARMSX2 skins repo.
 @MainActor
 final class SkinCatalog: ObservableObject {
     static let repo = "bagasromadon/ARMSX2-CustomControllerSkins"
@@ -44,32 +43,62 @@ final class SkinCatalog: ObservableObject {
 
     @Published private(set) var skins: [CatalogSkin] = []
     @Published private(set) var isLoading = false
+    @Published private(set) var lastUpdated: Date?
     @Published var lastError: String?
 
-    func fetch() async {
+    private var inFlight: Task<Void, Never>?
+
+    func fetch(force: Bool = false) async {
+        inFlight?.cancel()
+        let task = Task { await self.load(force: force) }
+        inFlight = task
+        await task.value
+        // Only the newest fetch owns the spinner; a superseded one leaves it be.
+        if inFlight == task {
+            inFlight = nil
+            isLoading = false
+        }
+    }
+
+    private func load(force: Bool) async {
         isLoading = true
         lastError = nil
         do {
-            let (data, response) = try await URLSession.shared.data(from: Self.manifestURL)
+            var request = URLRequest(url: Self.manifestURL)
+            // raw.githubusercontent.com serves max-age=300, so an ordinary
+            // refresh inside that window never leaves the URL cache and newly
+            // published skins stay invisible for five minutes.
+            if force {
+                request.cachePolicy = .reloadIgnoringLocalCacheData
+            }
+            let (data, response) = try await URLSession.shared.data(for: request)
             if let http = response as? HTTPURLResponse, http.statusCode != 200 {
                 throw URLError(.badServerResponse)
             }
             let manifest = try JSONDecoder().decode(SkinCatalogManifest.self, from: data)
-            skins = manifest.skins.filter { $0.isIOSReady }
+            guard !Task.isCancelled else { return }
+            skins = manifest.skins
+            lastUpdated = Date()
         } catch {
+            guard !Task.isCancelled else { return }
             lastError = error.localizedDescription
         }
-        isLoading = false
     }
 
-    func zipURL(for skin: CatalogSkin) -> URL {
-        let encoded = skin.file.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? skin.file
-        return URL(string: "\(Self.rawBase)/\(encoded)")!
+    static func zipURL(for skin: CatalogSkin) -> URL? {
+        assetURL(skin.file)
     }
 
-    func previewURL(for skin: CatalogSkin) -> URL? {
+    static func previewURL(for skin: CatalogSkin) -> URL? {
         guard let preview = skin.preview else { return nil }
-        let encoded = preview.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? preview
-        return URL(string: "\(Self.rawBase)/\(encoded)")
+        return assetURL(preview)
+    }
+
+    /// `..` and `/` both survive percent-encoding for `.urlPathAllowed`, so a
+    /// hostile manifest entry could otherwise walk the path off the repo.
+    private static func assetURL(_ path: String) -> URL? {
+        guard SkinAssetPath.isSafeRelative(path) else { return nil }
+        let encoded = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? path
+        return URL(string: "\(rawBase)/\(encoded)")
     }
 }

--- a/platforms/ios/app/src/main/swift/Models/SkinInstaller.swift
+++ b/platforms/ios/app/src/main/swift/Models/SkinInstaller.swift
@@ -39,10 +39,6 @@ final class SkinInstaller: ObservableObject {
         await install(skin, replacing: installedDescriptor(for: skin)?.id)
     }
 
-    func isInstalled(_ skin: CatalogSkin) -> Bool {
-        installedDescriptor(for: skin) != nil
-    }
-
     func uninstall(_ skin: CatalogSkin) {
         errors[skin.file] = nil
         guard let descriptor = installedDescriptor(for: skin) else { return }

--- a/platforms/ios/app/src/main/swift/Models/SkinInstaller.swift
+++ b/platforms/ios/app/src/main/swift/Models/SkinInstaller.swift
@@ -3,34 +3,84 @@
 
 import Foundation
 
+enum SkinInstallError: LocalizedError {
+    case unusableLink
+    case tooLarge
+    case emptyArchive
+
+    var errorDescription: String? {
+        switch self {
+        case .unusableLink:
+            return "This skin's download link is not usable."
+        case .tooLarge:
+            return "This skin is too large to install."
+        case .emptyArchive:
+            return "The download did not contain any usable skin files."
+        }
+    }
+}
+
 /// Downloads a skin zip from the catalog repo, extracts it via the bridge, and
 /// installs through VPadSkinLibraryStore.importSkin(from: directoryURL).
 @MainActor
 final class SkinInstaller: ObservableObject {
-    @Published private(set) var installingName: String?
+    /// Keyed by the catalog file path, so two taps on different rows do not
+    /// knock each other's spinner out.
+    @Published private(set) var installing: Set<String> = []
     @Published var errors: [String: String] = [:]
 
-    let catalog: SkinCatalog
-
-    init(catalog: SkinCatalog) {
-        self.catalog = catalog
-    }
+    private static let maxDownloadBytes: Int64 = 32 * 1024 * 1024
 
     func install(_ skin: CatalogSkin) async {
-        installingName = skin.name
-        errors[skin.name] = nil
+        await install(skin, replacing: nil)
+    }
+
+    func reinstall(_ skin: CatalogSkin) async {
+        await install(skin, replacing: installedDescriptor(for: skin)?.id)
+    }
+
+    func isInstalled(_ skin: CatalogSkin) -> Bool {
+        installedDescriptor(for: skin) != nil
+    }
+
+    func uninstall(_ skin: CatalogSkin) {
+        errors[skin.file] = nil
+        guard let descriptor = installedDescriptor(for: skin) else { return }
         do {
-            let zipURL = catalog.zipURL(for: skin)
+            try VPadSkinLibraryStore.shared.deleteImportedSkin(id: descriptor.id)
+            syncSelectedSkin()
+        } catch {
+            errors[skin.file] = error.localizedDescription
+        }
+    }
+
+    private func install(_ skin: CatalogSkin, replacing replacingSkinID: String?) async {
+        installing.insert(skin.file)
+        errors[skin.file] = nil
+        do {
+            guard let zipURL = SkinCatalog.zipURL(for: skin) else {
+                throw SkinInstallError.unusableLink
+            }
             let (tempURL, response) = try await URLSession.shared.download(from: zipURL)
             if let http = response as? HTTPURLResponse, http.statusCode != 200 {
                 throw URLError(.badServerResponse)
             }
 
-            // Give the temp file a .zip name so the bridge recognises it.
+            // Give the temp file a .zip name so the bridge recognises it. The
+            // name is remote-supplied and lands in a path component, so it stays
+            // out of this.
             let zipFile = FileManager.default.temporaryDirectory
-                .appendingPathComponent("\(skin.name)-\(UUID().uuidString).zip")
+                .appendingPathComponent("skin-download-\(UUID().uuidString).zip")
             try FileManager.default.moveItem(at: tempURL, to: zipFile)
             defer { try? FileManager.default.removeItem(at: zipFile) }
+
+            // This bounds what gets imported, not what the transfer already wrote
+            // to disk — capping mid-transfer needs a URLSessionDownloadDelegate.
+            // The largest legitimate catalog zip is a little over 3 MB.
+            let size = ((try? FileManager.default.attributesOfItem(atPath: zipFile.path))?[.size] as? NSNumber)?.int64Value ?? 0
+            guard size <= Self.maxDownloadBytes else {
+                throw SkinInstallError.tooLarge
+            }
 
             // Extract the zip to a temp directory — importSkin expects a
             // directory of loose files, not a raw zip archive.
@@ -41,28 +91,31 @@ final class SkinInstaller: ObservableObject {
 
             let extracted = ARMSX2Bridge.extractControllerSkinArchive(at: zipFile, to: extractDir)
             guard !extracted.isEmpty else {
-                throw URLError(.cannotDecodeContentData)
+                throw SkinInstallError.emptyArchive
             }
 
             _ = try await VPadSkinLibraryStore.shared.importSkin(
                 from: extractDir,
                 originalImportName: skin.name,
                 catalogID: skin.file,
+                replacingSkinID: replacingSkinID,
                 layoutPresets: .shared
             )
+            syncSelectedSkin()
         } catch {
-            errors[skin.name] = error.localizedDescription
+            errors[skin.file] = error.localizedDescription
         }
-        installingName = nil
+        installing.remove(skin.file)
     }
 
-    func isInstalled(_ skin: CatalogSkin) -> Bool {
-        VPadSkinLibraryStore.shared.importedDescriptors.contains { $0.displayName == skin.name }
+    private func installedDescriptor(for skin: CatalogSkin) -> VPadSkinDescriptor? {
+        VPadSkinLibraryStore.shared.importedDescriptors.first { $0.catalogID == skin.file }
     }
 
-    func uninstall(_ skin: CatalogSkin) {
-        guard let descriptor = VPadSkinLibraryStore.shared.importedDescriptors
-            .first(where: { $0.displayName == skin.name }) else { return }
-        try? VPadSkinLibraryStore.shared.deleteImportedSkin(id: descriptor.id)
+    /// The library resets a dangling selection on its own, but nothing keeps
+    /// SettingsStore's mirror in step — and a stale .custom there points the pad
+    /// at the old ControllerSkins/Custom folder instead of the stock art.
+    private func syncSelectedSkin() {
+        SettingsStore.shared.virtualPadSkin = VPadSkinLibraryStore.shared.selectedDescriptor.virtualPadSkin
     }
 }

--- a/platforms/ios/app/src/main/swift/Models/SkinInstaller.swift
+++ b/platforms/ios/app/src/main/swift/Models/SkinInstaller.swift
@@ -44,9 +44,10 @@ final class SkinInstaller: ObservableObject {
                 throw URLError(.cannotDecodeContentData)
             }
 
-            _ = try VPadSkinLibraryStore.shared.importSkin(
+            _ = try await VPadSkinLibraryStore.shared.importSkin(
                 from: extractDir,
                 originalImportName: skin.name,
+                catalogID: skin.file,
                 layoutPresets: .shared
             )
         } catch {

--- a/platforms/ios/app/src/main/swift/Models/VPadSkinLibraryStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/VPadSkinLibraryStore.swift
@@ -19,6 +19,10 @@ struct VPadSkinDescriptor: Codable, Equatable, Identifiable {
     var manifestVersion: Int?
     var originalImportName: String?
     var builtInSkinRawValue: Int?
+    // Repo-relative zip path of the catalog entry this came from, nil for
+    // anything the user imported by hand. Must stay Optional: the library is
+    // decoded all-or-nothing and a required key would wipe every legacy entry.
+    var catalogID: String?
     var createdAt: Date
     var updatedAt: Date
 
@@ -31,6 +35,7 @@ struct VPadSkinDescriptor: Codable, Equatable, Identifiable {
         manifestVersion: Int? = nil,
         originalImportName: String? = nil,
         builtInSkinRawValue: Int? = nil,
+        catalogID: String? = nil,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
@@ -42,6 +47,7 @@ struct VPadSkinDescriptor: Codable, Equatable, Identifiable {
         self.manifestVersion = manifestVersion
         self.originalImportName = originalImportName
         self.builtInSkinRawValue = builtInSkinRawValue
+        self.catalogID = catalogID
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }
@@ -246,12 +252,80 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
     func importSkin(
         from sourceURL: URL,
         originalImportName: String? = nil,
+        catalogID: String? = nil,
+        replacingSkinID: String? = nil,
         layoutPresets: PadLayoutPresetStore
-    ) throws -> VPadSkinImportResult {
+    ) async throws -> VPadSkinImportResult {
+        // Import first, delete second. A failed download or a corrupt zip has to
+        // leave the skin the user already has alone.
+        let wasSelected = replacingSkinID != nil && selectedSkinID == replacingSkinID
+        let result = try await performImport(
+            from: sourceURL,
+            originalImportName: originalImportName,
+            catalogID: catalogID,
+            replacingSkinID: replacingSkinID,
+            layoutPresets: layoutPresets
+        )
+        if let replacingSkinID {
+            retireReplacedSkin(
+                id: replacingSkinID,
+                replacement: result.descriptor,
+                wasSelected: wasSelected,
+                layoutPresets: layoutPresets
+            )
+        }
+        return result
+    }
+
+    /// Drops the install a reinstall just superseded, carrying the user's
+    /// per-game picks and the active layout over to the new descriptor.
+    private func retireReplacedSkin(
+        id oldID: String,
+        replacement: VPadSkinDescriptor,
+        wasSelected: Bool,
+        layoutPresets: PadLayoutPresetStore
+    ) {
+        let old = importedDescriptors.first { $0.id == oldID }
+
+        // Ahead of the delete, which would otherwise clear these instead.
+        layoutPresets.repointSkinAssignments(from: oldID, to: replacement.id)
+        if let oldPresetID = old?.linkedLayoutPresetID,
+           let newPresetID = replacement.linkedLayoutPresetID {
+            layoutPresets.repointLayoutPresetAssignments(from: oldPresetID, to: newPresetID)
+        }
+
+        try? deleteImportedSkin(id: oldID, layoutPresets: layoutPresets)
+
+        // createPreset does not uniquify, so without this every reinstall of
+        // Black leaves another preset called "Black Layout" in the picker.
+        if let oldPresetID = old?.linkedLayoutPresetID,
+           let preset = layoutPresets.preset(id: oldPresetID),
+           preset.source == .futureImportedSkin,
+           preset.linkedSkinID == oldID {
+            try? layoutPresets.deletePreset(id: oldPresetID)
+        }
+
+        if wasSelected {
+            selectSkin(id: replacement.id)
+        }
+    }
+
+    private func performImport(
+        from sourceURL: URL,
+        originalImportName: String?,
+        catalogID: String?,
+        replacingSkinID: String?,
+        layoutPresets: PadLayoutPresetStore
+    ) async throws -> VPadSkinImportResult {
         // Additive v2 manifest detection. A package carrying a valid v2 manifest
         // (info.json or a v2 manifest.json) is imported as an advanced manifest
         // skin; everything else falls through to the legacy importer below.
-        switch importV2ManifestSkin(from: sourceURL, originalImportName: originalImportName) {
+        switch importV2ManifestSkin(
+            from: sourceURL,
+            originalImportName: originalImportName,
+            catalogID: catalogID,
+            replacingSkinID: replacingSkinID
+        ) {
         case .notV2:
             break
         case .imported(let outcome):
@@ -269,7 +343,7 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
                 fallback: "Imported Skin"
             )
         )
-        let displayName = uniqueDisplayName(baseName)
+        let displayName = uniqueDisplayName(baseName, ignoringSkinID: replacingSkinID)
         let id = "imported-\(UUID().uuidString)"
         let destinationFolder = id
         let destination = assetsRootURL.appendingPathComponent(destinationFolder, isDirectory: true)
@@ -278,33 +352,21 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
         let maxImageBytes: Int64 = 16 * 1024 * 1024
         let maxImportedImages: Int = 64
 
-        var importedImageCount = 0
-        var warnings: [String] = []
-        for fileURL in files where Self.isSupportedImageFile(fileURL) {
-            if importedImageCount >= maxImportedImages {
-                warnings.append("Skipped remaining images; the import limit was reached.")
-                break
-            }
-            guard let destinationName = Self.destinationSkinFileName(for: fileURL) else {
-                warnings.append("Skipped \(fileURL.lastPathComponent).")
-                continue
-            }
+        // A real skin is 18-21 PNGs, so decoding and re-encoding them inline
+        // stalls the pad settings screen for the whole install.
+        let decoded = await Task.detached(priority: .userInitiated) {
+            Self.decodeSkinImages(
+                from: files,
+                maxImageBytes: maxImageBytes,
+                maxImportedImages: maxImportedImages
+            )
+        }.value
 
-            let fileSize = ((try? FileManager.default.attributesOfItem(atPath: fileURL.path))?[.size] as? NSNumber)?.int64Value ?? 0
-            if fileSize > maxImageBytes {
-                warnings.append("Skipped large image \(fileURL.lastPathComponent).")
-                continue
-            }
-
-            guard let image = UIImage(contentsOfFile: fileURL.path),
-                  let pngData = image.pngData() else {
-                warnings.append("Skipped invalid image \(fileURL.lastPathComponent).")
-                continue
-            }
-
-            try writeSkinAsset(pngData, to: destination.appendingPathComponent(destinationName))
-            importedImageCount += 1
+        var warnings = decoded.warnings
+        for asset in decoded.assets {
+            try writeSkinAsset(asset.data, to: destination.appendingPathComponent(asset.name))
         }
+        let importedImageCount = decoded.assets.count
 
         guard importedImageCount > 0 else {
             try? FileManager.default.removeItem(at: destination)
@@ -318,6 +380,7 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
             storageFolderName: destinationFolder,
             manifestVersion: manifest?.schemaVersion,
             originalImportName: originalImportName ?? sourceURL.lastPathComponent,
+            catalogID: catalogID,
             createdAt: now,
             updatedAt: now
         )
@@ -357,7 +420,7 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
     func importSkinArchive(
         from sourceURL: URL,
         layoutPresets: PadLayoutPresetStore
-    ) throws -> VPadSkinImportResult {
+    ) async throws -> VPadSkinImportResult {
         let accessGranted = sourceURL.startAccessingSecurityScopedResource()
         defer {
             if accessGranted {
@@ -383,14 +446,19 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
             throw VPadSkinLibraryStoreError.noUsableSkinImages
         }
 
-        return try importSkin(
+        return try await importSkin(
             from: archiveDirectory,
             originalImportName: sourceURL.lastPathComponent,
             layoutPresets: layoutPresets
         )
     }
 
-    private func importV2ManifestSkin(from sourceURL: URL, originalImportName: String?) -> SkinManifestImporter.V2ImportDecision {
+    private func importV2ManifestSkin(
+        from sourceURL: URL,
+        originalImportName: String?,
+        catalogID: String?,
+        replacingSkinID: String?
+    ) -> SkinManifestImporter.V2ImportDecision {
         switch SkinManifestImporter.detectPackage(sourceURL: sourceURL) {
         case .legacy:
             return .notV2
@@ -403,7 +471,8 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
             }
 
             let displayName = uniqueDisplayName(
-                sanitizedDisplayName(manifest.name, fallback: originalImportName ?? sourceURL.lastPathComponent)
+                sanitizedDisplayName(manifest.name, fallback: originalImportName ?? sourceURL.lastPathComponent),
+                ignoringSkinID: replacingSkinID
             )
             let id = "imported-\(UUID().uuidString)"
             let destination = assetsRootURL.appendingPathComponent(id, isDirectory: true)
@@ -428,6 +497,7 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
                     storageFolderName: id,
                     manifestVersion: 2,
                     originalImportName: originalImportName ?? sourceURL.lastPathComponent,
+                    catalogID: catalogID,
                     createdAt: now,
                     updatedAt: now
                 )
@@ -684,6 +754,53 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
         } catch {
             NSLog("[ARMSX2 iOS Skins] Failed to save skin library: %@", error.localizedDescription)
         }
+    }
+
+    /// Reads and re-encodes the skin's images. Deliberately touches nothing but
+    /// the files it is handed so it is safe to run off the main thread.
+    private static func decodeSkinImages(
+        from files: [URL],
+        maxImageBytes: Int64,
+        maxImportedImages: Int
+    ) -> (assets: [(name: String, data: Data)], warnings: [String]) {
+        var assets: [(name: String, data: Data)] = []
+        var warnings: [String] = []
+        // The caller writes these out afterwards, so the whole batch sits in
+        // memory at once. A real skin is a couple of MB; the per-image cap alone
+        // would let a hand-made package run to a gigabyte.
+        let maxTotalBytes = 64 * 1024 * 1024
+        var totalBytes = 0
+
+        for fileURL in files where isSupportedImageFile(fileURL) {
+            if assets.count >= maxImportedImages {
+                warnings.append("Skipped remaining images; the import limit was reached.")
+                break
+            }
+            if totalBytes >= maxTotalBytes {
+                warnings.append("Skipped remaining images; the skin is too large.")
+                break
+            }
+            guard let destinationName = destinationSkinFileName(for: fileURL) else {
+                warnings.append("Skipped \(fileURL.lastPathComponent).")
+                continue
+            }
+
+            let fileSize = ((try? FileManager.default.attributesOfItem(atPath: fileURL.path))?[.size] as? NSNumber)?.int64Value ?? 0
+            if fileSize > maxImageBytes {
+                warnings.append("Skipped large image \(fileURL.lastPathComponent).")
+                continue
+            }
+
+            guard let image = UIImage(contentsOfFile: fileURL.path),
+                  let pngData = image.pngData() else {
+                warnings.append("Skipped invalid image \(fileURL.lastPathComponent).")
+                continue
+            }
+
+            assets.append((name: destinationName, data: pngData))
+            totalBytes += pngData.count
+        }
+        return (assets, warnings)
     }
 
     private static func destinationSkinFileName(for url: URL) -> String? {

--- a/platforms/ios/app/src/main/swift/Views/Settings/SkinBrowserView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/SkinBrowserView.swift
@@ -6,21 +6,51 @@ import SwiftUI
 struct SkinBrowserView: View {
     @StateObject private var catalog = SkinCatalog()
     @StateObject private var installer = SkinInstaller()
+    // Held directly so the rows invalidate off the library itself rather than
+    // off whatever the installer happens to be publishing.
+    @State private var skinLibrary = VPadSkinLibraryStore.shared
     @State private var searchText = ""
     @State private var errorAlert: String?
     @State private var previewSkin: CatalogSkin?
+    @State private var skinPendingRemoval: CatalogSkin?
 
     var body: some View {
         List {
-            if catalog.isLoading && catalog.skins.isEmpty {
+            if let updated = catalog.lastUpdated {
+                HStack(spacing: 4) {
+                    Text("Updated")
+                    Text(updated, style: .relative)
+                    Text("ago")
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            if catalog.isLoading {
                 HStack { Spacer(); ProgressView(); Spacer() }
             }
 
-            if let error = catalog.lastError, catalog.skins.isEmpty {
-                VStack(spacing: 8) {
-                    Text(error).font(.caption).foregroundStyle(.secondary)
-                    Button("Retry") { Task { await catalog.fetch() } }
+            if let error = catalog.lastError {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(catalog.skins.isEmpty
+                         ? "Can't reach the skin catalog. Check your connection and pull down to try again."
+                         : error)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Button("Retry") { Task { await catalog.fetch(force: true) } }
                 }
+            }
+
+            if catalog.skins.isEmpty && !catalog.isLoading && catalog.lastError == nil {
+                Text("No skins are published yet.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if !catalog.skins.isEmpty && filteredSkins.isEmpty {
+                Text("No skins match that search.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             ForEach(filteredSkins) { skin in
@@ -31,7 +61,7 @@ struct SkinBrowserView: View {
         .navigationTitle("Skins")
         .navigationBarTitleDisplayMode(.inline)
         .task { await catalog.fetch() }
-        .refreshable { await catalog.fetch() }
+        .refreshable { await catalog.fetch(force: true) }
         .alert("Download Failed", isPresented: Binding(
             get: { errorAlert != nil },
             set: { if !$0 { errorAlert = nil } }
@@ -40,18 +70,58 @@ struct SkinBrowserView: View {
         } message: {
             Text(errorAlert ?? "")
         }
+        .alert(
+            "Remove Skin?",
+            isPresented: Binding(
+                get: { skinPendingRemoval != nil },
+                set: { if !$0 { skinPendingRemoval = nil } }
+            ),
+            presenting: skinPendingRemoval
+        ) { skin in
+            Button("Remove \(skin.name)", role: .destructive) {
+                installer.uninstall(skin)
+                skinPendingRemoval = nil
+            }
+            Button("Cancel", role: .cancel) { skinPendingRemoval = nil }
+        } message: { _ in
+            Text("This deletes the installed skin. Linked layout presets are kept.")
+        }
         .sheet(item: $previewSkin) { skin in
             SkinPreviewSheet(skin: skin)
         }
     }
 
+    /// Read here rather than inside a row closure so the library registers with
+    /// the observation tracking that wraps body.
+    private var installedFiles: Set<String> {
+        Set(skinLibrary.importedDescriptors.compactMap(\.catalogID))
+    }
+
     private var filteredSkins: [CatalogSkin] {
-        guard !searchText.isEmpty else { return catalog.skins }
-        return catalog.skins.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+        let installed = installedFiles
+        let matches = searchText.isEmpty ? catalog.skins : catalog.skins.filter { skin in
+            skin.name.localizedCaseInsensitiveContains(searchText)
+                || (skin.author?.localizedCaseInsensitiveContains(searchText) ?? false)
+        }
+        return matches.filter { installed.contains($0.file) }
+            + matches.filter { !installed.contains($0.file) }
+    }
+
+    private func subtitle(for skin: CatalogSkin) -> String? {
+        var parts: [String] = []
+        if let author = skin.author, !author.isEmpty {
+            parts.append(author)
+        }
+        if let size = skin.sizeBytes, size > 0 {
+            parts.append(Int64(size).formatted(.byteCount(style: .file)))
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
     }
 
     @ViewBuilder
     private func skinRow(_ skin: CatalogSkin) -> some View {
+        let isInstalled = installedFiles.contains(skin.file)
+
         HStack(spacing: 12) {
             if let url = SkinCatalog.previewURL(for: skin) {
                 Button {
@@ -68,22 +138,42 @@ struct SkinBrowserView: View {
                     .cornerRadius(8)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Preview \(skin.name)")
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(skin.name).font(.body)
-                if let author = skin.author {
-                    Text(author).font(.caption).foregroundStyle(.secondary)
+                if let subtitle = subtitle(for: skin) {
+                    Text(subtitle).font(.caption).foregroundStyle(.secondary)
+                }
+                if !skin.isIOSReady {
+                    Text("No recommended layout")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
                 }
             }
 
             Spacer()
 
-            if installer.isInstalled(skin) {
-                Image(systemName: "checkmark.circle.fill")
-                    .foregroundStyle(.green)
-            } else if installer.installing.contains(skin.file) {
+            if installer.installing.contains(skin.file) {
                 ProgressView()
+            } else if isInstalled {
+                Menu {
+                    Button {
+                        Task { await installer.reinstall(skin) }
+                    } label: {
+                        Label("Reinstall", systemImage: "arrow.clockwise")
+                    }
+                    Button(role: .destructive) {
+                        skinPendingRemoval = skin
+                    } label: {
+                        Label("Remove", systemImage: "trash")
+                    }
+                } label: {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                }
+                .accessibilityLabel("\(skin.name) is installed. Reinstall or remove it.")
             } else {
                 Button("Get") {
                     Task { await installer.install(skin) }
@@ -100,12 +190,13 @@ struct SkinBrowserView: View {
                         .foregroundStyle(.orange)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Show the error from \(skin.name)")
             }
         }
         .swipeActions(edge: .trailing) {
-            if installer.isInstalled(skin) {
+            if isInstalled {
                 Button(role: .destructive) {
-                    installer.uninstall(skin)
+                    skinPendingRemoval = skin
                 } label: {
                     Label("Remove", systemImage: "trash")
                 }

--- a/platforms/ios/app/src/main/swift/Views/Settings/SkinBrowserView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/SkinBrowserView.swift
@@ -5,16 +5,10 @@ import SwiftUI
 
 struct SkinBrowserView: View {
     @StateObject private var catalog = SkinCatalog()
-    @StateObject private var installer: SkinInstaller
+    @StateObject private var installer = SkinInstaller()
     @State private var searchText = ""
     @State private var errorAlert: String?
     @State private var previewSkin: CatalogSkin?
-
-    init() {
-        let catalog = SkinCatalog()
-        _catalog = StateObject(wrappedValue: catalog)
-        _installer = StateObject(wrappedValue: SkinInstaller(catalog: catalog))
-    }
 
     var body: some View {
         List {
@@ -47,7 +41,7 @@ struct SkinBrowserView: View {
             Text(errorAlert ?? "")
         }
         .sheet(item: $previewSkin) { skin in
-            SkinPreviewSheet(skin: skin, catalog: catalog)
+            SkinPreviewSheet(skin: skin)
         }
     }
 
@@ -59,7 +53,7 @@ struct SkinBrowserView: View {
     @ViewBuilder
     private func skinRow(_ skin: CatalogSkin) -> some View {
         HStack(spacing: 12) {
-            if let url = catalog.previewURL(for: skin) {
+            if let url = SkinCatalog.previewURL(for: skin) {
                 Button {
                     previewSkin = skin
                 } label: {
@@ -88,7 +82,7 @@ struct SkinBrowserView: View {
             if installer.isInstalled(skin) {
                 Image(systemName: "checkmark.circle.fill")
                     .foregroundStyle(.green)
-            } else if installer.installingName == skin.name {
+            } else if installer.installing.contains(skin.file) {
                 ProgressView()
             } else {
                 Button("Get") {
@@ -98,7 +92,7 @@ struct SkinBrowserView: View {
                 .controlSize(.small)
             }
 
-            if let error = installer.errors[skin.name] {
+            if let error = installer.errors[skin.file] {
                 Button {
                     errorAlert = error
                 } label: {
@@ -122,12 +116,11 @@ struct SkinBrowserView: View {
 
 private struct SkinPreviewSheet: View {
     let skin: CatalogSkin
-    let catalog: SkinCatalog
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         NavigationStack {
-            AsyncImage(url: catalog.previewURL(for: skin)) { image in
+            AsyncImage(url: SkinCatalog.previewURL(for: skin)) { image in
                 image.resizable().aspectRatio(contentMode: .fit)
             } placeholder: {
                 ProgressView()

--- a/platforms/ios/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift
@@ -578,14 +578,17 @@ struct VirtualPadSettingsView: View {
             ) { result in
                 switch result {
                 case .success(let urls):
-                    let result = importCustomSkins(urls)
-                    lastSkinImportResult = result.importResult
-                    skinImportMessage = result.message
+                    Task {
+                        let outcome = await importCustomSkins(urls)
+                        lastSkinImportResult = outcome.importResult
+                        skinImportMessage = outcome.message
+                        showSkinImportAlert = true
+                    }
                 case .failure(let error):
                     lastSkinImportResult = nil
                     skinImportMessage = "Skin import failed: \(error.localizedDescription)"
+                    showSkinImportAlert = true
                 }
-                showSkinImportAlert = true
             }
         }
         .alert(settings.localized("Custom Skin"), isPresented: $showSkinImportAlert) {
@@ -715,7 +718,7 @@ struct VirtualPadSettingsView: View {
         }
     }
 
-    private func importCustomSkins(_ urls: [URL]) -> (message: String, importResult: VPadSkinImportResult?) {
+    private func importCustomSkins(_ urls: [URL]) async -> (message: String, importResult: VPadSkinImportResult?) {
         let stagingDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("ARMSX2SkinImport-\(UUID().uuidString)", isDirectory: true)
         try? FileManager.default.createDirectory(at: stagingDirectory, withIntermediateDirectories: true)
@@ -743,7 +746,7 @@ struct VirtualPadSettingsView: View {
                 try? FileManager.default.copyItem(at: sourceURL, to: destination)
             }
             do {
-                let result = try skinLibrary.importSkin(
+                let result = try await skinLibrary.importSkin(
                     from: looseDirectory,
                     originalImportName: looseFiles.first?.lastPathComponent,
                     layoutPresets: layoutPresets
@@ -779,7 +782,7 @@ struct VirtualPadSettingsView: View {
                 continue
             }
             do {
-                let result = try skinLibrary.importSkin(
+                let result = try await skinLibrary.importSkin(
                     from: archiveDirectory,
                     originalImportName: sourceURL.lastPathComponent,
                     layoutPresets: layoutPresets


### PR DESCRIPTION
### What changed

* The Skins list now shows every skin in the catalog. It was quietly hiding 13 of the 26 published ones because they carry no recommended layout. Those import perfectly fine, they just leave your current button layout alone, so they are listed now with a small note saying so.
* Pull to refresh actually reaches the network. GitHub tells the app to cache the catalog for five minutes, so refreshing inside that window was giving you the same list back no matter how many times you pulled. That is the "the menu doesn't update the skins" people have been reporting. There is an "Updated ... ago" line above the list now so you can see whether a refresh landed.
* Skins you already have show a green tick again. The browser was comparing the catalog's name against the name stored inside the skin package, and those two drift apart on plenty of skins. So the row stayed on Get, and tapping it again piled up another copy called "Neon 2", then "Neon 3". Skins now remember which catalog entry they came from, so the match is exact.
* Tapping the tick opens Reinstall and Remove. Reinstall swaps the skin in place instead of adding a duplicate, and it keeps your per game skin picks and your active layout pointed at the new copy. Remove asks first, and it no longer swallows the error if something goes wrong.
* Installing a skin no longer freezes the settings screen. A real skin is 18 to 21 button images and all of them were being decoded and rewritten on the main thread while you waited.
* Removing the skin you are currently using now falls back to the stock artwork properly. It used to leave the pad pointing at an old folder that may not exist.

### Smaller things

* Rows show the author and the download size. Both were already in the catalog and simply unused.
* Search matches the author as well as the skin name.
* Installed skins sort to the top.
* Proper messages when the catalog is empty, when your search matches nothing, and when there is no connection. Previously you just got a blank screen.
* The loading spinner and any fetch error stay visible after a first successful load. Before this they were only shown on an empty list, so a refresh looked like nothing was happening and a failed one looked like it worked.
* Two taps on different skins no longer knock each other's spinner out.
* The warning triangle clears once a skin installs or is removed, instead of hanging around next to a skin that is perfectly fine.
* The preview thumbnail and the warning triangle have VoiceOver labels.
* Download links from the catalog are checked before use, and there is a size ceiling on what will be pulled down.

### Notes for reviewers

Skins gain an optional `catalogID` holding the repo relative zip path of the catalog entry they came from. It is optional on purpose. The skin library is decoded all or nothing and a required key would fail to read every existing entry, after which the next save would write an empty library over the user's skins. It stays empty for anything imported by hand.

The zip path is used as the identity rather than the display name, because names in the live catalog have already drifted from their filenames ("Dualshock 4" ships as `DualShock4.zip`).

Reinstall imports the new copy first and only deletes the old one once that succeeded, so a dead download or a corrupt zip leaves the skin you already have alone.

Built and tested against a device Release build.
