### PR TITLE
iOS: make the OSD fit the screen again and bring back the device stats

### DIFF
--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -92,6 +92,10 @@ static std::vector<u8> s_icon_pf_font_data;
 
 static float s_window_width;
 static float s_window_height;
+static float s_osd_inset_left = 0.0f;
+static float s_osd_inset_top = 0.0f;
+static float s_osd_inset_right = 0.0f;
+static float s_osd_inset_bottom = 0.0f;
 static Common::Timer s_last_render_time;
 
 // cached copies of WantCaptureKeyboard/Mouse, used to know when to dispatch events
@@ -285,7 +289,24 @@ void ImGuiManager::RequestScaleUpdate()
 
 void ImGuiManager::SetOSDSafeAreaInsets(float left, float top, float right, float bottom)
 {
-	// Stub — iOS uses this for rounded-corner OSD clearance. Full implementation in Phase 5.
+	// Already in physical pixels — the caller multiplies by the content scale — so these add
+	// straight onto margin without a conversion.
+	s_osd_inset_left = left;
+	s_osd_inset_top = top;
+	s_osd_inset_right = right;
+	s_osd_inset_bottom = bottom;
+}
+
+void ImGuiManager::GetOSDSafeAreaInsets(float* left, float* top, float* right, float* bottom)
+{
+	if (left)
+		*left = s_osd_inset_left;
+	if (top)
+		*top = s_osd_inset_top;
+	if (right)
+		*right = s_osd_inset_right;
+	if (bottom)
+		*bottom = s_osd_inset_bottom;
 }
 
 void ImGuiManager::ReloadFonts()

--- a/pcsx2/ImGui/ImGuiManager.h
+++ b/pcsx2/ImGui/ImGuiManager.h
@@ -50,6 +50,9 @@ namespace ImGuiManager
 	/// Sets safe-area insets for OSD elements (iOS rounded-corner clearance).
 	void SetOSDSafeAreaInsets(float left, float top, float right, float bottom);
 
+	/// Returns the safe-area insets, in physical pixels. Any pointer may be null.
+	void GetOSDSafeAreaInsets(float* left, float* top, float* right, float* bottom);
+
 	/// Rebuilds the ImGui font atlas using current settings.
 	void ReloadFonts();
 

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -79,6 +79,9 @@ SmallString s_gpu_usage_line;
 SmallString s_gpu_debug_info_line;
 SmallString s_gpu_stats_line;
 SmallString s_speed_icon;
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+SmallString s_ios_device_stats_line;
+#endif
 
 // Shrink-to-fit for the performance overlay. The widest line measured last frame decides how much
 // this frame has to come down; one frame of lag is invisible and it means we only measure once.
@@ -86,6 +89,14 @@ static float s_osd_fit = 1.0f;
 static float s_osd_max_base_w = 0.0f;
 
 constexpr ImU32 white_color = IM_COL32(255, 255, 255, 255);
+
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+// Battery, heat and RAM come from the iOS frontend. There is no header for these three; the bridge
+// forward-declares its own the same way.
+extern "C" bool ARMSX2_iOSShouldShowDeviceStatsOverlay();
+extern "C" int ARMSX2_iOSGetDeviceStatsOverlaySeverity();
+extern "C" const char* ARMSX2_iOSGetDeviceStatsOverlayLine();
+#endif
 
 /// The OSD's normal text colour. GSConfig.OsdColor is 0xRRGGBB, and 0 means "unset" — every
 /// frontend but Android leaves it there, so the overlay keeps its classic white by default.
@@ -98,6 +109,22 @@ __fi static ImU32 OsdTextColor()
 		return white_color;
 	return IM_COL32((rgb >> 16) & 0xFFu, (rgb >> 8) & 0xFFu, rgb & 0xFFu, 255);
 }
+
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+// Same red as the sub-95% speed line, so the OSD keeps one vocabulary of alarm.
+static ImU32 ARMSX2IOSDeviceStatsColor()
+{
+	switch (ARMSX2_iOSGetDeviceStatsOverlaySeverity())
+	{
+		case 2:
+			return IM_COL32(255, 100, 100, 255);
+		case 1:
+			return IM_COL32(255, 220, 100, 255);
+		default:
+			return OsdTextColor();
+	}
+}
+#endif
 
 // OSD positioning funcs
 ImVec2 CalculateOSDPosition(OsdOverlayPos position, float margin, const ImVec2& text_size, float window_width, float window_height)
