### PR TITLE
GS: fix missing draws on Adreno when texture replacements are loaded (#442)

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -524,6 +524,16 @@ set(pcsx2GSSources
 	GS/Renderers/Common/GSDevice.cpp
 	GS/Renderers/Common/GSDirtyRect.cpp
 	GS/Renderers/Common/GSFunctionMap.cpp
+	# The GPU driver-bug database is keyed on the DRIVER, not the platform: Turnip, PanVK and the
+	# Qualcomm blob all ship outside Android too (ARM Linux handhelds — Rocknix, Batocera). Building
+	# these only under ANDROID made every rule dead on exactly the hardware we test on, which is how
+	# #442 went unmatched. The one Android-only dependency (sys/system_properties.h) is guarded
+	# inside GSGPUProfile.cpp.
+	GS/Renderers/Common/GSGPUDriverProfile.cpp
+	GS/Renderers/Common/GSGPUProfile.cpp
+	GS/Renderers/Common/GSGPUProfileMali.cpp
+	GS/Renderers/Common/GSGPUProfileAdreno.cpp
+	GS/Renderers/Common/GSGPUProfilePowerVR.cpp
 	GS/Renderers/Common/GSPassScheduler.cpp
 	GS/Renderers/Common/GSRenderer.cpp
 	GS/Renderers/Common/GSTexture.cpp
@@ -570,6 +580,8 @@ set(pcsx2GSHeaders
 	GS/Renderers/Common/GSDirtyRect.h
 	GS/Renderers/Common/GSFastList.h
 	GS/Renderers/Common/GSFunctionMap.h
+	GS/Renderers/Common/GSGPUProfile.h
+	GS/Renderers/Common/GSGPUProfilePrivate.h
 	GS/Renderers/Common/GSPassScheduler.h
 	GS/Renderers/Common/GSRenderer.h
 	GS/Renderers/Common/GSShaderEnums.h
@@ -1167,17 +1179,10 @@ if(ANDROID)
 		Host/OboeAudioStream.cpp)
 	list(APPEND pcsx2GSSources
 		GS/Renderers/OpenGL/GLContextEGL.cpp
-		GS/Renderers/OpenGL/GLContextEGLAndroid.cpp
-		GS/Renderers/Common/GSGPUDriverProfile.cpp
-	GS/Renderers/Common/GSGPUProfile.cpp
-		GS/Renderers/Common/GSGPUProfileMali.cpp
-		GS/Renderers/Common/GSGPUProfileAdreno.cpp
-		GS/Renderers/Common/GSGPUProfilePowerVR.cpp)
+		GS/Renderers/OpenGL/GLContextEGLAndroid.cpp)
 	list(APPEND pcsx2GSHeaders
 		GS/Renderers/OpenGL/GLContextEGL.h
-		GS/Renderers/OpenGL/GLContextEGLAndroid.h
-		GS/Renderers/Common/GSGPUProfile.h
-		GS/Renderers/Common/GSGPUProfilePrivate.h)
+		GS/Renderers/OpenGL/GLContextEGLAndroid.h)
 	list(APPEND pcsx2Sources
 		Android/AndroidStubs.cpp
 		Android/AndroidPcapStubs.cpp

--- a/pcsx2/GS/Renderers/Common/GSGPUDriverProfile.cpp
+++ b/pcsx2/GS/Renderers/Common/GSGPUDriverProfile.cpp
@@ -339,7 +339,7 @@ static bool RuleMatches(const DriverRule& rule, const GpuProfileSelection& selec
 // Sources and exact upstream revisions are mirrored in docs/gpu-driver-database.json. A known
 // driver bug is not automatically an active workaround: expensive renderer fallbacks stay disabled
 // until their PCSX2 integration has a bounded, tested condition.
-static constexpr std::array<DriverRule, 25> s_driver_rules = {{
+static constexpr std::array<DriverRule, 26> s_driver_rules = {{
 	{"gl-arm-buffer-stream", MobileGpuApi::OpenGL, RuntimeGpuProfile::Mali,
 		MobileGpuDriver::ArmProprietary, MobileGpuArchitecture::Unknown, 0, 0, 0, {}, {}, 0, 0, false,
 		Bug(DriverBug::BrokenBufferStreaming) | Bug(DriverBug::BrokenUnsynchronizedMapping) |
@@ -405,10 +405,27 @@ static constexpr std::array<DriverRule, 25> s_driver_rules = {{
 		MobileGpuDriver::QualcommProprietary, MobileGpuArchitecture::Unknown, 0, 0, 0, {}, {}, 0, 0, false,
 		Bug(DriverBug::BrokenPrimitiveRestart) | Bug(DriverBug::BrokenProvokingVertex) |
 			Bug(DriverBug::BrokenSubpassFeedback) |
+			Bug(DriverBug::BrokenAttachmentFeedbackLoopLayout) |
 			Bug(DriverBug::BrokenReversedDepthRange) | Bug(DriverBug::SlowCachedReadbackMemory) |
 			Bug(DriverBug::SlowOptimalImageToBufferCopy),
 		Workaround(DriverWorkaround::DisableProvokingVertex) |
-			Workaround(DriverWorkaround::PreferCoherentReadback)},
+			Workaround(DriverWorkaround::PreferCoherentReadback) |
+			Workaround(DriverWorkaround::UseRenderTargetCopyForFeedback)},
+	// Turnip shares none of the blob's other defects but inherits the same broken render-target
+	// self-read, so it needs its own rule rather than the vk-qualcomm-proprietary one (which is
+	// keyed on MobileGpuDriver::QualcommProprietary).
+	//
+	// ARMSX2 #442: with an HD texture pack, Tales of the Abyss loses its entire 2D text layer the
+	// moment the replacement's alpha range flips those draws to require_one_barrier and the RT
+	// self-read engages. Device A/B on Turnip/Mesa 26.1.2 + Adreno 650 established that BOTH
+	// in-pass forms drop the content — the subpassLoad input attachment AND the
+	// feedback-loop-layout texelFetch sampler — while reading a separate RT copy renders
+	// correctly. Hence both bug bits and the expensive workaround. The reporter sees the same
+	// failure on the proprietary blob.
+	{"vk-turnip-attachment-self-read", MobileGpuApi::Vulkan, RuntimeGpuProfile::Adreno,
+		MobileGpuDriver::MesaTurnip, MobileGpuArchitecture::Unknown, 0, 0, 0, {}, {}, 0, 0, false,
+		Bug(DriverBug::BrokenSubpassFeedback) | Bug(DriverBug::BrokenAttachmentFeedbackLoopLayout),
+		Workaround(DriverWorkaround::UseRenderTargetCopyForFeedback)},
 	{"vk-qualcomm-pre-adreno8-readback", MobileGpuApi::Vulkan, RuntimeGpuProfile::Adreno,
 		MobileGpuDriver::QualcommProprietary, MobileGpuArchitecture::Unknown, 200, 799, 0, {}, {}, 0, 0, false,
 		Bug(DriverBug::SlowOptimalImageToBufferCopy),

--- a/pcsx2/GS/Renderers/Common/GSGPUProfile.cpp
+++ b/pcsx2/GS/Renderers/Common/GSGPUProfile.cpp
@@ -332,6 +332,7 @@ const char* GpuProfileDetector::WorkaroundToString(DriverWorkaround value)
 		case DriverWorkaround::UseDescriptorSets: return "UseDescriptorSets";
 		case DriverWorkaround::DisableProvokingVertex: return "DisableProvokingVertex";
 		case DriverWorkaround::DisableAttachmentFeedbackLoopLayout: return "DisableAttachmentFeedbackLoopLayout";
+		case DriverWorkaround::UseRenderTargetCopyForFeedback: return "UseRenderTargetCopyForFeedback";
 		case DriverWorkaround::EmulateColorWriteMask: return "EmulateColorWriteMask";
 		case DriverWorkaround::PreferCoherentReadback: return "PreferCoherentReadback";
 		case DriverWorkaround::UseStagingImageForReadback: return "UseStagingImageForReadback";

--- a/pcsx2/GS/Renderers/Common/GSGPUProfile.h
+++ b/pcsx2/GS/Renderers/Common/GSGPUProfile.h
@@ -142,6 +142,12 @@ enum class DriverWorkaround : u8
 	UseDescriptorSets,
 	DisableProvokingVertex,
 	DisableAttachmentFeedbackLoopLayout,
+	/// Read the render target from a separate COPY instead of in-pass, for drivers where no form
+	/// of attachment self-read works. Turns texture barriers off, which also disables framebuffer
+	/// fetch (it is the same in-tile read), so the RT is never bound as an attachment and sampled
+	/// at once. Expensive — a full render-target copy per feedback draw — so it is a last resort
+	/// for drivers that fail BOTH the input-attachment and feedback-loop-layout reads.
+	UseRenderTargetCopyForFeedback,
 	EmulateColorWriteMask,
 	PreferCoherentReadback,
 	UseStagingImageForReadback,

--- a/pcsx2/GS/Renderers/HW/GSTextureReplacementLoaders.cpp
+++ b/pcsx2/GS/Renderers/HW/GSTextureReplacementLoaders.cpp
@@ -475,8 +475,10 @@ static bool ParseDDSHeader(std::FILE* fp, DDSLoadInfo* info)
 
 		const GSDevice::FeatureSupport features(g_gs_device->Features());
 		// Mobile GPUs frequently expose no BC/BPTC support at all (Vulkan
-		// textureCompressionBC false: Adreno 650 / Snapdragon 865, and Mesa Turnip on any
-		// Adreno). Rejecting the file there silently drops the ENTIRE pack — and for packs
+		// textureCompressionBC false). It is driver-dependent rather than a property of the
+		// hardware: on Adreno 650 the Qualcomm blob gained BC at driver 512.614 (vulkan.gpuinfo.org
+		// splits cleanly across that revision), and Mesa Turnip reports it true. Rejecting the file
+		// on a driver that lacks it silently drops the ENTIRE pack — and for packs
 		// that also ship game-side data the result is worse than "no upscale": the P3P Slim
 		// Font mod pairs new FONT0.FNT glyph metrics with BC7 replacement glyphs, so with
 		// the textures dropped the game indexes the new narrow metrics into the old wide

--- a/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp
@@ -3265,18 +3265,26 @@ bool GSDeviceVK::CheckFeatures()
 	// their driver. Declared outside the Android block so it stays a harmless false on
 	// desktop. Populated from the resolved mobile profile just below.
 	bool force_xclipse_profile = false;
-#if defined(__ANDROID__)
-	// MediaTek (Dimensity/Helio) Mali Vulkan stacks return zero/stale destination color
-	// through ROAA (black / missing textures) across GPU generations, so detect the SoC
-	// here and disable fbfetch below. Ported from sashkinbro/EmuCoreX. Detection reads the
-	// ro.soc.* props already folded into the profile hints (no new JNI needed).
-	//
+
 	// The driver context feeds the driver-bug database (ported from EmuCoreX/sashkinbro with his
 	// approval). Vulkan is the good case: VkPhysicalDeviceDriverProperties names the blob outright,
 	// which is what the r44p1 DEVICE_LOST and 8-Elite push-descriptor fixes both learned the hard
 	// way — gate on driverID, never on vendorID, or Turnip/PanVK inherit proprietary workarounds.
 	// ProcessDeviceExtensions() has already filled m_device_driver_properties by the time we get
 	// here (CreateDeviceAndSwapChain runs before CheckFeatures), so one resolve sees everything.
+	//
+	// Resolved on EVERY platform, not just Android: the database is keyed on the DRIVER, and the
+	// same drivers ship off Android. Turnip on an ARM Linux handheld (Rocknix/Batocera) is the
+	// same Mesa stack with the same defects as Turnip on a phone, and it was the #442 reproducer.
+	// Gating this on __ANDROID__ made every rule silently dead on exactly the devices we test on.
+	// Resolution is pure data — a rule only changes behaviour where something queries HasBug()/
+	// UsesWorkaround(), and every such query is an explicit, per-defect decision.
+	//
+	// The MOBILE-SPECIFIC consequences below stay Android-only on purpose:
+	//   - SetRuntimeGPUProfile(): off Android the GL detector classifies every non-Mali GPU as
+	//     Adreno, so publishing the runtime profile here would hand desktop callers a wrong answer.
+	//   - GS tuning / GPU identity: their only consumers are themselves __ANDROID__-gated, and
+	//     changing desktop texture-pool sizing is not this code's business.
 	MobileDriverContext driver_context;
 	driver_context.api = MobileGpuApi::Vulkan;
 	driver_context.vendor_id = m_device_properties.vendorID;
@@ -3293,6 +3301,13 @@ bool GSDeviceVK::CheckFeatures()
 	const GpuProfileSelection mobile_profile = GpuProfileDetector::Resolve(
 		GSConfig.AndroidGpuProfileOverride, std::string_view(), m_device_properties.deviceName,
 		driver_context);
+	SetMobileDriverProfile(mobile_profile.driver);
+#if defined(__ANDROID__)
+	// MediaTek (Dimensity/Helio) Mali Vulkan stacks return zero/stale destination color
+	// through ROAA (black / missing textures) across GPU generations, so detect the SoC
+	// here and disable fbfetch below. Ported from sashkinbro/EmuCoreX. Detection reads the
+	// ro.soc.* props already folded into the profile hints (no new JNI needed).
+	//
 	// ★ Vulkan resolved mobile_profile and pushed every OTHER piece of it into the device
 	// (MediaTek SoC, GPU identity, GS tuning) but never the runtime profile itself, so
 	// IsMaliGPUProfile()/IsAdrenoGPUProfile() answered from the default for the entire Vulkan
@@ -3308,7 +3323,7 @@ bool GSDeviceVK::CheckFeatures()
 	// This is what constrains texture/target caching on weaker Mali (e.g. G615). From EmuCoreX.
 	SetMobileGPUIdentity(mobile_profile.gpu);
 	SetMobileGSTuning(mobile_profile.gs_tuning);
-	SetMobileDriverProfile(mobile_profile.driver);
+#endif
 	Console.WriteLn("VK: GPU profile override='%s' resolved='%s' driver='%s' version=%u.%u.%u "
 					"raw=%08x rules=%u bugs=%016llx workarounds=%016llx.",
 		GpuProfileDetector::OverrideToConfigString(mobile_profile.override_mode),
@@ -3322,7 +3337,28 @@ bool GSDeviceVK::CheckFeatures()
 		static_cast<unsigned long long>(mobile_profile.driver.bugs),
 		static_cast<unsigned long long>(mobile_profile.driver.workarounds));
 	DevCon.WriteLn("VK: GPU profile hints: %s", mobile_profile.hints.c_str());
-#endif
+
+	// BrokenSubpassFeedback + BrokenAttachmentFeedbackLoopLayout: on these drivers an in-pass
+	// render-target self-read can silently drop the whole draw, in BOTH shapes — the subpassLoad
+	// input attachment and the feedback-loop-layout texelFetch sampler. Reading a separate copy of
+	// the target is the only reliable form.
+	//
+	// ⚠️ Narrowed to replacement textures deliberately. Device A/B on Turnip/Adreno 650:
+	//   - TotA + HD pack, in-tile: text layer gone at 4x AND at 1x (so it is not tile-size related)
+	//   - TotA + HD pack, RT copy: correct
+	//   - NFS Underground, no pack, 608 barrier draws/frame through the same in-tile self-read:
+	//     renders correctly
+	// So the self-read is fine for ordinary blending and only fails when the draw also samples a
+	// replacement. Applying the copy unconditionally cost +38%/+40% frame time at 3x/4x on the
+	// NFSU dump (copies 5 -> 348 per frame, render passes 62 -> 391) for no correctness gain,
+	// which is far too much to charge every Adreno user for a bug none of them can hit without a
+	// texture pack. Pack users pay it and get correct output; everyone else keeps the fast path.
+	//
+	// If a title is ever reported losing draws WITHOUT a pack, widen this to unconditional — the
+	// underlying driver defect is not replacement-specific, only our evidence is.
+	const bool rt_self_read_is_broken =
+		GetMobileDriverProfile().UsesWorkaround(DriverWorkaround::UseRenderTargetCopyForFeedback) &&
+		GSConfig.LoadTextureReplacements;
 
 	// framebuffer_fetch: the tiler-native ordered Cd read (ROAA / subpassLoad in tile
 	// memory). It lets DetermineBarriers() (GSRendererHW.cpp) drop every per-primitive
@@ -3349,6 +3385,12 @@ bool GSDeviceVK::CheckFeatures()
 	// it ON there — the fast blend path on a tiler that drops the per-primitive
 	// barriers spiking GS on transparency-heavy scenes. Proprietary Adreno stays
 	// opt-in via EnableAdrenoFramebufferFetch; DisableFramebufferFetch still overrides.
+	//
+	// ⚠️ In practice this is currently moot on Adreno: UseRenderTargetCopyForFeedback turns texture
+	// barriers off below, and "fbfetch needs barriers" then clears framebuffer_fetch regardless of
+	// what this resolves to. Framebuffer fetch IS the in-tile self-read, so a driver that cannot
+	// do that read cannot have it. Kept as-is so a driver that stops carrying the bug recovers the
+	// fast path for free.
 	const bool is_turnip = (m_device_driver_properties.driverID == VK_DRIVER_ID_MESA_TURNIP);
 	// Samsung Xclipse (Exynos AMD-RDNA2) has no working ROAA-based framebuffer fetch — force it off
 	// there so we never route the fast-blend path into a broken unit. Inert if the 0x144D vendorID
@@ -3386,22 +3428,38 @@ bool GSDeviceVK::CheckFeatures()
 	// GL_ARM_shader_framebuffer_fetch (GSDeviceOGL) and never touches the Vulkan ROAA path.
 	const bool unreliable_mali_fbfetch =
 		(is_mediatek_mali_vk || is_mali_g57) && !GSConfig.ForceMaliFramebufferFetch;
+	// is_adreno (not just is_turnip): the removed `if (is_adreno)` block used to force fbfetch on
+	// for the whole vendor, so making it opt-in here would silently drop the proprietary blob onto
+	// the per-primitive barrier path — a regression unrelated to #442. Keeping the vendor listed
+	// preserves that default while letting DisableFramebufferFetch actually take effect, which the
+	// old unconditional force ate (see feedback_adreno_fbfetch_ini_override_measurement_trap).
+	// EnableAdrenoFramebufferFetch is therefore redundant now, but stays as a no-op OR term rather
+	// than churning a shipped INI key and its Android settings entry.
 	const bool vendor_allows_fbfetch = !unreliable_mali_fbfetch &&
-		(is_mali_vk || is_turnip || GSConfig.EnableAdrenoFramebufferFetch) && !is_xclipse_vk;
+		(is_mali_vk || is_adreno || GSConfig.EnableAdrenoFramebufferFetch) && !is_xclipse_vk;
 	m_features.framebuffer_fetch = vendor_allows_fbfetch &&
 		m_optional_extensions.vk_ext_rasterization_order_attachment_access && !GSConfig.DisableFramebufferFetch;
 	m_features.texture_barrier = GSConfig.OverrideTextureBarriers != 0;
-	// Qualcomm Adreno (turnip/freedreno) only reads the render target correctly through the coherent
-	// rasterization-order subpassLoad input-attachment path. The feedback-loop-layout sampler drops
-	// content (objects vanish) and the RT-copy fallback miscolours 16-bit fbmask draws, so force the
-	// subpassLoad path on regardless of INI: enable framebuffer fetch (requires the rasterization-order
-	// extension) and texture barriers, and disable the feedback-loop layout so the RT is bound as an
-	// input attachment. See GSTextureVK::Create for the matching image usage.
-	if (is_adreno)
+	// No working in-pass render-target self-read (ARMSX2 #442, Qualcomm/Turnip). Force the RT-COPY
+	// path: with texture barriers off, GSRendererHW reads Cd from a separate copy of the target
+	// (draw_rt_clone) instead of sampling the live attachment, and "fbfetch needs barriers" below
+	// (framebuffer_fetch &= texture_barrier) drops the in-tile read too. Expensive — one RT copy
+	// per feedback draw — but it is the only shape this driver renders correctly.
+	//
+	// tfx.glsl selects the read purely from two defines: DISABLE_TEXTURE_BARRIER (this path) or
+	// HAS_FEEDBACK_LOOP_LAYOUT. Both compile texelFetch; the difference is whether the sampled
+	// image is a copy or the live attachment, and only the copy works here. Turning
+	// framebuffer_fetch off on its own does NOT change the variant — it leaves subpassLoad in
+	// place, which is equally broken.
+	//
+	// Only applied when OverrideTextureBarriers is on auto (-1). An explicit 1 still wins, so the
+	// in-tile path stays reachable for A/B-ing this workaround's cost and for a future driver
+	// revision that fixes the read; an explicit 0 already lands here anyway.
+	if (rt_self_read_is_broken && GSConfig.OverrideTextureBarriers < 0)
 	{
-		m_optional_extensions.vk_ext_attachment_feedback_loop_layout = false;
-		m_features.framebuffer_fetch = m_optional_extensions.vk_ext_rasterization_order_attachment_access;
-		m_features.texture_barrier = true;
+		Console.WriteLn("VK: texture replacements active on a driver with an unreliable in-pass "
+						"render-target self-read — forcing the RT-copy blend path.");
+		m_features.texture_barrier = false;
 	}
 	// Mali r44p1: the attachment-feedback-loop-layout disable in CreateDevice only swapped the
 	// RT-as-texture LAYOUT/descriptor — it never removed the in-tile RT self-read itself, so Maximum

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -978,6 +978,11 @@ bool Pcsx2Config::GSOptions::RestartOptionsAreEqual(const GSOptions& right) cons
 		   OpEqu(EnableAdrenoFramebufferFetch) &&
 		   OpEqu(ForceMaliFramebufferFetch) &&
 		   OpEqu(OverrideTextureBarriers) &&
+		   // Drivers carrying UseRenderTargetCopyForFeedback only take the RT-copy path when
+		   // replacements are loaded (see GSDeviceVK::CheckFeatures), and that decision picks the
+		   // tfx.glsl RT-read variant at shader-compile time. Toggling this in place would leave
+		   // m_features.texture_barrier and every compiled pipeline disagreeing with the setting.
+		   OpEqu(LoadTextureReplacements) &&
 		   OpEqu(DepthFeedbackMode) &&
 		   OpEqu(BackThreadMode) &&
 		   OpEqu(HWAA1) &&

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -349,6 +349,11 @@
     </ClCompile>
     <ClCompile Include="GS\GSDump.cpp" />
     <ClCompile Include="GS\Renderers\Common\GSFunctionMap.cpp" />
+    <ClCompile Include="GS\Renderers\Common\GSGPUDriverProfile.cpp" />
+    <ClCompile Include="GS\Renderers\Common\GSGPUProfile.cpp" />
+    <ClCompile Include="GS\Renderers\Common\GSGPUProfileMali.cpp" />
+    <ClCompile Include="GS\Renderers\Common\GSGPUProfileAdreno.cpp" />
+    <ClCompile Include="GS\Renderers\Common\GSGPUProfilePowerVR.cpp" />
     <ClCompile Include="GS\Renderers\HW\GSHwHack.cpp" />
     <ClCompile Include="GS\GSLocalMemory.cpp" />
     <ClCompile Include="GS\GSLocalMemoryMultiISA.cpp" />
@@ -792,6 +797,8 @@
     <ClInclude Include="GS\GSDump.h" />
     <ClInclude Include="GS\Renderers\Common\GSFastList.h" />
     <ClInclude Include="GS\Renderers\Common\GSFunctionMap.h" />
+    <ClInclude Include="GS\Renderers\Common\GSGPUProfile.h" />
+    <ClInclude Include="GS\Renderers\Common\GSGPUProfilePrivate.h" />
     <ClInclude Include="GS\GSLocalMemory.h" />
     <ClInclude Include="GS\GSLzma.h" />
     <ClInclude Include="GS\GSPerfMon.h" />

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -1091,6 +1091,21 @@
     <ClCompile Include="GS\Renderers\Common\GSFunctionMap.cpp">
       <Filter>System\Ps2\GS\Renderers\Common</Filter>
     </ClCompile>
+    <ClCompile Include="GS\Renderers\Common\GSGPUDriverProfile.cpp">
+      <Filter>System\Ps2\GS\Renderers\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="GS\Renderers\Common\GSGPUProfile.cpp">
+      <Filter>System\Ps2\GS\Renderers\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="GS\Renderers\Common\GSGPUProfileMali.cpp">
+      <Filter>System\Ps2\GS\Renderers\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="GS\Renderers\Common\GSGPUProfileAdreno.cpp">
+      <Filter>System\Ps2\GS\Renderers\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="GS\Renderers\Common\GSGPUProfilePowerVR.cpp">
+      <Filter>System\Ps2\GS\Renderers\Common</Filter>
+    </ClCompile>
     <ClCompile Include="GS\GSCapture.cpp">
       <Filter>System\Ps2\GS\Window</Filter>
     </ClCompile>
@@ -2040,6 +2055,12 @@
       <Filter>System\Ps2\GS\Renderers\Common</Filter>
     </ClInclude>
     <ClInclude Include="GS\Renderers\Common\GSFunctionMap.h">
+      <Filter>System\Ps2\GS\Renderers\Common</Filter>
+    </ClInclude>
+    <ClInclude Include="GS\Renderers\Common\GSGPUProfile.h">
+      <Filter>System\Ps2\GS\Renderers\Common</Filter>
+    </ClInclude>
+    <ClInclude Include="GS\Renderers\Common\GSGPUProfilePrivate.h">
       <Filter>System\Ps2\GS\Renderers\Common</Filter>
     </ClInclude>
     <ClInclude Include="GS\GSCapture.h">


### PR DESCRIPTION
Fixes #442 — Tales of the Abyss with an HD texture pack loses its entire 2D text layer (title, "HD REMASTER", menu, copyright) on Vulkan/Adreno. Device-confirmed fixed on Snapdragon 865 / Adreno 650 / Turnip Mesa 26.1.2.

## Cause

Some draws read the render target back while it is still bound as the colour attachment. On Adreno, Vulkan silently drops those draws. The reporter saw it on **both Turnip and the proprietary blob**, which was the clue that it is the read itself rather than any one driver stack.

The texture pack is what triggers it: replacement textures shift the source alpha range, which changes a blending decision and flips exactly those text draws onto the framebuffer-read path. Pack off, the same draws never read the framebuffer and render fine. A `-drawlog` ledger over one dump, pack-on vs pack-off, is byte-identical **except** the `barrier` column on those six draws.

Device A/B on Turnip/Adreno 650 — both in-pass forms fail, only a separate copy works:

| RT read | shader define | result |
|---|---|---|
| `subpassLoad` on an input attachment | *(none)* | draws dropped |
| `texelFetch` on the live attachment | `HAS_FEEDBACK_LOOP_LAYOUT` | draws dropped |
| `texelFetch` on a separate RT copy | `DISABLE_TEXTURE_BARRIER` | **correct** |

Not tile-size related — the text is missing at 1× as well as 4×.

This replaces an `if (is_adreno)` block that forced the `subpassLoad` path on regardless of INI. Its own comment already recorded that the feedback-loop sampler drops content; what it missed is that `subpassLoad` drops it too, so it was choosing between two broken reads.

## Why it is narrowed to texture replacements

**NFS Underground pushes 608 barrier draws per frame through the same in-tile self-read with no pack, and renders correctly.** So the read is fine for ordinary blending, and applying the copy unconditionally would be charging every Adreno user for a bug they cannot hit without a pack:

| upscale | in-tile | RT copy | |
|---|---|---|---|
| 1× | 8.86 ms | 9.53 ms | +7.6% |
| 3× | 13.55 ms | 18.76 ms | **+38%** |
| 4× | 23.43 ms | 32.74 ms | **+40%** |

(NFSU dump replay, SD865, `-loop 25 -perf`; copies 5 → 348 per frame, render passes 62 → 391.)

Gated on `LoadTextureReplacements`, pack users get correct output and everyone else keeps the fast path. If a title is ever reported losing draws *without* a pack, widen it to unconditional — the driver defect is not replacement-specific, only our evidence is.

## The driver-bug database was dead outside Android

Rather than add another inline vendor test, this routes the decision through `GSGPUProfile`'s driver-bug database — which turned out never to have been consulted anywhere. Two separate reasons:

1. Its five source files were compiled only under `if(ANDROID)` in `pcsx2/CMakeLists.txt` and were **absent from `pcsx2.vcxproj` entirely**.
2. Every call site was `#if defined(__ANDROID__)`.

So every rule was dead on the ARM Linux handhelds we test on — including the device that reproduces this bug. Note that removing the `#if` alone does not link; the sources have to join the build first.

This resolves the driver profile on all platforms and gives the database its first `HasBug`/`UsesWorkaround` consumer, via a new `UseRenderTargetCopyForFeedback` workaround on `vk-qualcomm-proprietary` and a new `vk-turnip-attachment-self-read` rule.

**The mobile-only consequences stay Android-gated on purpose** — `SetRuntimeGPUProfile` (off Android the detector classifies every non-Mali GPU as Adreno), and GS pool tuning / GPU identity (their only consumers are themselves `__ANDROID__`-gated, and desktop pool sizing is out of scope here).

## Risk to non-Adreno targets: none

Verified two ways.

- **By construction**: `LooksLikeAdreno()` requires the literal `adreno`/`qualcomm`/`qcom`/`snapdragon` in the hints, so desktop GPUs resolve to `RuntimeGpuProfile::Unknown`. All 26 rules require Mali/Adreno/PowerVR except the two `*-android-shader-serialization` rules, which are gated on `min_android_sdk = 1`.
- **Empirically**, on Apple/Honeykrisp Vulkan: `resolved='Unknown' rules=0 bugs=0 workarounds=0`.

Two smaller items ride along because dropping the `is_adreno` force exposed them:

- **Adreno joins `vendor_allows_fbfetch`.** `EnableAdrenoFramebufferFetch` defaults to `false` in C++, and the removed block forced fbfetch on for the whole vendor, so without this the proprietary blob would silently drop to the per-primitive barrier path. Keeping the vendor listed preserves that default *and* lets `DisableFramebufferFetch` actually take effect there, which the unconditional force used to eat.
- **`LoadTextureReplacements` joins `RestartOptionsAreEqual`.** It now selects the `tfx.glsl` RT-read variant at shader-compile time, so toggling it in place would leave the feature flag and every compiled pipeline disagreeing with the setting. It already purged the whole texture cache on that edge, so the added cost is a GS reopen.

`OverrideTextureBarriers` still wins when set explicitly: `1` restores the in-tile path, `0` forces the copy.

## Testing

- Device, SD865/Adreno 650/Turnip, stock INI at 4×: pack **on** → gate fires, text renders; pack **off** → gate silent, `fbfetch=yes(in-tile)` retained. Both checked on clean single instances.
- NFS Underground on the in-tile path: renders correctly (the observation the narrowing rests on).
- `recompiler_tests`: 1513 passed, 2 skipped, 0 failed.
- Desktop `clang-devel` and the Rocknix cross build both link clean.

## Not verified

The block being replaced also claimed the RT-copy path *"miscolours 16-bit fbmask draws"*. We have never confirmed that, and it is now the path pack users take. Worth a look at a title with 16-bit fbmask effects before this is relied on.

Separately, Turnip dropping content on a legal in-render-pass attachment self-read — in both forms — looks like a Mesa bug worth reporting upstream. We have a reproducer dump.
