### PR TITLE
iOS: Preserve menu pause state and complete game-card zoom transitions

### DIFF
--- a/platforms/ios/app/src/main/swift/Models/AppState.swift
+++ b/platforms/ios/app/src/main/swift/Models/AppState.swift
@@ -185,10 +185,16 @@ final class AppState: @unchecked Sendable {
         }
     }
 
-    func shutdownAndBoot(isoName: String) {
+    func shutdownAndBoot(
+        isoName: String,
+        launchTransition: GameplayLaunchTransition? = nil
+    ) {
         guard requireBootableBIOS() else { return }
         pendingBootAction = { [weak self] in
-            self?.bootGame(isoName: isoName)
+            self?.bootGame(
+                isoName: isoName,
+                launchTransition: launchTransition
+            )
         }
         ARMSX2Bridge.requestVMShutdown()
     }

--- a/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
@@ -1748,6 +1748,14 @@ final class SettingsStore {
             UserDefaults.standard.set(clearLiquidGlassUI, forKey: "ARMSX2iOSClearLiquidGlassUI")
         }
     }
+    var gameCardZoomAnimationEnabled: Bool = true {
+        didSet {
+            UserDefaults.standard.set(
+                gameCardZoomAnimationEnabled,
+                forKey: "ARMSX2iOSGameCardZoomAnimationEnabled"
+            )
+        }
+    }
     var backgroundPrimaryAsset: BackgroundAsset? {
         didSet {
             if let asset = backgroundPrimaryAsset {
@@ -2033,6 +2041,9 @@ final class SettingsStore {
         clearLiquidGlassUI = UserDefaults.standard.object(
             forKey: "ARMSX2iOSClearLiquidGlassUI"
         ) as? Bool ?? true
+        gameCardZoomAnimationEnabled = UserDefaults.standard.object(
+            forKey: "ARMSX2iOSGameCardZoomAnimationEnabled"
+        ) as? Bool ?? true
         backgroundPrimaryAsset = Self.loadBackgroundAsset(forKey: "ARMSX2iOSBackgroundPrimaryAsset")
         backgroundLandscapeAsset = Self.loadBackgroundAsset(forKey: "ARMSX2iOSBackgroundLandscapeAsset")
         backgroundFitMode = BackgroundFitMode(rawValue: UserDefaults.standard.string(forKey: "ARMSX2iOSBackgroundFitMode") ?? "") ?? .fill
@@ -2262,6 +2273,9 @@ final class SettingsStore {
         dynamicAppearancePreferences = DynamicAppearancePreferences.load() ?? .standard
         clearLiquidGlassUI = UserDefaults.standard.object(
             forKey: "ARMSX2iOSClearLiquidGlassUI"
+        ) as? Bool ?? true
+        gameCardZoomAnimationEnabled = UserDefaults.standard.object(
+            forKey: "ARMSX2iOSGameCardZoomAnimationEnabled"
         ) as? Bool ?? true
         backgroundPrimaryAsset = Self.loadBackgroundAsset(forKey: "ARMSX2iOSBackgroundPrimaryAsset")
         backgroundLandscapeAsset = Self.loadBackgroundAsset(forKey: "ARMSX2iOSBackgroundLandscapeAsset")

--- a/platforms/ios/app/src/main/swift/Views/GameListView.swift
+++ b/platforms/ios/app/src/main/swift/Views/GameListView.swift
@@ -1383,7 +1383,7 @@ struct GameListView: View {
 
 		if appState.runningGameName != nil {
 			pendingGameName = game.bootName
-            pendingGameplayLaunchTransition = makeGameplayLaunchTransition(for: game)
+			pendingGameplayLaunchTransition = makeGameplayLaunchTransition(for: game)
 			showRestartAlert = true
 		} else {
             let transition = makeGameplayLaunchTransition(for: game)

--- a/platforms/ios/app/src/main/swift/Views/GameListView.swift
+++ b/platforms/ios/app/src/main/swift/Views/GameListView.swift
@@ -162,12 +162,18 @@ private extension View {
         for gameID: String,
         in registry: GameplayLaunchCardRegistry
     ) -> some View {
-        background {
-            GameplayLaunchCardRegistrationView(
-                gameID: gameID,
-                registry: registry
-            )
-            .allowsHitTesting(false)
+        overlay {
+            GeometryReader { geometry in
+                GameplayLaunchCardRegistrationView(
+                    gameID: gameID,
+                    registry: registry
+                )
+                .frame(
+                    width: geometry.size.width,
+                    height: geometry.size.height
+                )
+                .allowsHitTesting(false)
+            }
         }
     }
 }
@@ -292,6 +298,7 @@ struct GameListView: View {
     @State private var showGameReplacementAlert = false
     @State private var coverTemplateDraft = CoverStore.defaultCoverURLTemplate
     @State private var pendingGameName: String = ""
+    @State private var pendingGameplayLaunchTransition: GameplayLaunchTransition?
     @State private var pendingGameImportURLs: [URL] = []
     @State private var existingGameImportFileNames: [String] = []
     @State private var pendingCoverGameName: String?
@@ -533,12 +540,20 @@ struct GameListView: View {
                 Text("Use ${serial}, ${title}, or ${filetitle}. Default: \(CoverStore.defaultCoverURLTemplate)")
             }
             .alert(settings.localized("Restart VM?"), isPresented: $showRestartAlert) {
-                Button(settings.localized("Cancel"), role: .cancel) {}
+                Button(settings.localized("Cancel"), role: .cancel) {
+                    pendingGameplayLaunchTransition = nil
+                }
                 Button(settings.localized("Restart"), role: .destructive) {
                     if pendingGameName.isEmpty {
+                        pendingGameplayLaunchTransition = nil
                         appState.shutdownAndBootBIOS()
                     } else {
-                        appState.shutdownAndBoot(isoName: pendingGameName)
+                        let transition = pendingGameplayLaunchTransition
+                        pendingGameplayLaunchTransition = nil
+                        appState.shutdownAndBoot(
+                            isoName: pendingGameName,
+                            launchTransition: transition
+                        )
                     }
                 }
 			} message: {
@@ -792,7 +807,7 @@ struct GameListView: View {
 
     private func coverFlowLibrary(containerSize: CGSize) -> some View {
         let metrics = CoverFlowMetrics(containerSize: containerSize)
-        let availableHeight = max(0, containerSize.height - 62)
+        let availableHeight = max(0, containerSize.height - 12)
 
         return ScrollView(.horizontal, showsIndicators: false) {
             LazyHStack(alignment: .center, spacing: metrics.itemSpacing) {
@@ -1368,6 +1383,7 @@ struct GameListView: View {
 
 		if appState.runningGameName != nil {
 			pendingGameName = game.bootName
+            pendingGameplayLaunchTransition = makeGameplayLaunchTransition(for: game)
 			showRestartAlert = true
 		} else {
             let transition = makeGameplayLaunchTransition(for: game)
@@ -1382,6 +1398,9 @@ struct GameListView: View {
     private func makeGameplayLaunchTransition(
         for game: ISOEntry
     ) -> GameplayLaunchTransition? {
+        guard settings.gameCardZoomAnimationEnabled else {
+            return nil
+        }
         guard let cardView = gameplayLaunchCardRegistry.view(for: game.id),
               let window = cardView.window else {
             return nil

--- a/platforms/ios/app/src/main/swift/Views/GameScreenView.swift
+++ b/platforms/ios/app/src/main/swift/Views/GameScreenView.swift
@@ -316,7 +316,6 @@ struct GameScreenView: View {
                         clearCurrentGameCache()
                     },
                     onBackToMenu: {
-                        overlayRoute = .hidden
                         appState.returnToMenu()
                     },
                     onResume: {

--- a/platforms/ios/app/src/main/swift/Views/Settings/AppearanceSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/AppearanceSettingsView.swift
@@ -122,6 +122,9 @@ struct AppearanceSettingsView: View {
                 Toggle(isOn: $settings.clearLiquidGlassUI) {
                     Label(settings.localized("Clear Liquid Glass UI"), systemImage: "rectangle.on.rectangle")
                 }
+                Toggle(isOn: $settings.gameCardZoomAnimationEnabled) {
+                    Label(settings.localized("Game card zoom animation"), systemImage: "rectangle.inset.filled.and.person.filled")
+                }
             } header: {
                 Text(settings.localized("Interface"))
             } footer: {


### PR DESCRIPTION
# iOS: Preserve menu pause state and complete game-card zoom transitions

## Summary

This PR fixes the VM resuming when leaving the Quick Menu for the main menu and completes the optional game-card zoom transition across portrait, landscape, and confirmed VM restarts.

It also adds a persistent Appearance setting that lets users disable the game-card zoom animation without affecting game launch behavior.

## Changes

### Preserve pause state when returning to the menu, only one line changed to preserve the following

- Keep the Quick Menu overlay in its paused route while gameplay is being removed.
- Remove the intermediate transition to the hidden gameplay route from **Back to Menu**.
- Prevent that intermediate route from sending a resume request immediately before the menu sends its pause request.
- Leave the running VM paused behind the Games library until the user explicitly returns to the game.

### Game card zoom animation setting

- Adds **Game card zoom animation** under **Settings → Appearance → Interface**.
- Enables the setting by default.
- Persists the setting in `UserDefaults`.
- Reloads the value during both initial settings construction and settings reload.
- When disabled, game launch proceeds normally without capturing or presenting a card snapshot.

### Zoom animation after Restart VM confirmation

- Captures the selected card transition when a different game is tapped while a VM is already active.
- Retains the captured transition while the **Restart VM?** confirmation is displayed.
- Passes the transition through the asynchronous VM shutdown callback.
- Starts the newly selected game with the same card zoom used by a normal cold launch.
- Clears the pending snapshot when Restart is cancelled or when Boot BIOS is selected.
- Keeps existing callers source-compatible by making the restart transition optional.

### Landscape zoom animation

- Replaces the implicit background anchor sizing with an explicit `GeometryReader`-sized overlay.
- Gives the non-observable UIKit card anchor the exact rendered card width and height in list, portrait grid, and landscape cover-flow layouts.
- Continues to read only the tapped card's frame.
- Does not restore the previous observable per-card frame dictionary or introduce scroll-driven SwiftUI state updates.

## State flow

### Back to Menu

1. The Quick Menu remains in its paused route.
2. `AppState.returnToMenu()` requests VM pause.
3. Gameplay presentation is removed.
4. The menu appears while the VM remains paused.
5. Selecting **Now Running** explicitly resumes the VM.

### Restart with another game

1. The tapped card produces one rasterized transition snapshot.
2. The restart alert retains that snapshot.
3. Confirmation requests VM shutdown.
4. The existing shutdown observer invokes the pending boot action.
5. The boot action carries the snapshot into the normal gameplay launch transition.
6. The menu background and card fade into the newly running game.

## Performance and resource impact

- The zoom setting avoids all card snapshot work when disabled.
- Card frames remain in a weak, non-observable registry.
- Landscape sizing uses local layout geometry and does not publish frame changes into Games-view state.
- Only the tapped card is rasterized.
- A pending restart retains one `UIImage` for the short confirmation/shutdown interval.
- Cancelling the alert releases that pending image immediately.
- Existing gameplay transition completion still releases menu background and library resources.

## Files changed

- `platforms/ios/app/src/main/swift/Models/AppState.swift`
- `platforms/ios/app/src/main/swift/Models/SettingsStore.swift`
- `platforms/ios/app/src/main/swift/Views/GameListView.swift`
- `platforms/ios/app/src/main/swift/Views/GameScreenView.swift`
- `platforms/ios/app/src/main/swift/Views/Settings/AppearanceSettingsView.swift`

## Validation

- No runtime or automated tests were run, as requested.
- The complete iOS project built successfully with:

  ```sh ./platforms/ios/scripts/build-ios-ipa.sh ```

- Swift whole-module compilation and unsigned iOS arm64 linking completed successfully.

## Suggested manual checks

1. Pause gameplay, select **Back to Menu**, wait, and confirm the VM remains paused.
2. Select **Now Running** and confirm this explicit action resumes gameplay.
3. Launch a game from portrait with the zoom setting enabled and disabled.
4. Launch a game from landscape cover flow with the zoom setting enabled.
5. While a VM is active, select another game, confirm **Restart**, and verify the selected card zooms into the new game.
6. Cancel the restart alert and verify the current VM and menu remain unchanged.

### Did you use AI to help find, test, or implement this issue or feature?
Yes, to generate this PR.