@@ -223,13 +250,18 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 	// nothing and return BEFORE any draw call, so a line string cached before a pause can't
 	// linger on screen (the rebuild block below is skipped while the VM is paused, which is
 	// why toggling in the menu looked inert).
-	if (!GSConfig.OsdShowFPS && !GSConfig.OsdShowVPS && !GSConfig.OsdShowSpeed &&
-		!GSConfig.OsdShowResolution && !GSConfig.OsdShowCPU && !GSConfig.OsdShowGPU &&
-		!GSConfig.OsdShowGSStats && !GSConfig.OsdShowFrameTimes && !GSConfig.OsdShowHardwareInfo &&
-		!GSConfig.OsdShowVersion && !GSConfig.OsdShowGPUStats)
-	{
+	const bool no_perf_lines = !GSConfig.OsdShowFPS && !GSConfig.OsdShowVPS && !GSConfig.OsdShowSpeed &&
+							   !GSConfig.OsdShowResolution && !GSConfig.OsdShowCPU && !GSConfig.OsdShowGPU &&
+							   !GSConfig.OsdShowGSStats && !GSConfig.OsdShowFrameTimes && !GSConfig.OsdShowHardwareInfo &&
+							   !GSConfig.OsdShowVersion && !GSConfig.OsdShowGPUStats;
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+	// A Custom preset with nothing but Device Stats ticked is reachable, and it lands here.
+	if (no_perf_lines && !ARMSX2_iOSShouldShowDeviceStatsOverlay())
 		return;
-	}
+#else
+	if (no_perf_lines)
+		return;
+#endif
 
 	const float shadow_offset = std::ceil(scale);
 
