### PR TITLE
Feat: Displays the current game CRC next to its serial in the in-game pause menu and by long-pressing a game in the main grid

### DIFF
--- a/platforms/android/app/src/main/java/com/armsx2/ui/emulation/EmulationMenuScreen.kt
+++ b/platforms/android/app/src/main/java/com/armsx2/ui/emulation/EmulationMenuScreen.kt
@@ -249,7 +249,7 @@ private fun MenuPage(
                 .padding(bottom = 18.dp),
         ) {
             if (compact) CompactMenuTabs(state.tab, viewModel::selectTab)
-            MenuHeader(compact, state.hardcore, state.richPresence)
+            MenuHeader(compact, state.hardcore, state.richPresence, state.gameCRC)
             HorizontalDivider(
                 modifier = Modifier.padding(horizontal = 8.dp),
                 color = MaterialTheme.colorScheme.outline.copy(alpha = 0.34f),
@@ -413,7 +413,7 @@ private fun tabGlyph(tab: EmulationMenuTab): String = when (tab) {
 }
 
 @Composable
-private fun MenuHeader(compact: Boolean, hardcore: Boolean, richPresence: String) {
+private fun MenuHeader(compact: Boolean, hardcore: Boolean, richPresence: String, gameCRC: String) {
     val game = MainActivityRuntime.currentGame.value
     Row(
         Modifier.fillMaxWidth().padding(horizontal = if (compact) 12.dp else 16.dp, vertical = 12.dp),
@@ -445,10 +445,14 @@ private fun MenuHeader(compact: Boolean, hardcore: Boolean, richPresence: String
                     com.armsx2.ui.common.StatusChip(g.extension.ifBlank { g.platform.key.uppercase() })
                 }
             }
-            if (!game?.serial.isNullOrBlank()) {
+            val identity = buildList {
+                game?.serial?.takeIf { it.isNotBlank() }?.let(::add)
+                gameCRC.takeIf { it.isNotBlank() }?.let { add("CRC $it") }
+            }.joinToString("  ·  ")
+            if (identity.isNotBlank()) {
                 Spacer(Modifier.height(2.dp))
                 Text(
-                    game?.serial.orEmpty(),
+                    identity,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/platforms/android/app/src/main/java/com/armsx2/ui/emulation/EmulationMenuViewModel.kt
+++ b/platforms/android/app/src/main/java/com/armsx2/ui/emulation/EmulationMenuViewModel.kt
@@ -42,6 +42,8 @@ data class EmulationMenuUiState(
     // RetroAchievements rich-presence line ("what you're doing right now"); shown in the
     // pause-menu header when a set is loaded. Empty when RA is off / no set.
     val richPresence: String = "",
+    // Current boot ELF CRC, used directly by <SERIAL>_<CRC>.pnach filenames.
+    val gameCRC: String = "",
 )
 
 class EmulationMenuViewModel(application: Application) : AndroidViewModel(application) {
@@ -59,6 +61,10 @@ class EmulationMenuViewModel(application: Application) : AndroidViewModel(applic
         val items = runCatching { parseAchievementItems(raJson) }.getOrDefault(emptyList())
         val raRoot = runCatching { org.json.JSONObject(raJson) }.getOrNull()
         val richPresence = runCatching { NativeApp.getRichPresence().orEmpty() }.getOrDefault("")
+        val gameCRC = runCatching { NativeApp.getGameCRC().orEmpty().trim().uppercase() }
+            .getOrDefault("")
+            .takeIf { it.matches(Regex("[0-9A-F]{8}")) && it != "00000000" }
+            .orEmpty()
         val summary = if (items.isNotEmpty()) {
             "${items.count { it.unlocked }} / ${items.size}"
         } else {
@@ -80,6 +86,7 @@ class EmulationMenuViewModel(application: Application) : AndroidViewModel(applic
             raAvatarUrl = raRoot?.optString("avatarUrl").orEmpty(),
             achievements = items,
             richPresence = richPresence,
+            gameCRC = gameCRC,
         )
     }
 

--- a/platforms/android/app/src/main/java/com/armsx2/ui/home/HomeScreen.kt
+++ b/platforms/android/app/src/main/java/com/armsx2/ui/home/HomeScreen.kt
@@ -641,6 +641,20 @@ fun HomeScreen(
     }
 
     menuGame?.let { game ->
+        val menuCRC by androidx.compose.runtime.produceState<String?>(initialValue = null, game.uri) {
+            value = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                val serial = game.serial?.takeIf { it.isNotBlank() }
+                runCatching {
+                    if (kr.co.iefriends.pcsx2.NativeApp.getGameSerial()?.takeIf { it.isNotBlank() } == serial) {
+                        kr.co.iefriends.pcsx2.NativeApp.getGameCRC()
+                            ?.takeIf { it.matches(Regex("[0-9A-Fa-f]{8}")) && it != "00000000" }
+                            ?.uppercase()
+                    } else {
+                        null
+                    }
+                }.getOrNull() ?: com.armsx2.DiscIdentity.crcOf(game.uri)
+            }
+        }
         ModalBottomSheet(onDismissRequest = { menuGame = null }) {
             Column(
                 Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).padding(start = 8.dp, end = 8.dp, bottom = 20.dp),
@@ -652,6 +666,16 @@ fun HomeScreen(
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp),
+                )
+                val identity = buildList {
+                    game.serial?.takeIf { it.isNotBlank() }?.let(::add)
+                    add("CRC ${menuCRC ?: "…"}")
+                }.joinToString("  ·  ")
+                Text(
+                    identity,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 8.dp),
                 )
                 GameMenuAction("▶", str("action.play")) {
                     menuGame = null

--- a/platforms/android/app/src/main/java/com/armsx2/ui/settings/InfoTab.kt
+++ b/platforms/android/app/src/main/java/com/armsx2/ui/settings/InfoTab.kt
@@ -122,7 +122,9 @@ fun InfoTab(game: GameInfo?) {
             Spacer(Modifier.height(10.dp))
             InfoRow(str("info.title"), game.title, clipboard)
             InfoRow(str("info.serial"), serial ?: "—", clipboard)
-            crc?.let { InfoRow(str("info.crc"), it, clipboard) }
+            // Keep the row stable while an unbooted CHD is being identified in the
+            // background; once resolved this is the value used in the PNACH filename.
+            InfoRow(str("info.crc"), crc ?: "—", clipboard)
             InfoRow(str("info.region"), regionName(game.serial), clipboard)
             InfoRow(str("info.container"), game.extension.takeIf { it.isNotBlank() } ?: "—", clipboard)
             InfoRow(str("info.platform"), game.platform.name, clipboard)


### PR DESCRIPTION
### Description of Changes
*Displays the current game CRC next to its serial in the in-game pause menu.
*Displays the serial and CRC in the game details sheet opened by long-pressing a game in the main grid.
*Keeps the CRC row visible in the per-game Info tab while CHD identification is in progress.
*Formats the identity as SLPM-xxxxx · CRC XXXXXXXX where applicable.
### Rationale behind Changes
PNACH files are identified using the game CRC, but the CRC was not readily visible in several Android UI paths. Users had to use external tools or inspect logs to determine the correct PNACH filename.
Showing the CRC near the game serial makes it easier to find, create, rename, and troubleshoot the corresponding <SERIAL>_<CRC>.pnach file, especially for CHD games.
### Suggested Testing Steps
Launch a PS2 game with a valid serial, such as SLPM-xxxxx.
Open the in-game pause menu.
Verify that the header shows SLPM-xxxxx · CRC XXXXXXXX.
Return to the Android game library.
Long-press the same game in the main grid.
Verify that its serial and CRC appear below the game title.
Open the game’s per-game settings and select the Info tab.
Verify that the CRC row is visible and resolves correctly.
### Did you use AI to help find, test, or implement this issue or feature?
Yes. AI was used to trace the Android UI paths responsible for the pause-menu header, long-press game details, and per-game Info tab, and to help implement and review the CRC display changes.