### PR TITLE
iOS: Extend Dynamic Actions and enforce Hardcore automatic-fire restrictions

### DIFF
--- a/platforms/ios/app/src/main/swift/Models/DynamicThumbstickSettings.swift
+++ b/platforms/ios/app/src/main/swift/Models/DynamicThumbstickSettings.swift
@@ -238,6 +238,10 @@ final class DynamicThumbstickSettings {
     var rightThumbstickActionsEnabled: Bool { didSet { setBool("DynamicThumbstickActionsEnabled", rightThumbstickActionsEnabled) } }
     var holdAimWhileSwipe: Bool { didSet { setBool("HoldAimWhileSwipe", holdAimWhileSwipe) } }
     var doubleTapToHoldAim: Bool { didSet { setBool("DoubleTapToHoldAim", doubleTapToHoldAim) } }
+    var singleTapActionOnNonAimMode: Bool {
+        didSet { setBool("SingleTapActionOnNonAimMode", singleTapActionOnNonAimMode) }
+    }
+    var actionsOnNonAimMode: Bool { didSet { setBool("ActionsOnNonAimMode", actionsOnNonAimMode) } }
     var tapToFire: Bool { didSet { setBool("TapToFire", tapToFire) } }
     var rapidTapFireEnabled: Bool { didSet { setBool("RapidTapFireEnabled", rapidTapFireEnabled) } }
     var releaseFireWhenTouchEnds: Bool { didSet { setBool("ReleaseFireWhenTouchEnds", releaseFireWhenTouchEnds) } }
@@ -304,6 +308,8 @@ final class DynamicThumbstickSettings {
         rightThumbstickActionsEnabled = Self.bool("DynamicThumbstickActionsEnabled", default: false)
         holdAimWhileSwipe = Self.bool("HoldAimWhileSwipe", default: false)
         doubleTapToHoldAim = Self.bool("DoubleTapToHoldAim", default: false)
+        singleTapActionOnNonAimMode = Self.bool("SingleTapActionOnNonAimMode", default: true)
+        actionsOnNonAimMode = Self.bool("ActionsOnNonAimMode", default: false)
         tapToFire = Self.bool("TapToFire", default: true)
         rapidTapFireEnabled = Self.bool("RapidTapFireEnabled", default: true)
         releaseFireWhenTouchEnds = Self.bool("ReleaseFireWhenTouchEnds", default: true)
@@ -336,7 +342,10 @@ final class DynamicThumbstickSettings {
             legacyThumbsticks = true
             dynamicThumbsticks = false
         }
-        if holdAimWhileSwipe && doubleTapToHoldAim {
+        if actionsOnNonAimMode && doubleTapToHoldAim {
+            doubleTapToHoldAim = false
+            setBool("DoubleTapToHoldAim", false)
+        } else if holdAimWhileSwipe && doubleTapToHoldAim {
             doubleTapToHoldAim = false
             setBool("DoubleTapToHoldAim", false)
         }
@@ -373,7 +382,34 @@ final class DynamicThumbstickSettings {
         doubleTapToHoldAim = enabled
         if enabled {
             holdAimWhileSwipe = false
+            actionsOnNonAimMode = false
         }
+    }
+
+    func setActionsOnNonAimMode(_ enabled: Bool) {
+        actionsOnNonAimMode = enabled
+        if enabled {
+            doubleTapToHoldAim = false
+        }
+    }
+
+    var singleTapActionAllowedInNonAimMode: Bool {
+        !doubleTapToHoldAim || singleTapActionOnNonAimMode || actionsOnNonAimMode
+    }
+
+    static func automaticFireBlockedByHardcore() -> Bool {
+        let state = ARMSX2Bridge.retroAchievementsState()
+        let active = (state["hardcoreActive"] as? NSNumber)?.boolValue ?? false
+        let preference = (state["hardcorePreference"] as? NSNumber)?.boolValue ?? false
+        let achievementsEnabled = (state["enabled"] as? NSNumber)?.boolValue ??
+            ARMSX2Bridge.getINIBool("Achievements", key: "Enabled", defaultValue: false)
+        let persistedPreference = ARMSX2Bridge.getINIBool(
+            "Achievements",
+            key: "ChallengeMode",
+            defaultValue: false
+        )
+        return active || ARMSX2Bridge.isRetroAchievementsHardcoreActive() ||
+            (achievementsEnabled && (preference || persistedPreference))
     }
 
     func restoreDefaults() {
@@ -411,6 +447,8 @@ final class DynamicThumbstickSettings {
         rightThumbstickActionsEnabled = false
         holdAimWhileSwipe = false
         doubleTapToHoldAim = false
+        singleTapActionOnNonAimMode = true
+        actionsOnNonAimMode = false
         tapToFire = true
         rapidTapFireEnabled = true
         releaseFireWhenTouchEnds = true

--- a/platforms/ios/app/src/main/swift/Views/Controller/DynamicThumbstickControls.swift
+++ b/platforms/ios/app/src/main/swift/Views/Controller/DynamicThumbstickControls.swift
@@ -648,6 +648,7 @@ final class VirtualPadTouchActionController {
     private var aimEngaged = false
     private var enteredAimThisInteraction = false
     private var rapidFireEngaged = false
+    private var automaticFireBlockedByHardcore = false
     private var aimReleaseTask: Task<Void, Never>?
     private var fireReleaseTask: Task<Void, Never>?
     private var fireLoopTask: Task<Void, Never>?
@@ -686,13 +687,21 @@ final class VirtualPadTouchActionController {
             setAimPressed(true)
         }
 
-        let insideRapidWindow = lastFireTapTime.map { now - $0 <= settings.rapidTapWindow } == true
-        if !insideRapidWindow { fireTapCount = 0 }
-        if !enteredAimThisInteraction &&
-            settings.rapidTapFireEnabled &&
-            insideRapidWindow &&
-            fireTapCount >= max(settings.rapidTapActivationCount - 1, 1) {
-            startRapidFire()
+        let automaticActionsAllowed = aimEngaged || settings.actionsOnNonAimMode
+        if automaticFireIsBlocked || !automaticActionsAllowed {
+            resetFireTapSequence()
+            if automaticFireIsBlocked {
+                stopRapidFire()
+            }
+        } else {
+            let insideRapidWindow = lastFireTapTime.map { now - $0 <= settings.rapidTapWindow } == true
+            if !insideRapidWindow { fireTapCount = 0 }
+            if !enteredAimThisInteraction &&
+                settings.rapidTapFireEnabled &&
+                insideRapidWindow &&
+                fireTapCount >= max(settings.rapidTapActivationCount - 1, 1) {
+                startRapidFire()
+            }
         }
     }
 
@@ -716,17 +725,24 @@ final class VirtualPadTouchActionController {
             return
         }
 
-        if let lastFireTapTime, now - lastFireTapTime <= settings.rapidTapWindow {
-            fireTapCount += 1
+        if (aimEngaged || settings.actionsOnNonAimMode) && !automaticFireIsBlocked {
+            if let lastFireTapTime, now - lastFireTapTime <= settings.rapidTapWindow {
+                fireTapCount += 1
+            } else {
+                fireTapCount = 1
+            }
+            self.lastFireTapTime = now
         } else {
-            fireTapCount = 1
+            resetFireTapSequence()
         }
-        self.lastFireTapTime = now
 
         if rapidFireEngaged {
             return
         }
-        guard settings.tapToFire else { return }
+        guard settings.tapToFire,
+              aimEngaged || settings.singleTapActionAllowedInNonAimMode else {
+            return
+        }
         if settings.doubleTapToHoldAim && !aimEngaged {
             scheduleSingleFire(after: settings.doubleTapWindow)
         } else {
@@ -827,7 +843,12 @@ final class VirtualPadTouchActionController {
     }
 
     private func startRapidFire() {
-        guard !rapidFireEngaged else { return }
+        let settings = DynamicThumbstickSettings.shared
+        guard !rapidFireEngaged,
+              !automaticFireIsBlocked,
+              aimEngaged || settings.actionsOnNonAimMode else {
+            return
+        }
         cancelPendingSingleFire()
         rapidFireEngaged = true
         crosshairState.setRapidFiring(true)
@@ -835,6 +856,12 @@ final class VirtualPadTouchActionController {
         fireLoopTask?.cancel()
         fireLoopTask = Task { @MainActor [weak self] in
             while !Task.isCancelled, let self, self.rapidFireEngaged {
+                guard !self.automaticFireIsBlocked else {
+                    self.rapidFireEngaged = false
+                    self.crosshairState.setRapidFiring(false)
+                    self.resetFireTapSequence()
+                    break
+                }
                 let interval = max(DynamicThumbstickSettings.shared.automaticFireInterval, 0.06)
                 self.setHoldFirePressed(true)
                 self.crosshairState.triggerShot()
@@ -878,12 +905,32 @@ final class VirtualPadTouchActionController {
     }
 
     private func setHoldFirePressed(_ pressed: Bool) {
+        if pressed && automaticFireIsBlocked {
+            Self.setActionButton(
+                pressed: false,
+                activeButton: &activeHoldFireButton,
+                selectedButton: DynamicThumbstickSettings.shared.holdFireButton(for: side),
+                source: "\(sourcePrefix).holdFire"
+            )
+            return
+        }
         Self.setActionButton(
             pressed: pressed,
             activeButton: &activeHoldFireButton,
             selectedButton: DynamicThumbstickSettings.shared.holdFireButton(for: side),
             source: "\(sourcePrefix).holdFire"
         )
+    }
+
+    func updateHardcoreAutomaticFireRestriction(_ blocked: Bool) {
+        automaticFireBlockedByHardcore = blocked
+        guard blocked else { return }
+        resetFireTapSequence()
+        stopRapidFire()
+    }
+
+    private var automaticFireIsBlocked: Bool {
+        automaticFireBlockedByHardcore || ARMSX2Bridge.isRetroAchievementsHardcoreActive()
     }
 
     private var sourcePrefix: String {
@@ -916,6 +963,16 @@ final class VirtualPadTouchActionController {
 final class VirtualPadTouchActionSession {
     let left = VirtualPadTouchActionController(side: .left)
     let right = VirtualPadTouchActionController(side: .right)
+
+    init() {
+        refreshHardcoreAutomaticFireRestriction()
+    }
+
+    func refreshHardcoreAutomaticFireRestriction() {
+        let blocked = DynamicThumbstickSettings.automaticFireBlockedByHardcore()
+        left.updateHardcoreAutomaticFireRestriction(blocked)
+        right.updateHardcoreAutomaticFireRestriction(blocked)
+    }
 
     func reset() {
         left.reset()

--- a/platforms/ios/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift
@@ -28,6 +28,7 @@ struct VirtualPadSettingsView: View {
     @State private var skinPendingDelete: VPadSkinDescriptor?
     @State private var skinPendingRename: VPadSkinDescriptor?
     @State private var skinRenameDraft = ""
+    @State private var automaticFireBlockedByHardcore = false
 
     var body: some View {
         Form {
@@ -444,6 +445,24 @@ struct VirtualPadSettingsView: View {
                             set: { dynamicSettings.setDoubleTapToHoldAim($0) }
                         )
                     )
+                    Toggle(
+                        settings.localized("Enable Single-Tap Action on Non-Aim Mode"),
+                        isOn: Binding(
+                            get: { dynamicSettings.singleTapActionAllowedInNonAimMode },
+                            set: { dynamicSettings.singleTapActionOnNonAimMode = $0 }
+                        )
+                    )
+                    .disabled(
+                        !dynamicSettings.doubleTapToHoldAim ||
+                            dynamicSettings.actionsOnNonAimMode
+                    )
+                    Toggle(
+                        settings.localized("Enable Actions on Non-Aim Mode"),
+                        isOn: Binding(
+                            get: { dynamicSettings.actionsOnNonAimMode },
+                            set: { dynamicSettings.setActionsOnNonAimMode($0) }
+                        )
+                    )
                     DynamicControlSlider(
                         title: dynamicActionTitle("Aim Release Delay", role: .aim),
                         value: $dynamicSettings.aimReleaseDelay,
@@ -480,8 +499,18 @@ struct VirtualPadSettingsView: View {
                     )
                     Toggle(
                         dynamicActionTitle("Multiple Taps Enable Automatic Fire", role: .holdFire),
-                        isOn: $dynamicSettings.rapidTapFireEnabled
+                        isOn: Binding(
+                            get: {
+                                dynamicSettings.rapidTapFireEnabled &&
+                                    !automaticFireBlockedByHardcore
+                            },
+                            set: { enabled in
+                                guard !automaticFireBlockedByHardcore else { return }
+                                dynamicSettings.rapidTapFireEnabled = enabled
+                            }
+                        )
                     )
+                    .disabled(automaticFireBlockedByHardcore)
                     DynamicControlSlider(
                         title: dynamicActionTitle("Multiple-Tap Window", role: .holdFire),
                         value: $dynamicSettings.rapidTapWindow,
@@ -489,7 +518,7 @@ struct VirtualPadSettingsView: View {
                         step: 0.01,
                         valueLabel: durationLabel
                     )
-                    .disabled(!dynamicSettings.rapidTapFireEnabled)
+                    .disabled(automaticFireControlsDisabled)
                     DynamicControlSlider(
                         title: dynamicActionTitle("Taps to Activate", role: .holdFire),
                         value: Binding(
@@ -500,7 +529,7 @@ struct VirtualPadSettingsView: View {
                         step: 1,
                         valueLabel: { "\(Int($0)) taps" }
                     )
-                    .disabled(!dynamicSettings.rapidTapFireEnabled)
+                    .disabled(automaticFireControlsDisabled)
                     DynamicControlSlider(
                         title: dynamicActionTitle("Automatic Fire Interval", role: .holdFire),
                         value: $dynamicSettings.automaticFireInterval,
@@ -508,17 +537,17 @@ struct VirtualPadSettingsView: View {
                         step: 0.01,
                         valueLabel: durationLabel
                     )
-                    .disabled(!dynamicSettings.rapidTapFireEnabled)
+                    .disabled(automaticFireControlsDisabled)
                     Toggle(
                         dynamicActionTitle("Extend Automatic Fire While Dragging", role: .holdFire),
                         isOn: $dynamicSettings.extendFireWhileDragging
                     )
-                        .disabled(!dynamicSettings.rapidTapFireEnabled)
+                        .disabled(automaticFireControlsDisabled)
                     Toggle(
                         dynamicActionTitle("Release Fire When Touch Ends", role: .holdFire),
                         isOn: $dynamicSettings.releaseFireWhenTouchEnds
                     )
-                        .disabled(!dynamicSettings.rapidTapFireEnabled)
+                        .disabled(automaticFireControlsDisabled)
                     DynamicControlSlider(
                         title: dynamicActionTitle("Fire Release Delay", role: .holdFire),
                         value: $dynamicSettings.fireReleaseDelay,
@@ -526,9 +555,16 @@ struct VirtualPadSettingsView: View {
                         step: 0.05,
                         valueLabel: durationLabel
                     )
-                    .disabled(!dynamicSettings.rapidTapFireEnabled || dynamicSettings.releaseFireWhenTouchEnds)
+                    .disabled(
+                        automaticFireControlsDisabled ||
+                            dynamicSettings.releaseFireWhenTouchEnds
+                    )
                 } header: {
                     Text(settings.localized("Dynamic Actions"))
+                } footer: {
+                    if automaticFireBlockedByHardcore {
+                        Text(settings.localized("Automatic Fire is disabled while RetroAchievements Hardcore Mode is on."))
+                    }
                 }
             }
 
@@ -540,6 +576,14 @@ struct VirtualPadSettingsView: View {
         }
         .navigationTitle(settings.localized("Virtual Pad"))
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear(perform: refreshHardcoreAutomaticFireRestriction)
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: Notification.Name("ARMSX2RetroAchievementsStateChanged")
+            )
+        ) { _ in
+            refreshHardcoreAutomaticFireRestriction()
+        }
         .sheet(isPresented: $showLayoutImporter) {
             ImportDocumentPicker(
                 allowedContentTypes: [.json, .data],
@@ -931,6 +975,14 @@ struct VirtualPadSettingsView: View {
 
     private func durationLabel(_ value: Double) -> String {
         String(format: "%.2f s", value)
+    }
+
+    private var automaticFireControlsDisabled: Bool {
+        automaticFireBlockedByHardcore || !dynamicSettings.rapidTapFireEnabled
+    }
+
+    private func refreshHardcoreAutomaticFireRestriction() {
+        automaticFireBlockedByHardcore = DynamicThumbstickSettings.automaticFireBlockedByHardcore()
     }
 }
 

--- a/platforms/ios/app/src/main/swift/Views/VirtualControllerView.swift
+++ b/platforms/ios/app/src/main/swift/Views/VirtualControllerView.swift
@@ -300,6 +300,7 @@ struct VirtualControllerView: View {
         // Prepare mask images before gameplay input so the first press cannot decode/scan on the hot path.
         .onAppear {
             ARMSX2VirtualPadMaskImageCache.prewarm(descriptor: effectiveSkinDescriptor)
+            activeTouchActionSession.refreshHardcoreAutomaticFireRestriction()
             configureAuxiliaryInputs()
         }
         .onChange(of: skinLibrary.selectedSkinID) { _, _ in
@@ -331,7 +332,15 @@ struct VirtualControllerView: View {
             cancelActiveInputSession()
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
+            activeTouchActionSession.refreshHardcoreAutomaticFireRestriction()
             configureAuxiliaryInputs()
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: Notification.Name("ARMSX2RetroAchievementsStateChanged")
+            )
+        ) { _ in
+            activeTouchActionSession.refreshHardcoreAutomaticFireRestriction()
         }
         .onDisappear {
             stopAuxiliaryInputs()


### PR DESCRIPTION
# iOS: Extend Dynamic Actions and enforce Hardcore automatic-fire restrictions

## Summary

This PR extends the iOS Virtual Pad's Dynamic Actions so players can choose which tap actions remain available outside Aim Mode. It also makes automatic fire comply with RetroAchievements Hardcore Mode at both the settings and runtime layers.

The changes are isolated to the Virtual Pad implementation and do not modify the menu, game library, backgrounds, presets, or emulator core.

## Changes

### Actions outside Aim Mode

- Adds **Enable Single-Tap Action on Non-Aim Mode**.
- Adds **Enable Actions on Non-Aim Mode**.
- Keeps single-tap actions available outside Aim Mode whenever **Double Tap to Hold Aim** is disabled.
- Allows the explicit single-tap option to preserve one-shot actions while **Double Tap to Hold Aim** remains enabled.
- Makes the full non-Aim action mode expose both tap and multiple-tap actions outside Aim Mode.
- Automatically disables **Double Tap to Hold Aim** when full non-Aim actions are enabled, preventing conflicting gesture interpretations.
- Resets the new options to safe defaults when Dynamic Control settings are restored.

### Dynamic Action routing

- Single taps are accepted only when the selected non-Aim policy allows them.
- Multiple taps can start automatic fire outside Aim Mode only when full non-Aim actions are enabled.
- Invalid or disallowed tap sequences are cleared instead of being retained for a later gesture.
- Rapid fire verifies its permission before starting and while its loop is running.
- Disabling permission releases the automatic-fire action and resets its tap sequence.

### RetroAchievements Hardcore Mode

- Automatic fire is force-disabled while Hardcore Mode is active.
- Runtime checks account for the active Hardcore state and the enabled persisted Challenge Mode preference.
- An already-running automatic-fire loop stops immediately when Hardcore becomes active.
- The automatic-fire toggle and all dependent sliders are disabled in Settings while the restriction applies.
- A settings footer explains why automatic fire is unavailable.
- The restriction is refreshed when:
  - the Virtual Pad appears;
  - the application becomes active; or
  - RetroAchievements publishes a state change.

## Behavior matrix

| Configuration | Single tap outside Aim Mode | Multiple taps / automatic fire outside Aim Mode | |---|---:|---:|
| Double Tap to Hold Aim off | Enabled | Disabled | | Double Tap to Hold Aim on, Single-Tap option on | Enabled | Disabled | | Full Actions on Non-Aim Mode on | Enabled | Enabled | | RetroAchievements Hardcore Mode on | Manual single tap follows the configured policy | Always disabled |

## Performance and resource impact

- No display link, timer, or frame-by-frame observer is added.
- Hardcore restrictions refresh from existing lifecycle and RetroAchievements notifications.
- Tap-state cleanup prevents an invalid sequence or automatic-fire task from remaining active after its permission changes.
- Automatic fire retains its existing task-based timing only while the action is allowed and engaged.

## Files changed

- `platforms/ios/app/src/main/swift/Models/DynamicThumbstickSettings.swift`
- `platforms/ios/app/src/main/swift/Views/Controller/DynamicThumbstickControls.swift`
- `platforms/ios/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift`
- `platforms/ios/app/src/main/swift/Views/VirtualControllerView.swift`

## Validation

- The complete combined working tree builds successfully with:

  ```sh ./platforms/ios/scripts/build-ios-ipa.sh ```

- The generated unsigned IPA completed Swift compilation and linking for `arm64-apple-ios17.0`.
- This split archive contains only the four Virtual Pad source files listed above and this PR description.

## Suggested review checks

1. Confirm a single tap performs the selected action outside Aim Mode when Double Tap to Hold Aim is disabled.
2. Enable Double Tap to Hold Aim and verify the explicit single-tap option controls non-Aim single shots.
3. Enable full Actions on Non-Aim Mode and verify Double Tap to Hold Aim is disabled.
4. Verify multiple taps can engage automatic fire outside Aim Mode only with full non-Aim actions enabled.
5. Enable RetroAchievements Hardcore Mode and verify automatic fire stops immediately and its settings become disabled.
6. Disable Hardcore Mode and confirm the controls refresh without restarting the application.

### Did you use AI to help find, test, or implement this issue or feature?
Yes, to generate this PR.