@@ -475,6 +507,16 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 				DRAW_LINE(osd_font, font_size, s_speed_line.c_str(), s_speed_line_color);
 			}
 
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+			if (ARMSX2_iOSShouldShowDeviceStatsOverlay())
+			{
+				const char* stats_line = ARMSX2_iOSGetDeviceStatsOverlayLine();
+				s_ios_device_stats_line.assign(stats_line ? stats_line : "");
+				if (!s_ios_device_stats_line.empty())
+					DRAW_LINE(osd_font, font_size, s_ios_device_stats_line.c_str(), ARMSX2IOSDeviceStatsColor());
+			}
+#endif
+
 			if (GSConfig.OsdShowGSStats)
 			{
 				GSgetStats(s_gs_stats_line);
@@ -634,6 +676,11 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 		{
 			if (GSConfig.OsdShowFPS || GSConfig.OsdShowVPS || GSConfig.OsdShowSpeed || GSConfig.OsdShowVersion)
 				DRAW_LINE(osd_font, font_size, s_speed_line.c_str(), s_speed_line_color);
+
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+			if (ARMSX2_iOSShouldShowDeviceStatsOverlay() && !s_ios_device_stats_line.empty())
+				DRAW_LINE(osd_font, font_size, s_ios_device_stats_line.c_str(), ARMSX2IOSDeviceStatsColor());
+#endif
 
 			if (GSConfig.OsdShowGSStats)
 			{

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -45,6 +45,7 @@
 #include <TargetConditionals.h>
 #endif
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <limits>
@@ -78,6 +79,11 @@ SmallString s_gpu_usage_line;
 SmallString s_gpu_debug_info_line;
 SmallString s_gpu_stats_line;
 SmallString s_speed_icon;
+
+// Shrink-to-fit for the performance overlay. The widest line measured last frame decides how much
+// this frame has to come down; one frame of lag is invisible and it means we only measure once.
+static float s_osd_fit = 1.0f;
+static float s_osd_max_base_w = 0.0f;
 
 constexpr ImU32 white_color = IM_COL32(255, 255, 255, 255);
 
@@ -150,7 +156,9 @@ ImVec2 CalculatePerformanceOverlayTextPosition(OsdOverlayPos position, float mar
 			break;
 	}
 
-	return ImVec2(x_pos, position_y);
+	// A line wider than the window would otherwise start at negative x and run off the left edge,
+	// which is far worse than being clipped on the right.
+	return ImVec2(std::max(abs_margin, x_pos), position_y);
 }
 
 bool ShouldUseLeftAlignment(OsdOverlayPos position)
@@ -226,7 +234,15 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 	const float shadow_offset = std::ceil(scale);
 
 	ImFont* const osd_font = ImGuiManager::GetOSDFont();
-	const float font_size = ImGuiManager::GetFontSizeStandard();
+	const float base_font_size = ImGuiManager::GetFontSizeStandard();
+	const float avail = GetWindowWidth() - 2.0f * margin;
+	// Only ever shrink: the user picked their size with OsdScale and we are not going to second-guess
+	// it upwards. Portrait is less than half the width of landscape, which is where this bites.
+	s_osd_fit = (avail > 0.0f && s_osd_max_base_w > avail) ? std::clamp(avail / s_osd_max_base_w, 0.5f, 1.0f) : 1.0f;
+	s_osd_max_base_w = 0.0f;
+	// Integral so we don't ask ImGui for a new font bake on every sub-pixel wobble.
+	const float font_size = std::max(1.0f, std::floor(base_font_size * s_osd_fit));
+	const float fit_norm = base_font_size / font_size;
 	const float line_height = ImGuiFullscreen::GetLineHeight({ osd_font, font_size });
 
 	ImDrawList* dl = ImGui::GetBackgroundDrawList();
@@ -261,6 +277,8 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 	do \
 	{ \
 		text_size = font->CalcTextSizeA(size, std::numeric_limits<float>::max(), -1.0f, (text), nullptr, nullptr); \
+		/* Normalise back to the unshrunk width, or the factor chases its own tail every frame. */ \
+		s_osd_max_base_w = std::max(s_osd_max_base_w, text_size.x * fit_norm); \
 		const ImVec2 text_pos = CalculatePerformanceOverlayTextPosition(GSConfig.OsdPerformancePos, margin, text_size, GetWindowWidth(), position_y); \
 		const bool __bold_osd = GSConfig.OsdBoldText; \
 		dl->AddText(font, size, ImVec2(text_pos.x + shadow_offset, text_pos.y + shadow_offset), IM_COL32(0, 0, 0, 100), (text)); \
@@ -777,22 +795,26 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 			float min_vps = s_vps_min;
 			float max_vps = std::max(s_vps_max, min_vps + 10.0f);
 
+			// The graph has to come down with the text or it overhangs a shrunken block.
+			const float graph_scale = scale * s_osd_fit;
+
 			SmallString label_buf;
 			label_buf.format("{:.1f}", max_val);
-			const float y_label_w = osd_font->CalcTextSizeA(font_size, FLT_MAX, 0.0f, label_buf.c_str(), label_buf.c_str() + label_buf.length()).x + 4.0f * scale;
+			const float y_label_w = osd_font->CalcTextSizeA(font_size, FLT_MAX, 0.0f, label_buf.c_str(), label_buf.c_str() + label_buf.length()).x + 4.0f * graph_scale;
 			label_buf.format("{:.0f}", max_vps);
-			const float right_label_w = osd_font->CalcTextSizeA(font_size, FLT_MAX, 0.0f, label_buf.c_str(), label_buf.c_str() + label_buf.length()).x + 4.0f * scale;
+			const float right_label_w = osd_font->CalcTextSizeA(font_size, FLT_MAX, 0.0f, label_buf.c_str(), label_buf.c_str() + label_buf.length()).x + 4.0f * graph_scale;
 
-			const float pad = 4.0f * scale;
-			const float row_gap = 2.0f * scale;
+			const float pad = 4.0f * graph_scale;
+			const float row_gap = 2.0f * graph_scale;
 			const float legend_h = (font_size * 2.0f) + row_gap + pad;
-			const ImVec2 graph_size(200.0f * scale, 60.0f * scale);
+			const ImVec2 graph_size(200.0f * graph_scale, 60.0f * graph_scale);
 			const ImVec2 total_size(y_label_w + graph_size.x + right_label_w + 2.0f * pad, graph_size.y + legend_h + 2.0f * pad);
+			s_osd_max_base_w = std::max(s_osd_max_base_w, total_size.x * fit_norm);
 
 			ImGui::SetNextWindowSize(total_size);
 			ImGui::SetNextWindowPos(CalculatePerformanceOverlayTextPosition(GSConfig.OsdPerformancePos, margin, total_size, GetWindowWidth(), position_y));
 			ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.0f, 0.0f, 0.0f, 0.45f));
-			ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 4.0f * scale);
+			ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 4.0f * graph_scale);
 			ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
 			ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
 			ImGui::PushFont(osd_font, font_size);
