### PR TITLE
iOS: stop the OSD dancing and pin it to one place in portrait

### DIFF
--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -30,6 +30,7 @@
 #include "imgui_internal.h"
 #include "common/Image.h"
 
+#include <atomic>
 #include <chrono>
 #include <cmath>
 #include <deque>
@@ -92,10 +93,11 @@ static std::vector<u8> s_icon_pf_font_data;
 
 static float s_window_width;
 static float s_window_height;
-static float s_osd_inset_left = 0.0f;
-static float s_osd_inset_top = 0.0f;
-static float s_osd_inset_right = 0.0f;
-static float s_osd_inset_bottom = 0.0f;
+// Written by whichever thread owns the window's layout, read by the GS thread while it draws.
+static std::atomic<float> s_osd_inset_left{0.0f};
+static std::atomic<float> s_osd_inset_top{0.0f};
+static std::atomic<float> s_osd_inset_right{0.0f};
+static std::atomic<float> s_osd_inset_bottom{0.0f};
 static Common::Timer s_last_render_time;
 
 // cached copies of WantCaptureKeyboard/Mouse, used to know when to dispatch events
@@ -291,22 +293,22 @@ void ImGuiManager::SetOSDSafeAreaInsets(float left, float top, float right, floa
 {
 	// Already in physical pixels — the caller multiplies by the content scale — so these add
 	// straight onto margin without a conversion.
-	s_osd_inset_left = left;
-	s_osd_inset_top = top;
-	s_osd_inset_right = right;
-	s_osd_inset_bottom = bottom;
+	s_osd_inset_left.store(left, std::memory_order_relaxed);
+	s_osd_inset_top.store(top, std::memory_order_relaxed);
+	s_osd_inset_right.store(right, std::memory_order_relaxed);
+	s_osd_inset_bottom.store(bottom, std::memory_order_relaxed);
 }
 
 void ImGuiManager::GetOSDSafeAreaInsets(float* left, float* top, float* right, float* bottom)
 {
 	if (left)
-		*left = s_osd_inset_left;
+		*left = s_osd_inset_left.load(std::memory_order_relaxed);
 	if (top)
-		*top = s_osd_inset_top;
+		*top = s_osd_inset_top.load(std::memory_order_relaxed);
 	if (right)
-		*right = s_osd_inset_right;
+		*right = s_osd_inset_right.load(std::memory_order_relaxed);
 	if (bottom)
-		*bottom = s_osd_inset_bottom;
+		*bottom = s_osd_inset_bottom.load(std::memory_order_relaxed);
 }
 
 void ImGuiManager::ReloadFonts()

--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -990,18 +990,25 @@ void ImGuiManager::DrawOSDMessages(Common::Timer::Value current_time)
 	const float font_size = GetFontSizeStandard();
 	const float scale = s_global_scale;
 	const float spacing = std::ceil(5.0f * scale);
-	const float margin = std::ceil(GSConfig.OsdMargin * scale);
+	const float base_margin = std::ceil(GSConfig.OsdMargin * scale);
+	// Same clearance the performance overlay gets — messages land in the same corners, so a notch
+	// covers them just as readily.
+	const float inset_left = s_osd_inset_left.load(std::memory_order_relaxed);
+	const float inset_right = s_osd_inset_right.load(std::memory_order_relaxed);
+	const float margin = base_margin + std::max(inset_left, inset_right);
+	const float top_margin = base_margin + s_osd_inset_top.load(std::memory_order_relaxed);
+	const float bottom_margin = base_margin + s_osd_inset_bottom.load(std::memory_order_relaxed);
 	const float padding = std::ceil(8.0f * scale);
 	const float rounding = std::ceil(5.0f * scale);
 	const float max_width = s_window_width - (margin + padding) * 2.0f;
 
-	float position_y = margin;
+	float position_y = top_margin;
 	switch (GSConfig.OsdMessagesPos)
 	{
 		case OsdOverlayPos::TopLeft:
 		case OsdOverlayPos::TopCenter:
 		case OsdOverlayPos::TopRight:
-			position_y = margin;
+			position_y = top_margin;
 			break;
 
 		case OsdOverlayPos::CenterLeft:
@@ -1014,12 +1021,12 @@ void ImGuiManager::DrawOSDMessages(Common::Timer::Value current_time)
 		case OsdOverlayPos::BottomCenter:
 		case OsdOverlayPos::BottomRight:
 			// For bottom positions, start from the bottom and let messages stack upward
-			position_y = s_window_height - margin;
+			position_y = s_window_height - bottom_margin;
 			break;
 
 		case OsdOverlayPos::None:
 		default:
-			position_y = margin;
+			position_y = top_margin;
 			break;
 	}
 

--- a/pcsx2/ImGui/ImGuiManager.h
+++ b/pcsx2/ImGui/ImGuiManager.h
@@ -47,7 +47,8 @@ namespace ImGuiManager
 	/// Updates scaling of the on-screen elements.
 	void RequestScaleUpdate();
 
-	/// Sets safe-area insets for OSD elements (iOS rounded-corner clearance).
+	/// Sets safe-area insets for OSD elements, in physical pixels. Safe to call from any thread,
+	/// so the frontend can push straight from its layout callback.
 	void SetOSDSafeAreaInsets(float left, float top, float right, float bottom);
 
 	/// Returns the safe-area insets, in physical pixels. Any pointer may be null.

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -199,10 +199,10 @@ bool ShouldUseLeftAlignment(OsdOverlayPos position)
 namespace ImGuiManager
 {
 	static void FormatProcessorStat(SmallStringBase& text, double usage, double time);
-	static void DrawPerformanceOverlay(float& position_y, float scale, float margin, float spacing);
-	static void DrawShaderCompileIndicator(float scale, float margin, float spacing);
-	static void DrawSettingsOverlay(float scale, float margin, float spacing);
-	static void DrawInputsOverlay(float scale, float margin, float spacing);
+	static void DrawPerformanceOverlay(float& position_y, float scale, float margin, float bottom_margin, float spacing);
+	static void DrawShaderCompileIndicator(float scale, float margin, float bottom_margin, float spacing);
+	static void DrawSettingsOverlay(float scale, float margin, float bottom_margin, float spacing);
+	static void DrawInputsOverlay(float scale, float margin, float bottom_margin, float spacing);
 	static void DrawInputRecordingOverlay(float& position_y, float scale, float margin, float spacing);
 	static void DrawVideoCaptureOverlay(float& position_y, float scale, float margin, float spacing);
 	static void DrawTextureReplacementsOverlay(float& position_y, float scale, float margin, float spacing);
@@ -246,7 +246,7 @@ __ri void ImGuiManager::FormatProcessorStat(SmallStringBase& text, double usage,
 		text.append_format("{:.1f}% ({:.2f}ms)", usage, time);
 }
 
-__ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, float margin, float spacing)
+__ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, float margin, float bottom_margin, float spacing)
 {
 	// The perf-OSD flags in GSConfig are refreshed from the authoritative EmuConfig.GS at
 	// the top of RenderOverlays (see the note there). When every perf line is off, draw
@@ -315,7 +315,7 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 		case OsdOverlayPos::BottomCenter:
 		case OsdOverlayPos::BottomRight:
 
-			position_y = GetWindowHeight() - margin - (line_height * 15.0f + spacing * 14.0f);
+			position_y = GetWindowHeight() - bottom_margin - (line_height * 15.0f + spacing * 14.0f);
 			break;
 
 		case OsdOverlayPos::TopLeft:
@@ -989,7 +989,7 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 // assume one line. DrawSettingsOverlay runs first, so this is current.
 static float s_settings_overlay_height = 0.0f;
 
-__ri void ImGuiManager::DrawShaderCompileIndicator(float scale, float margin, float spacing)
+__ri void ImGuiManager::DrawShaderCompileIndicator(float scale, float margin, float bottom_margin, float spacing)
 {
 	static bool s_indicator_was_visible = false;
 	static double s_indicator_fade_in_start = 0.0;
@@ -1027,7 +1027,7 @@ __ri void ImGuiManager::DrawShaderCompileIndicator(float scale, float margin, fl
 
 	ImFont* const font = ImGuiManager::GetOSDFont();
 	const float font_size = ImGuiManager::GetFontSizeStandard();
-	const float baseline_y = GetWindowHeight() - margin - s_settings_overlay_height;
+	const float baseline_y = GetWindowHeight() - bottom_margin - s_settings_overlay_height;
 	const float radius = std::ceil(10.0f * scale);
 	const float cx = GetWindowWidth() - margin - radius;
 	const float cy = baseline_y - spacing - radius;
@@ -1063,7 +1063,7 @@ __ri void ImGuiManager::DrawShaderCompileIndicator(float scale, float margin, fl
 	dl->PathStroke(text_col, thickness, false);
 }
 
-__ri void ImGuiManager::DrawSettingsOverlay(float scale, float margin, float spacing)
+__ri void ImGuiManager::DrawSettingsOverlay(float scale, float margin, float bottom_margin, float spacing)
 {
 	s_settings_overlay_height = 0.0f;
 
@@ -1226,7 +1226,7 @@ __ri void ImGuiManager::DrawSettingsOverlay(float scale, float margin, float spa
 
 	s_settings_overlay_height = text_size.y;
 
-	const float position_y = GetWindowHeight() - margin - text_size.y;
+	const float position_y = GetWindowHeight() - bottom_margin - text_size.y;
 	const ImVec2 text_pos(std::max(margin, GetWindowWidth() - margin - text_size.x), position_y);
 	const bool bold_osd = GSConfig.OsdBoldText;
 	dl->AddText(font, font_size,
@@ -1241,7 +1241,7 @@ __ri void ImGuiManager::DrawSettingsOverlay(float scale, float margin, float spa
 	}
 }
 
-__ri void ImGuiManager::DrawInputsOverlay(float scale, float margin, float spacing)
+__ri void ImGuiManager::DrawInputsOverlay(float scale, float margin, float bottom_margin, float spacing)
 {
 	// Technically this is racing the CPU thread.. but it doesn't really matter, at worst, the inputs get displayed onscreen late.
 	if (!GSConfig.OsdShowInputs ||
@@ -1274,7 +1274,7 @@ __ri void ImGuiManager::DrawInputsOverlay(float scale, float margin, float spaci
 	}
 
 	float current_x = ImFloor(margin);
-	float current_y = ImFloor(display_size.y - margin - ((static_cast<float>(num_ports) * (line_height + spacing)) - spacing));
+	float current_y = ImFloor(display_size.y - bottom_margin - ((static_cast<float>(num_ports) * (line_height + spacing)) - spacing));
 	const ImVec4 clip_rect(current_x, current_y, display_size.x - margin, display_size.y);
 
 	SmallString text;
@@ -2067,11 +2067,13 @@ void ImGuiManager::RenderOverlays()
 	const float base_margin = std::ceil(GSConfig.OsdMargin * scale);
 	const float spacing = std::ceil(5.0f * scale);
 
-	// The frontend hands us the cut-out and rounded-corner clearance on every rotation. Only one
-	// horizontal margin is threaded through the draw functions, so take the worse side.
-	float inset_left = 0.0f, inset_top = 0.0f, inset_right = 0.0f;
-	ImGuiManager::GetOSDSafeAreaInsets(&inset_left, &inset_top, &inset_right, nullptr);
+	// The frontend hands us the cut-out and home-indicator clearance on every rotation. Only one
+	// horizontal margin is threaded through the draw functions, so take the worse side; the bottom
+	// needs its own, or content anchored down there is spaced off the notch instead of the indicator.
+	float inset_left = 0.0f, inset_top = 0.0f, inset_right = 0.0f, inset_bottom = 0.0f;
+	ImGuiManager::GetOSDSafeAreaInsets(&inset_left, &inset_top, &inset_right, &inset_bottom);
 	const float margin = base_margin + std::max(inset_left, inset_right);
+	const float bottom_margin = base_margin + inset_bottom;
 	float position_y = base_margin + inset_top;
 
 	DrawIndicatorsOverlay(position_y, scale, margin, spacing);
@@ -2079,10 +2081,10 @@ void ImGuiManager::RenderOverlays()
 	DrawInputRecordingOverlay(position_y, scale, margin, spacing);
 	DrawTextureReplacementsOverlay(position_y, scale, margin, spacing);
 	if (GSConfig.OsdPerformancePos != OsdOverlayPos::None)
-		DrawPerformanceOverlay(position_y, scale, margin, spacing);
-	DrawSettingsOverlay(scale, margin, spacing);
-	DrawShaderCompileIndicator(scale, margin, spacing);
-	DrawInputsOverlay(scale, margin, spacing);
+		DrawPerformanceOverlay(position_y, scale, margin, bottom_margin, spacing);
+	DrawSettingsOverlay(scale, margin, bottom_margin, spacing);
+	DrawShaderCompileIndicator(scale, margin, bottom_margin, spacing);
+	DrawInputsOverlay(scale, margin, bottom_margin, spacing);
 	if (SaveStateSelectorUI::s_open)
 		SaveStateSelectorUI::Draw();
 }

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -83,10 +83,13 @@ SmallString s_speed_icon;
 SmallString s_ios_device_stats_line;
 #endif
 
-// Shrink-to-fit for the performance overlay. The widest line measured last frame decides how much
-// this frame has to come down; one frame of lag is invisible and it means we only measure once.
-static float s_osd_fit = 1.0f;
-static float s_osd_max_base_w = 0.0f;
+// Shrink-to-fit for the performance overlay. Only ever comes down, and only far enough for the widest
+// line to fit, so a value gaining a digit can't resize the block under the reader.
+static float s_osd_font_size = 0.0f;
+static float s_osd_fit_avail = -1.0f;
+static float s_osd_fit_base = -1.0f;
+static u32 s_osd_fit_lines = 0;
+static float s_osd_widest = 0.0f;
 
 constexpr ImU32 white_color = IM_COL32(255, 255, 255, 255);
 
@@ -249,32 +252,50 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 	// the top of RenderOverlays (see the note there). When every perf line is off, draw
 	// nothing and return BEFORE any draw call, so a line string cached before a pause can't
 	// linger on screen (the rebuild block below is skipped while the VM is paused, which is
-	// why toggling in the menu looked inert).
-	const bool no_perf_lines = !GSConfig.OsdShowFPS && !GSConfig.OsdShowVPS && !GSConfig.OsdShowSpeed &&
-							   !GSConfig.OsdShowResolution && !GSConfig.OsdShowCPU && !GSConfig.OsdShowGPU &&
-							   !GSConfig.OsdShowGSStats && !GSConfig.OsdShowFrameTimes && !GSConfig.OsdShowHardwareInfo &&
-							   !GSConfig.OsdShowVersion && !GSConfig.OsdShowGPUStats;
+	// why toggling in the menu looked inert). Packed rather than a chain of ors because the
+	// shrink-to-fit below needs to notice the set changing, not just emptying.
+	u32 enabled_lines =
+		(static_cast<u32>(GSConfig.OsdShowFPS) << 0) | (static_cast<u32>(GSConfig.OsdShowVPS) << 1) |
+		(static_cast<u32>(GSConfig.OsdShowSpeed) << 2) | (static_cast<u32>(GSConfig.OsdShowResolution) << 3) |
+		(static_cast<u32>(GSConfig.OsdShowCPU) << 4) | (static_cast<u32>(GSConfig.OsdShowGPU) << 5) |
+		(static_cast<u32>(GSConfig.OsdShowGSStats) << 6) | (static_cast<u32>(GSConfig.OsdShowFrameTimes) << 7) |
+		(static_cast<u32>(GSConfig.OsdShowHardwareInfo) << 8) | (static_cast<u32>(GSConfig.OsdShowVersion) << 9) |
+		(static_cast<u32>(GSConfig.OsdShowGPUStats) << 10);
 #if defined(__APPLE__) && TARGET_OS_IPHONE
 	// A Custom preset with nothing but Device Stats ticked is reachable, and it lands here.
-	if (no_perf_lines && !ARMSX2_iOSShouldShowDeviceStatsOverlay())
-		return;
-#else
-	if (no_perf_lines)
-		return;
+	enabled_lines |= static_cast<u32>(ARMSX2_iOSShouldShowDeviceStatsOverlay()) << 11;
 #endif
+	if (enabled_lines == 0)
+		return;
 
 	const float shadow_offset = std::ceil(scale);
 
 	ImFont* const osd_font = ImGuiManager::GetOSDFont();
 	const float base_font_size = ImGuiManager::GetFontSizeStandard();
 	const float avail = GetWindowWidth() - 2.0f * margin;
-	// Only ever shrink: the user picked their size with OsdScale and we are not going to second-guess
-	// it upwards. Portrait is less than half the width of landscape, which is where this bites.
-	s_osd_fit = (avail > 0.0f && s_osd_max_base_w > avail) ? std::clamp(avail / s_osd_max_base_w, 0.5f, 1.0f) : 1.0f;
-	s_osd_max_base_w = 0.0f;
-	// Integral so we don't ask ImGui for a new font bake on every sub-pixel wobble.
-	const float font_size = std::max(1.0f, std::floor(base_font_size * s_osd_fit));
-	const float fit_norm = base_font_size / font_size;
+
+	// Deriving the size from the current text every frame is what made the block dance — the widest
+	// line changes width constantly, and right-aligned rows each move by their own share of the
+	// rescale. Start over only when the space or the line set changes; in between, ratchet and hold.
+	if (avail != s_osd_fit_avail || base_font_size != s_osd_fit_base || enabled_lines != s_osd_fit_lines)
+	{
+		s_osd_fit_avail = avail;
+		s_osd_fit_base = base_font_size;
+		s_osd_fit_lines = enabled_lines;
+		s_osd_font_size = base_font_size;
+		s_osd_widest = 0.0f;
+	}
+	else if (avail > 0.0f && s_osd_widest > avail)
+	{
+		// Widths are linear in the size, so one step gets there. Integral, or ImGui bakes a fresh
+		// atlas for every sub-pixel wobble; half size is as small as this stays readable.
+		const float needed = std::floor(s_osd_font_size * avail / s_osd_widest);
+		s_osd_font_size = std::clamp(needed, std::max(1.0f, std::floor(base_font_size * 0.5f)), s_osd_font_size);
+	}
+	s_osd_widest = 0.0f;
+
+	const float font_size = s_osd_font_size;
+	const float fit = font_size / base_font_size;
 	const float line_height = ImGuiFullscreen::GetLineHeight({ osd_font, font_size });
 
 	ImDrawList* dl = ImGui::GetBackgroundDrawList();
@@ -309,8 +330,7 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 	do \
 	{ \
 		text_size = font->CalcTextSizeA(size, std::numeric_limits<float>::max(), -1.0f, (text), nullptr, nullptr); \
-		/* Normalise back to the unshrunk width, or the factor chases its own tail every frame. */ \
-		s_osd_max_base_w = std::max(s_osd_max_base_w, text_size.x * fit_norm); \
+		s_osd_widest = std::max(s_osd_widest, text_size.x); \
 		const ImVec2 text_pos = CalculatePerformanceOverlayTextPosition(GSConfig.OsdPerformancePos, margin, text_size, GetWindowWidth(), position_y); \
 		const bool __bold_osd = GSConfig.OsdBoldText; \
 		dl->AddText(font, size, ImVec2(text_pos.x + shadow_offset, text_pos.y + shadow_offset), IM_COL32(0, 0, 0, 100), (text)); \
@@ -842,8 +862,9 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 			float min_vps = s_vps_min;
 			float max_vps = std::max(s_vps_max, min_vps + 10.0f);
 
-			// The graph has to come down with the text or it overhangs a shrunken block.
-			const float graph_scale = scale * s_osd_fit;
+			// The graph has to come down with the text or it overhangs a shrunken block. Off the size
+			// the text actually got, not the ratio we asked for, or the two disagree by up to a step.
+			const float graph_scale = scale * fit;
 
 			SmallString label_buf;
 			label_buf.format("{:.1f}", max_val);
@@ -856,7 +877,7 @@ __ri void ImGuiManager::DrawPerformanceOverlay(float& position_y, float scale, f
 			const float legend_h = (font_size * 2.0f) + row_gap + pad;
 			const ImVec2 graph_size(200.0f * graph_scale, 60.0f * graph_scale);
 			const ImVec2 total_size(y_label_w + graph_size.x + right_label_w + 2.0f * pad, graph_size.y + legend_h + 2.0f * pad);
-			s_osd_max_base_w = std::max(s_osd_max_base_w, total_size.x * fit_norm);
+			s_osd_widest = std::max(s_osd_widest, total_size.x);
 
 			ImGui::SetNextWindowSize(total_size);
 			ImGui::SetNextWindowPos(CalculatePerformanceOverlayTextPosition(GSConfig.OsdPerformancePos, margin, total_size, GetWindowWidth(), position_y));

--- a/platforms/ios/app/src/main/cpp/ios_main.mm
+++ b/platforms/ios/app/src/main/cpp/ios_main.mm
@@ -318,15 +318,20 @@ void ARMSX2ConfigureImGuiFonts(const char* reason)
     int h = std::max(1, (int)(self.bounds.size.height * scale + 0.5));
     float s = (float)scale;
 
-    // Indent corner-anchored OSD by a small fixed clearance so it isn't clipped by the display's rounded corners
-    constexpr double kOsdCornerInsetPt = 18.0;
-    const float osd_inset = (float)(kOsdCornerInsetPt * scale);
+    // Keep corner-anchored OSD out of the notch, the Dynamic Island and the home indicator. UIKit
+    // already knows where those are; a flat constant was both too much on a device with square
+    // corners and nowhere near enough on one with a cut-out.
+    const UIEdgeInsets safe = self.safeAreaInsets;
+    ImGuiManager::SetOSDSafeAreaInsets((float)(safe.left * scale), (float)(safe.top * scale),
+                                       (float)(safe.right * scale), (float)(safe.bottom * scale));
+
     // -layoutSubviews is UIKit, i.e. the main thread, and it fires on every rotation and resize
     // with the VM running. The MTGS ring is single-producer and belongs to the CPU thread, so hop
-    // there first (Host::RunOnGSThread chains RunOnCPUThread -> MTGS::RunOnGSThread).
-    Host::RunOnGSThread([w, h, s, osd_inset]() {
+    // there first (Host::RunOnGSThread chains RunOnCPUThread -> MTGS::RunOnGSThread). The insets
+    // go direct because that hop drops anything queued while the GS thread is closed, which is
+    // every layout pass before a game boots — the OSD then drew unindented until the first rotate.
+    Host::RunOnGSThread([w, h, s]() {
         GSResizeDisplayWindow(w, h, s);
-        ImGuiManager::SetOSDSafeAreaInsets(osd_inset, osd_inset, osd_inset, osd_inset);
     });
 }
 @end


### PR DESCRIPTION
Follow up to #441. Users reported the OSD dancing during game startup and landing in two different places in portrait, and both came out of that change.

### What changed

* The performance overlay stops resizing itself every frame. The shrink to fit added in #441 derived its size from whatever the longest line happened to be at that instant, so a value gaining a digit moved the quotient, the floor dropped a whole step, and the entire block rescaled. Because the overlay is right aligned, every row then shifted by its own share of the rescale, which is why it looked like the rows were dancing independently. It picks a size once now and holds it until the available width, the font size or the set of enabled lines changes.
* The frame time graph was breathing about 5 pixels per frame with completely static content. The graph scaled off the continuous fit factor while the width accumulator normalised by the floored one, so whenever the graph was the widest element the loop never converged. Both sides use the size the text actually got now.
* The OSD sits in one place in portrait instead of two. The safe area clearance was pushed through a hop that drops anything queued while the GS thread is closed, which is every layout pass before a game boots. UIKit then has no reason to lay out again until something changes the bounds, so it stayed at zero for the whole session unless you rotated. It goes across directly now, as relaxed atomics, since the layout thread writes it and the GS thread reads it.
* Clearance comes from the view's own safe area insets rather than a flat 18pt on all four sides. That constant was too much on a phone with square corners and nowhere near enough on one with a cut out. No extra corner allowance is needed on top: wherever a display corner is rounded, an adjacent inset already exceeds the corner radius.
* Content anchored to the bottom of the screen gets the bottom inset. It was being spaced off the edge by the larger horizontal inset, which is zero in portrait, so the settings string and the shader compile spinner sat under the home indicator. Message toasts were skipping the insets altogether.

### Notes for reviewers

The fit is a ratchet: monotone non increasing within a key, reset only when the width, the base font size or the enabled line set changes. Hysteresis or a slow grow back would only have changed how often the block jumps, since the coupling between content and size survives either way. The ratchet removes that coupling by construction, so no feedback loop can exist.

The enabled line set is part of the reset key on purpose. Without it, going from Full to Simple would leave the overlay permanently shrunk to fit a line that is no longer drawn.

Nothing here touches the global ImGui scale or UpdateScale, and the change reduces font bakes rather than adding them.

Off iOS every inset is zero, so the margin arithmetic is numerically unchanged for Qt and Android.

One thing knowingly left alone: the horizontal margin still applies the worse of the two sides to both edges. Correcting it means changing eight signatures in shared code for an error that errs conservatively and is nil on symmetric landscape insets.

Built and packaged against a device Release build. Not yet run on hardware, so the portrait behaviour during startup and the notch clearance have not been watched in person.