@@ -807,7 +829,7 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 
 				const int num_ticks = std::max(1, std::min(8, static_cast<int>(graph_size.y / (font_size * 1.1f))));
 				const float left_label_x = wpos.x + pad + y_label_w;
-				const float right_label_x = plot_br.x + 2.0f * scale;
+				const float right_label_x = plot_br.x + 2.0f * graph_scale;
 
 				const ImU32 ft_col = IM_COL32(100, 200, 255, 230);
 				const ImU32 vps_col = IM_COL32(100, 255, 100, 230);
@@ -824,7 +846,7 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 
 						s.format("{:.1f}", min_val + (max_val - min_val) * frac);
 						const float left_text_w = osd_font->CalcTextSizeA(font_size, FLT_MAX, 0.0f, s.c_str(), s.c_str() + s.length()).x;
-						const float lx = left_label_x - left_text_w - 2.0f * scale;
+						const float lx = left_label_x - left_text_w - 2.0f * graph_scale;
 						dl->AddText(osd_font, font_size, ImVec2(lx + shadow_offset, ly + shadow_offset), IM_COL32(0, 0, 0, 100), s.c_str(), s.c_str() + s.length());
 						dl->AddText(osd_font, font_size, ImVec2(lx, ly), ft_col, s.c_str(), s.c_str() + s.length());
 
@@ -865,7 +887,7 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 
 				const float legend_y = plot_br.y + pad * 0.5f;
 				const float legend_square_size = font_size * 0.65f;
-				const float legend_gap = 4.0f * scale;
+				const float legend_gap = 4.0f * graph_scale;
 				SmallString frame_part, vps_part;
 				frame_part.format("Frame: {:.2f} ms", PerformanceMetrics::GetAverageFrameTime());
 				vps_part.format("V-Blank: {:.2f}", PerformanceMetrics::GetFPS());
@@ -894,6 +916,10 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 
 #undef DRAW_LINE
 }
+
+// How tall the settings string ended up. It wraps now, so the indicator below can no longer
+// assume one line. DrawSettingsOverlay runs first, so this is current.
+static float s_settings_overlay_height = 0.0f;
 
 __ri void ImGuiManager::DrawShaderCompileIndicator(float scale, float margin, float spacing)
 {
@@ -933,8 +959,7 @@ __ri void ImGuiManager::DrawShaderCompileIndicator(float scale, float margin, fl
 
 	ImFont* const font = ImGuiManager::GetOSDFont();
 	const float font_size = ImGuiManager::GetFontSizeStandard();
-	const float baseline_y =
-		GetWindowHeight() - margin - (GSConfig.OsdShowSettings ? font_size : 0.0f);
+	const float baseline_y = GetWindowHeight() - margin - s_settings_overlay_height;
 	const float radius = std::ceil(10.0f * scale);
 	const float cx = GetWindowWidth() - margin - radius;
 	const float cy = baseline_y - spacing - radius;
@@ -972,6 +997,8 @@ __ri void ImGuiManager::DrawShaderCompileIndicator(float scale, float margin, fl
 
 __ri void ImGuiManager::DrawSettingsOverlay(float scale, float margin, float spacing)
 {
+	s_settings_overlay_height = 0.0f;
+
 	if (!GSConfig.OsdShowSettings ||
 		FullscreenUI::HasActiveWindow())
 		return;
@@ -1111,23 +1138,38 @@ __ri void ImGuiManager::DrawSettingsOverlay(float scale, float margin, float spa
 
 	const float shadow_offset = std::ceil(scale);
 	ImFont* const font = ImGuiManager::GetOSDFont();
-	const float font_size = ImGuiManager::GetFontSizeStandard();
-	const float position_y = GetWindowHeight() - margin - font_size;
+	const float base_font_size = ImGuiManager::GetFontSizeStandard();
+	const float avail = GetWindowWidth() - 2.0f * margin;
 
 	ImDrawList* dl = ImGui::GetBackgroundDrawList();
 	ImVec2 text_size =
-		font->CalcTextSizeA(font_size, std::numeric_limits<float>::max(), -1.0f, text.c_str(), text.c_str() + text.length(), nullptr);
-	const ImVec2 text_pos(GetWindowWidth() - margin - text_size.x, position_y);
+		font->CalcTextSizeA(base_font_size, std::numeric_limits<float>::max(), -1.0f, text.c_str(), text.c_str() + text.length(), nullptr);
+
+	// This one runs to a couple of hundred characters, so shrinking it far enough to fit on a single
+	// line would leave it unreadable. Take it down a little, then let it wrap onto two or three.
+	float font_size = base_font_size;
+	float wrap_width = 0.0f;
+	if (avail > 0.0f && text_size.x > avail)
+	{
+		font_size = std::max(1.0f, std::floor(base_font_size * std::clamp(avail / text_size.x, 0.6f, 1.0f)));
+		wrap_width = avail;
+		text_size = font->CalcTextSizeA(font_size, std::numeric_limits<float>::max(), wrap_width, text.c_str(), text.c_str() + text.length(), nullptr);
+	}
+
+	s_settings_overlay_height = text_size.y;
+
+	const float position_y = GetWindowHeight() - margin - text_size.y;
+	const ImVec2 text_pos(std::max(margin, GetWindowWidth() - margin - text_size.x), position_y);
 	const bool bold_osd = GSConfig.OsdBoldText;
 	dl->AddText(font, font_size,
 		ImVec2(text_pos.x + shadow_offset, text_pos.y + shadow_offset), IM_COL32(0, 0, 0, 100),
-		text.c_str(), text.c_str() + text.length());
+		text.c_str(), text.c_str() + text.length(), wrap_width);
 	dl->AddText(font, font_size, text_pos, white_color,
-		text.c_str(), text.c_str() + text.length());
+		text.c_str(), text.c_str() + text.length(), wrap_width);
 	if (bold_osd)
 	{
 		dl->AddText(font, font_size, ImVec2(text_pos.x + 0.6f, text_pos.y), white_color,
-			text.c_str(), text.c_str() + text.length());
+			text.c_str(), text.c_str() + text.length(), wrap_width);
 	}
 }
 

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -1996,9 +1996,15 @@ void ImGuiManager::RenderOverlays()
 	}
 
 	const float scale = ImGuiManager::GetGlobalScale();
-	const float margin = std::ceil(GSConfig.OsdMargin * scale);
+	const float base_margin = std::ceil(GSConfig.OsdMargin * scale);
 	const float spacing = std::ceil(5.0f * scale);
-	float position_y = margin;
+
+	// The frontend hands us the cut-out and rounded-corner clearance on every rotation. Only one
+	// horizontal margin is threaded through the draw functions, so take the worse side.
+	float inset_left = 0.0f, inset_top = 0.0f, inset_right = 0.0f;
+	ImGuiManager::GetOSDSafeAreaInsets(&inset_left, &inset_top, &inset_right, nullptr);
+	const float margin = base_margin + std::max(inset_left, inset_right);
+	float position_y = base_margin + inset_top;
 
 	DrawIndicatorsOverlay(position_y, scale, margin, spacing);
 	DrawVideoCaptureOverlay(position_y, scale, margin, spacing);

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
@@ -3158,7 +3158,7 @@ static std::string ARMSX2PerGameSettingsPath(const std::string& serial, u32 crc)
 
 // Apply OSD preset — sets ALL GSConfig flags to match the preset
 + (void)applyOsdPreset:(int)preset {
-    // 1 simple: clean player readout; device stats are Swift-side.
+    // 1 simple: clean player readout, plus the device stats line the overlay draws.
     // 2 detail: performance and renderer diagnostics.
     // 3 full: closest to Android's full stats section. 0 is off.
     const bool simple = (preset == 1);

--- a/platforms/ios/app/src/main/cpp/ios_main.mm
+++ b/platforms/ios/app/src/main/cpp/ios_main.mm
@@ -726,8 +726,11 @@ static const ARMSX2IOSDeviceStatsCache& ARMSX2IOSRefreshDeviceStatsCacheLocked()
         return s_device_stats_cache;
     }
 
+    // Mirror the rule the Swift side loads with, so a fresh install with the key still absent agrees
+    // with the preset instead of showing stats at Off.
     s_device_stats_cache.show = s_settings_interface ?
-        s_settings_interface->GetBoolValue("ARMSX2iOS/UI", "OsdShowDeviceStats", true) : true;
+        s_settings_interface->GetBoolValue("ARMSX2iOS/UI", "OsdShowDeviceStats",
+            s_settings_interface->GetIntValue("ARMSX2iOS/UI", "OsdPreset", 0) != 0) : false;
 
     @autoreleasepool {
         UIDevice* device = [UIDevice currentDevice];
@@ -774,8 +777,15 @@ extern "C" int ARMSX2_iOSGetDeviceStatsOverlaySeverity()
 
 extern "C" const char* ARMSX2_iOSGetDeviceStatsOverlayLine()
 {
-    std::lock_guard<std::mutex> lock(s_device_stats_mutex);
-    return ARMSX2IOSRefreshDeviceStatsCacheLocked().line.c_str();
+    // Handing back a pointer into the cached string leaves the caller reading it after the lock has
+    // gone, and another thread refreshing the cache can reallocate it underneath them. Copy into
+    // storage the calling thread owns instead.
+    static thread_local std::string copy;
+    {
+        std::lock_guard<std::mutex> lock(s_device_stats_mutex);
+        copy = ARMSX2IOSRefreshDeviceStatsCacheLocked().line;
+    }
+    return copy.c_str();
 }
 
 // Structured device stats for the SwiftUI VoiceOver HUD mirror. Reads the same


### PR DESCRIPTION
### What changed

* The OSD fits the screen again. It was sized purely from the device pixel ratio with no idea how wide the window actually is, so in portrait the longer lines simply ran off the edge and got cut. It now measures itself and shrinks until it fits. It only ever shrinks, so it never grows past the size you picked, and landscape looks exactly as it did before.
* Full mode is usable in portrait. That preset turns on the settings string, the hardware info and the frame time graph all at once, which is why it was the worst offender. The graph scales along with the text, and the settings string wraps onto a second or third line rather than being chopped off, since shrinking a line that long far enough to fit would leave it unreadable.
* The device stats line is back. Battery, heat, RAM and a Low Power marker, the same readout as before. It turns out it was never really removed: the code that builds that line is still in the app and has been all along, it just lost the piece that drew it during a refactor. That piece is restored.
* Device stats show on Simple, Detail and Full, and are hidden on Off, which is what the presets always intended. They go amber when the device gets warm or the battery drops below a third, and red when it gets hot or drops below fifteen percent.
* The OSD keeps clear of the notch and the Dynamic Island. The app was already working out the right clearance every time you rotate the device and handing it over, and it was being thrown away on the other side. It is used now, so the overlay no longer tucks under the cutout in landscape or under the status bar in portrait.

### Smaller things

* A line that is still wider than the window now stops at the screen edge instead of sliding off to the left, so you lose the tail of a line rather than the start of it.
* The frame time graph's labels and legend follow the same shrink as everything else. They used to be positioned with the unshrunk size, so at small scales the V Blank labels sat right on the window edge.
* The "Compiled N shaders" indicator sits above the settings string properly now that the string can be more than one line tall.
* If you build a Custom preset with nothing ticked except Device Stats, it draws. The overlay used to give up early when all of the built in stat toggles were off.

### Notes for reviewers

The fit factor is local to the performance overlay. It deliberately does not touch the global ImGui scale, because changing that restyles the UI and reloads the fullscreen UI's SVG resources, which is not something you want happening every frame.

The width it measures is normalised by the current fit factor before being compared. Without that, each frame measures text that already carries the previous frame's shrink and the factor oscillates instead of settling. With it the value is a fixed point and settles in one frame, including across a rotation.

The fit and the position clamp apply on every platform rather than being guarded to iOS. On a desktop sized window they are no ops, and an overlay that stays on screen seems like the right behaviour everywhere. Only the device stats block is iOS only.

One fix that came along with the restoration: the function returning the stats line handed back a pointer into a string owned by a mutex guarded cache, after releasing the mutex. Harmless while nothing called it, not harmless once something does.

Built and packaged against a device Release build. Not yet run on hardware, so the portrait layout, the rotation behaviour and the severity colours have not been watched in person.
