### PR TITLE
iOS: fix skin imports quietly losing the layout, and say what actually went wrong

### DIFF
--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
@@ -1312,15 +1312,60 @@ static BOOL ARMSX2IsControllerSkinImportName(NSString* name, NSSet<NSString*>* a
     return key.length > 0 && [allowedJSONNames containsObject:key];
 }
 
+// Skin authors hand-edit manifests and a raw tab inside a string is enough to
+// fail every JSON parser. Substituting a space keeps the length, and no byte
+// below 0x20 can be a UTF-8 continuation byte or part of a "\t" pair, so
+// multi-byte text and real escapes come through untouched.
+//
+// Swift has to do the same thing after extraction, so there is a second copy in
+// SkinManifestImporter.repairedJSON. Change one, change the other.
+static NSData* ARMSX2RepairedJSONData(NSData* data)
+{
+    NSMutableData* repaired = [data mutableCopy];
+    uint8_t* bytes = static_cast<uint8_t*>(repaired.mutableBytes);
+    const NSUInteger length = repaired.length;
+    BOOL inString = NO;
+    BOOL escaped = NO;
+    BOOL changed = NO;
+
+    for (NSUInteger i = 0; i < length; i++) {
+        const uint8_t byte = bytes[i];
+        if (!inString) {
+            if (byte == 0x22)
+                inString = YES;
+            continue;
+        }
+
+        if (escaped)
+            escaped = NO;
+        else if (byte == 0x5C)
+            escaped = YES;
+        else if (byte == 0x22)
+            inString = NO;
+        else if (byte < 0x20) {
+            bytes[i] = 0x20;
+            changed = YES;
+        }
+    }
+    return changed ? repaired : nil;
+}
+
 static NSMutableSet<NSString*>* ARMSX2AllowedControllerSkinJSONNames(zip_t* zf, zip_int64_t count)
 {
+    static const zip_uint64_t kMaxLooseLayoutBytes = 1024 * 1024;
+    static const NSUInteger kMaxLooseLayoutEntries = 8;
+
     NSMutableSet<NSString*>* allowedJSONNames = [NSMutableSet setWithObject:@"manifest.json"];
-    for (zip_uint64_t i = 0; i < static_cast<zip_uint64_t>(std::max<zip_int64_t>(count, 0)); i++) {
+    NSMutableSet<NSString*>* namedLayoutKeys = [NSMutableSet set];
+    const zip_uint64_t entryCount = static_cast<zip_uint64_t>(std::max<zip_int64_t>(count, 0));
+    for (zip_uint64_t i = 0; i < entryCount; i++) {
         zip_stat_t stat = {};
         if (zip_stat_index(zf, i, ZIP_FL_ENC_GUESS, &stat) != 0 || !stat.name)
             continue;
 
         NSString* entryName = [NSString stringWithUTF8String:stat.name];
+        if ([entryName containsString:@"__MACOSX"] || [entryName.lastPathComponent hasPrefix:@"."])
+            continue;
         if (![ARMSX2ControllerSkinJSONImportKey(entryName) isEqualToString:@"manifest.json"])
             continue;
 
@@ -1334,16 +1379,60 @@ static NSMutableSet<NSString*>* ARMSX2AllowedControllerSkinJSONNames(zip_t* zf, 
 
         NSData* manifestData = [NSData dataWithBytes:data->data() length:data->size()];
         id manifestObject = [NSJSONSerialization JSONObjectWithData:manifestData options:0 error:nil];
-        if (![manifestObject isKindOfClass:NSDictionary.class])
-            continue;
+        if (![manifestObject isKindOfClass:NSDictionary.class]) {
+            NSData* repaired = ARMSX2RepairedJSONData(manifestData);
+            manifestObject = repaired ? [NSJSONSerialization JSONObjectWithData:repaired options:0 error:nil] : nil;
+            if (![manifestObject isKindOfClass:NSDictionary.class])
+                continue;
+        }
 
         id layoutValue = [(NSDictionary*)manifestObject objectForKey:@"layout"];
         if (![layoutValue isKindOfClass:NSString.class])
             continue;
 
         NSString* layoutKey = ARMSX2ControllerSkinJSONImportKey((NSString*)layoutValue);
-        if (layoutKey.length > 0)
+        if (layoutKey.length > 0) {
             [allowedJSONNames addObject:layoutKey];
+            [namedLayoutKeys addObject:layoutKey];
+        }
+    }
+
+    // Naming a layout is not the same as shipping one. If the named file is really
+    // in there we are done; if it is not, fall through and let the loose pass find
+    // whatever the author actually shipped.
+    for (zip_uint64_t i = 0; i < entryCount && namedLayoutKeys.count > 0; i++) {
+        zip_stat_t stat = {};
+        if (zip_stat_index(zf, i, ZIP_FL_ENC_GUESS, &stat) != 0 || !stat.name)
+            continue;
+        NSString* entryName = [NSString stringWithUTF8String:stat.name];
+        if ([entryName containsString:@"__MACOSX"] || [entryName.lastPathComponent hasPrefix:@"."])
+            continue;
+        if ([namedLayoutKeys containsObject:ARMSX2ControllerSkinJSONImportKey(entryName)])
+            return allowedJSONNames;
+    }
+
+    // Nothing named, nothing readable to name it, or the named file is absent. Let
+    // the other jsons through so Swift can work out which one is the layout, but
+    // keep it bounded: too many candidates and it has no way to choose.
+    NSSet<NSString*>* manifestKeys = [NSSet setWithArray:@[@"manifest.json", @"info.json", @"manifest-v2.json"]];
+    NSUInteger looseCount = 0;
+    for (zip_uint64_t i = 0; i < entryCount && looseCount < kMaxLooseLayoutEntries; i++) {
+        zip_stat_t stat = {};
+        if (zip_stat_index(zf, i, ZIP_FL_ENC_GUESS, &stat) != 0 || !stat.name)
+            continue;
+        if ((stat.valid & ZIP_STAT_SIZE) && stat.size > kMaxLooseLayoutBytes)
+            continue;
+
+        NSString* entryName = [NSString stringWithUTF8String:stat.name];
+        if ([entryName containsString:@"__MACOSX"] || [entryName.lastPathComponent hasPrefix:@"."])
+            continue;
+
+        NSString* key = ARMSX2ControllerSkinJSONImportKey(entryName);
+        if (key.length == 0 || [manifestKeys containsObject:key] || [allowedJSONNames containsObject:key])
+            continue;
+
+        [allowedJSONNames addObject:key];
+        looseCount++;
     }
     return allowedJSONNames;
 }
@@ -2228,6 +2317,11 @@ static std::string ARMSX2PerGameSettingsPath(const std::string& serial, u32 crc)
             continue;
 
         NSString *entryName = [NSString stringWithUTF8String:stat.name];
+        // Every file in a mac-built zip has a "._" sibling, and they were eating
+        // the entry budget one-for-one with the real art. Skips dotfiles in
+        // general, which a skin has no business shipping anyway.
+        if ([entryName containsString:@"__MACOSX"] || [entryName.lastPathComponent hasPrefix:@"."])
+            continue;
         if (entryName.length == 0 || [entryName hasSuffix:@"/"] || !ARMSX2IsControllerSkinImportName(entryName, allowedJSONNames))
             continue;
 

--- a/platforms/ios/app/src/main/swift/Models/InitialContentBootstrap.swift
+++ b/platforms/ios/app/src/main/swift/Models/InitialContentBootstrap.swift
@@ -273,15 +273,27 @@ final class InitialContentBootstrap {
             let originalName = sourceURL.lastPathComponent
             let descriptor: VPadSkinDescriptor
 
-            if let existing = skinLibrary.importedDescriptors.first(where: {
+            let existing = skinLibrary.importedDescriptors.first {
                 $0.originalImportName?.caseInsensitiveCompare(originalName) == .orderedSame
-            }) {
+            }
+
+            // The same filename is not the same file. Someone dropping an
+            // updated zip in here expects it to take. An unreadable date keeps
+            // the old behaviour rather than reimporting on every launch.
+            var isNewerOnDisk = false
+            if let existing,
+               let modified = (try? sourceURL.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate {
+                isNewerOnDisk = modified > existing.updatedAt
+            }
+
+            if let existing, !isNewerOnDisk {
                 descriptor = existing
                 result.skipped += 1
             } else {
                 do {
                     let importResult = try await skinLibrary.importSkinArchive(
                         from: sourceURL,
+                        replacingSkinID: existing?.id,
                         layoutPresets: layoutPresets
                     )
                     descriptor = importResult.descriptor

--- a/platforms/ios/app/src/main/swift/Models/SkinCatalog.swift
+++ b/platforms/ios/app/src/main/swift/Models/SkinCatalog.swift
@@ -21,15 +21,18 @@ struct SkinCatalogManifest: Codable {
 }
 
 enum SkinCatalogError: LocalizedError {
-    case fetchFailed(URL, Error)
-    case decodeFailed(Error)
+    case unreachable
+    case serverError(Int)
+    case malformed
 
     var errorDescription: String? {
         switch self {
-        case .fetchFailed(let url, let error):
-            return "Could not load the skin catalog: \(error.localizedDescription)"
-        case .decodeFailed(let error):
-            return "The skin catalog format changed: \(error.localizedDescription)"
+        case .unreachable:
+            return "Can't reach the skin catalog. Check your connection and pull down to try again."
+        case .serverError(let code):
+            return "The skin catalog server answered with \(code). Pull down to try again."
+        case .malformed:
+            return "The skin catalog downloaded fine but can't be read. The file itself is broken, so this needs fixing in the skins repo rather than here."
         }
     }
 }
@@ -73,15 +76,23 @@ final class SkinCatalog: ObservableObject {
             }
             let (data, response) = try await URLSession.shared.data(for: request)
             if let http = response as? HTTPURLResponse, http.statusCode != 200 {
-                throw URLError(.badServerResponse)
+                throw SkinCatalogError.serverError(http.statusCode)
             }
-            let manifest = try JSONDecoder().decode(SkinCatalogManifest.self, from: data)
             guard !Task.isCancelled else { return }
+            // Reaching the file and being able to read it are different failures. One
+            // missing comma upstream used to come out as "check your connection", which
+            // sent people hunting a network problem they did not have.
+            let manifest: SkinCatalogManifest
+            do {
+                manifest = try JSONDecoder().decode(SkinCatalogManifest.self, from: data)
+            } catch {
+                throw SkinCatalogError.malformed
+            }
             skins = manifest.skins
             lastUpdated = Date()
         } catch {
             guard !Task.isCancelled else { return }
-            lastError = error.localizedDescription
+            lastError = (error as? SkinCatalogError ?? .unreachable).localizedDescription
         }
     }
 

--- a/platforms/ios/app/src/main/swift/Models/SkinInstaller.swift
+++ b/platforms/ios/app/src/main/swift/Models/SkinInstaller.swift
@@ -28,6 +28,8 @@ final class SkinInstaller: ObservableObject {
     /// knock each other's spinner out.
     @Published private(set) var installing: Set<String> = []
     @Published var errors: [String: String] = [:]
+    /// Warnings the import raised but which are not failures, keyed the same way.
+    @Published var notices: [String: String] = [:]
 
     private static let maxDownloadBytes: Int64 = 32 * 1024 * 1024
 
@@ -41,6 +43,7 @@ final class SkinInstaller: ObservableObject {
 
     func uninstall(_ skin: CatalogSkin) {
         errors[skin.file] = nil
+        notices[skin.file] = nil
         guard let descriptor = installedDescriptor(for: skin) else { return }
         do {
             try VPadSkinLibraryStore.shared.deleteImportedSkin(id: descriptor.id)
@@ -53,6 +56,7 @@ final class SkinInstaller: ObservableObject {
     private func install(_ skin: CatalogSkin, replacing replacingSkinID: String?) async {
         installing.insert(skin.file)
         errors[skin.file] = nil
+        notices[skin.file] = nil
         do {
             guard let zipURL = SkinCatalog.zipURL(for: skin) else {
                 throw SkinInstallError.unusableLink
@@ -90,13 +94,16 @@ final class SkinInstaller: ObservableObject {
                 throw SkinInstallError.emptyArchive
             }
 
-            _ = try await VPadSkinLibraryStore.shared.importSkin(
+            let result = try await VPadSkinLibraryStore.shared.importSkin(
                 from: extractDir,
                 originalImportName: skin.name,
                 catalogID: skin.file,
                 replacingSkinID: replacingSkinID,
                 layoutPresets: .shared
             )
+            if !result.warnings.isEmpty {
+                notices[skin.file] = result.warnings.joined(separator: "\n")
+            }
             syncSelectedSkin()
         } catch {
             errors[skin.file] = error.localizedDescription

--- a/platforms/ios/app/src/main/swift/Models/SkinManifestImporter.swift
+++ b/platforms/ios/app/src/main/swift/Models/SkinManifestImporter.swift
@@ -90,6 +90,10 @@ enum SkinManifestImporter {
             let manifest = try SkinManifestV2.decode(from: data)
             return .v2(manifest: manifest, packageRoot: packageRoot, repairedParentFolder: repairedParentFolder)
         } catch {
+            if let repaired = repairedJSON(data),
+               let manifest = try? SkinManifestV2.decode(from: repaired) {
+                return .v2(manifest: manifest, packageRoot: packageRoot, repairedParentFolder: repairedParentFolder)
+            }
             return .invalidV2(message: "the v2 manifest could not be parsed: \(error.localizedDescription)")
         }
     }
@@ -124,14 +128,51 @@ enum SkinManifestImporter {
     /// 2, a representations map, or a game-type identifier (the latter only when
     /// the file is not also an explicit v1 schemaVersion manifest).
     static func hasV2Marker(_ data: Data) -> Bool {
-        guard let object = try? JSONSerialization.jsonObject(with: data),
-              let dictionary = object as? [String: Any] else {
+        var object = try? JSONSerialization.jsonObject(with: data)
+        if object == nil, let repaired = repairedJSON(data) {
+            object = try? JSONSerialization.jsonObject(with: repaired)
+        }
+        guard let dictionary = object as? [String: Any] else {
             return false
         }
         if dictionary["representations"] != nil { return true }
         if (dictionary["formatVersion"] as? Int) == 2 { return true }
         if dictionary["gameTypeIdentifier"] != nil && dictionary["schemaVersion"] == nil { return true }
         return false
+    }
+
+    /// Substitutes a space for raw control bytes sitting inside JSON strings, so
+    /// a hand-edited manifest still parses. Returns nil when nothing changed;
+    /// callers parse strictly first and only fall back on failure. Nothing below
+    /// 0x20 can be a UTF-8 continuation byte or half of a "\t" pair, so escapes
+    /// and multi-byte text are left alone.
+    ///
+    /// The extractor needs this before Swift ever sees the file, so the same
+    /// walk exists as ARMSX2RepairedJSONData in ARMSX2Bridge.mm. Keep them level.
+    static func repairedJSON(_ data: Data) -> Data? {
+        var out = Data(capacity: data.count)
+        var inString = false
+        var escaped = false
+        var changed = false
+        for byte in data {
+            if inString {
+                if escaped {
+                    escaped = false
+                } else if byte == 0x5C {
+                    escaped = true
+                } else if byte == 0x22 {
+                    inString = false
+                } else if byte < 0x20 {
+                    out.append(0x20)
+                    changed = true
+                    continue
+                }
+            } else if byte == 0x22 {
+                inString = true
+            }
+            out.append(byte)
+        }
+        return changed ? out : nil
     }
 
     // MARK: - Validation

--- a/platforms/ios/app/src/main/swift/Models/VPadSkinLibraryStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/VPadSkinLibraryStore.swift
@@ -429,9 +429,34 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
         )
     }
 
+    /// The name this extracted skin is asking for, before uniquing pushes it to
+    /// "Something 2". Callers use it to spot a re-import of what they already
+    /// have.
+    func intendedDisplayName(forExtractedSkinAt url: URL) -> String {
+        let files = skinImportFiles(from: url)
+        return sanitizedDisplayName(
+            manifest(in: files)?.manifest.name,
+            fallback: sanitizedDisplayName(
+                sourceName(from: url.lastPathComponent),
+                fallback: "Imported Skin"
+            )
+        )
+    }
+
+    /// Matched on the display name, not the file it arrived in - the same skin
+    /// gets re-zipped under a new filename all the time. Catalog installs are
+    /// left out; replacing one by hand would strand its catalogID and break the
+    /// installed badge in the browser.
+    func existingImportedSkin(matchingName name: String) -> VPadSkinDescriptor? {
+        importedDescriptors.first {
+            $0.catalogID == nil && $0.displayName.caseInsensitiveCompare(name) == .orderedSame
+        }
+    }
+
     @discardableResult
     func importSkinArchive(
         from sourceURL: URL,
+        replacingSkinID: String? = nil,
         layoutPresets: PadLayoutPresetStore
     ) async throws -> VPadSkinImportResult {
         let accessGranted = sourceURL.startAccessingSecurityScopedResource()
@@ -462,6 +487,7 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
         return try await importSkin(
             from: archiveDirectory,
             originalImportName: sourceURL.lastPathComponent,
+            replacingSkinID: replacingSkinID,
             layoutPresets: layoutPresets
         )
     }

--- a/platforms/ios/app/src/main/swift/Models/VPadSkinLibraryStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/VPadSkinLibraryStore.swift
@@ -99,6 +99,22 @@ private struct VPadSkinManifest: Codable {
     var layout: String?
 }
 
+/// Whether a package had a manifest at all matters as much as what it said. A
+/// package with none is normal; one carrying a manifest nobody can read is worth
+/// telling the author about.
+private enum ManifestRead {
+    case absent
+    case read(VPadSkinManifest, repaired: Bool)
+    case unreadable
+
+    var manifest: VPadSkinManifest? {
+        if case .read(let manifest, _) = self {
+            return manifest
+        }
+        return nil
+    }
+}
+
 enum VPadSkinLibraryStoreError: LocalizedError {
     case missingSkin
     case noUsableSkinImages
@@ -345,7 +361,7 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
         let now = Date()
         let files = skinImportFiles(from: sourceURL)
         let manifestRead = manifest(in: files)
-        let manifest = manifestRead?.manifest
+        let manifest = manifestRead.manifest
         let baseName = sanitizedDisplayName(
             manifest?.name,
             fallback: sanitizedDisplayName(
@@ -373,8 +389,13 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
         }.value
 
         var warnings = decoded.warnings
-        if manifestRead?.repaired == true {
+        switch manifestRead {
+        case .read(_, repaired: true):
             warnings.append("The skin's manifest had a formatting error and was repaired on import.")
+        case .unreadable:
+            warnings.append("The skin's manifest could not be read, so the name and layout were worked out from the files instead.")
+        case .read, .absent:
+            break
         }
         for asset in decoded.assets {
             try writeSkinAsset(asset.data, to: destination.appendingPathComponent(asset.name))
@@ -398,24 +419,41 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
             updatedAt: now
         )
 
+        var layoutURL: URL?
+        var namedLayoutMissing = false
         if let layoutName = manifest?.layout?.trimmingCharacters(in: .whitespacesAndNewlines),
            !layoutName.isEmpty {
-            if let layoutURL = files.first(where: { $0.lastPathComponent.caseInsensitiveCompare(URL(fileURLWithPath: layoutName).lastPathComponent) == .orderedSame }) {
-                do {
-                    let data = try Data(contentsOf: layoutURL)
-                    let snapshot = try Self.decodeImportedLayoutSnapshot(from: data)
-                    let preset = layoutPresets.createPreset(
-                        named: "\(displayName) Layout",
-                        snapshot: snapshot,
-                        source: .futureImportedSkin,
-                        linkedSkinID: descriptor.id
-                    )
-                    descriptor.linkedLayoutPresetID = preset.id
-                } catch {
-                    warnings.append("Skipped invalid recommended layout.")
-                }
-            } else {
+            layoutURL = files.first { $0.lastPathComponent.caseInsensitiveCompare(URL(fileURLWithPath: layoutName).lastPathComponent) == .orderedSame }
+            namedLayoutMissing = layoutURL == nil
+        }
+
+        if layoutURL == nil {
+            // Nothing named, nothing readable to name it, or the named file is not in
+            // the package. A skin folder almost always holds one other json and it is
+            // the layout, so a package that names the wrong file still works out.
+            let candidates = Self.candidateLayoutURLs(in: files)
+            if candidates.count == 1 {
+                layoutURL = candidates[0]
+            } else if candidates.count > 1 {
+                warnings.append("Several layouts were found in this skin; none was applied automatically.")
+            } else if namedLayoutMissing {
                 warnings.append("Skipped missing recommended layout.")
+            }
+        }
+
+        if let layoutURL {
+            do {
+                let data = try Data(contentsOf: layoutURL)
+                let snapshot = try Self.decodeImportedLayoutSnapshot(from: data)
+                let preset = layoutPresets.createPreset(
+                    named: "\(displayName) Layout",
+                    snapshot: snapshot,
+                    source: .futureImportedSkin,
+                    linkedSkinID: descriptor.id
+                )
+                descriptor.linkedLayoutPresetID = preset.id
+            } catch {
+                warnings.append("Skipped invalid recommended layout.")
             }
         }
 
@@ -433,23 +471,28 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
     /// "Something 2". Callers use it to spot a re-import of what they already
     /// have.
     func intendedDisplayName(forExtractedSkinAt url: URL) -> String {
-        let files = skinImportFiles(from: url)
+        let fallback = sanitizedDisplayName(
+            sourceName(from: url.lastPathComponent),
+            fallback: "Imported Skin"
+        )
+        // A v2 package keeps its name in info.json, so asking only the legacy
+        // manifest would miss it and quietly skip the prompt.
+        if case .v2(let v2Manifest, _, _) = SkinManifestImporter.detectPackage(sourceURL: url) {
+            return sanitizedDisplayName(v2Manifest.name, fallback: fallback)
+        }
         return sanitizedDisplayName(
-            manifest(in: files)?.manifest.name,
-            fallback: sanitizedDisplayName(
-                sourceName(from: url.lastPathComponent),
-                fallback: "Imported Skin"
-            )
+            manifest(in: skinImportFiles(from: url)).manifest?.name,
+            fallback: fallback
         )
     }
 
     /// Matched on the display name, not the file it arrived in - the same skin
-    /// gets re-zipped under a new filename all the time. Catalog installs are
-    /// left out; replacing one by hand would strand its catalogID and break the
-    /// installed badge in the browser.
+    /// gets re-zipped under a new filename all the time. Catalog installs count
+    /// too: replacing one by hand drops its catalogID, which is honest, since the
+    /// browser should go back to offering it rather than claiming it is installed.
     func existingImportedSkin(matchingName name: String) -> VPadSkinDescriptor? {
         importedDescriptors.first {
-            $0.catalogID == nil && $0.displayName.caseInsensitiveCompare(name) == .orderedSame
+            $0.displayName.caseInsensitiveCompare(name) == .orderedSame
         }
     }
 
@@ -617,6 +660,27 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
         try PadLayoutImportExport.decodeSnapshot(from: data)
     }
 
+    /// Loose jsons in the package that actually decode as a layout. The payload
+    /// needs five keys, so the decode is the real filter and the name check just
+    /// keeps the manifests out of the loop.
+    private static func candidateLayoutURLs(in files: [URL]) -> [URL] {
+        let maxCandidates = 8
+        let maxBytes = 1024 * 1024
+        var examined = 0
+        var matches: [URL] = []
+        for url in files where examined < maxCandidates {
+            guard url.pathExtension.lowercased() == "json" else { continue }
+            let name = url.lastPathComponent.lowercased()
+            guard !SkinManifestImporter.manifestFileNames.contains(name), !name.hasPrefix(".") else { continue }
+            guard let size = (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize, size < maxBytes else { continue }
+            examined += 1
+            guard let data = try? Data(contentsOf: url),
+                  (try? decodeImportedLayoutSnapshot(from: data)) != nil else { continue }
+            matches.append(url)
+        }
+        return matches
+    }
+
     static func canonicalSkinFileName(forImportPath path: String) -> String? {
         let url = URL(fileURLWithPath: path)
         let exact = url.lastPathComponent.lowercased()
@@ -745,19 +809,19 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
         return [sourceURL]
     }
 
-    private func manifest(in files: [URL]) -> (manifest: VPadSkinManifest, repaired: Bool)? {
+    private func manifest(in files: [URL]) -> ManifestRead {
         guard let manifestURL = files.first(where: { $0.lastPathComponent.caseInsensitiveCompare("manifest.json") == .orderedSame }),
               let data = try? Data(contentsOf: manifestURL) else {
-            return nil
+            return .absent
         }
         if let decoded = try? JSONDecoder().decode(VPadSkinManifest.self, from: data) {
-            return (decoded, false)
+            return .read(decoded, repaired: false)
         }
         guard let repaired = SkinManifestImporter.repairedJSON(data),
               let decoded = try? JSONDecoder().decode(VPadSkinManifest.self, from: repaired) else {
-            return nil
+            return .unreadable
         }
-        return (decoded, true)
+        return .read(decoded, repaired: true)
     }
 
     private func copySkinAsset(from sourceURL: URL, to destinationURL: URL) throws {

--- a/platforms/ios/app/src/main/swift/Models/VPadSkinLibraryStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/VPadSkinLibraryStore.swift
@@ -99,9 +99,18 @@ private struct VPadSkinManifest: Codable {
     var layout: String?
 }
 
-enum VPadSkinLibraryStoreError: Error {
+enum VPadSkinLibraryStoreError: LocalizedError {
     case missingSkin
     case noUsableSkinImages
+
+    var errorDescription: String? {
+        switch self {
+        case .missingSkin:
+            return "That skin is no longer in the library."
+        case .noUsableSkinImages:
+            return "No usable button images were found."
+        }
+    }
 }
 
 @Observable
@@ -335,7 +344,8 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
         }
         let now = Date()
         let files = skinImportFiles(from: sourceURL)
-        let manifest = manifest(in: files)
+        let manifestRead = manifest(in: files)
+        let manifest = manifestRead?.manifest
         let baseName = sanitizedDisplayName(
             manifest?.name,
             fallback: sanitizedDisplayName(
@@ -363,6 +373,9 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
         }.value
 
         var warnings = decoded.warnings
+        if manifestRead?.repaired == true {
+            warnings.append("The skin's manifest had a formatting error and was repaired on import.")
+        }
         for asset in decoded.assets {
             try writeSkinAsset(asset.data, to: destination.appendingPathComponent(asset.name))
         }
@@ -706,12 +719,19 @@ final class VPadSkinLibraryStore: @unchecked Sendable {
         return [sourceURL]
     }
 
-    private func manifest(in files: [URL]) -> VPadSkinManifest? {
+    private func manifest(in files: [URL]) -> (manifest: VPadSkinManifest, repaired: Bool)? {
         guard let manifestURL = files.first(where: { $0.lastPathComponent.caseInsensitiveCompare("manifest.json") == .orderedSame }),
               let data = try? Data(contentsOf: manifestURL) else {
             return nil
         }
-        return try? JSONDecoder().decode(VPadSkinManifest.self, from: data)
+        if let decoded = try? JSONDecoder().decode(VPadSkinManifest.self, from: data) {
+            return (decoded, false)
+        }
+        guard let repaired = SkinManifestImporter.repairedJSON(data),
+              let decoded = try? JSONDecoder().decode(VPadSkinManifest.self, from: repaired) else {
+            return nil
+        }
+        return (decoded, true)
     }
 
     private func copySkinAsset(from sourceURL: URL, to destinationURL: URL) throws {

--- a/platforms/ios/app/src/main/swift/Views/Settings/SkinBrowserView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/SkinBrowserView.swift
@@ -32,9 +32,7 @@ struct SkinBrowserView: View {
 
             if let error = catalog.lastError {
                 VStack(alignment: .leading, spacing: 8) {
-                    Text(catalog.skins.isEmpty
-                         ? "Can't reach the skin catalog. Check your connection and pull down to try again."
-                         : error)
+                    Text(error)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                     Button("Retry") { Task { await catalog.fetch(force: true) } }

--- a/platforms/ios/app/src/main/swift/Views/Settings/SkinBrowserView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/SkinBrowserView.swift
@@ -10,7 +10,7 @@ struct SkinBrowserView: View {
     // off whatever the installer happens to be publishing.
     @State private var skinLibrary = VPadSkinLibraryStore.shared
     @State private var searchText = ""
-    @State private var errorAlert: String?
+    @State private var detailAlert: String?
     @State private var previewSkin: CatalogSkin?
     @State private var skinPendingRemoval: CatalogSkin?
 
@@ -62,13 +62,13 @@ struct SkinBrowserView: View {
         .navigationBarTitleDisplayMode(.inline)
         .task { await catalog.fetch() }
         .refreshable { await catalog.fetch(force: true) }
-        .alert("Download Failed", isPresented: Binding(
-            get: { errorAlert != nil },
-            set: { if !$0 { errorAlert = nil } }
+        .alert("Skin Install", isPresented: Binding(
+            get: { detailAlert != nil },
+            set: { if !$0 { detailAlert = nil } }
         )) {
             Button("OK", role: .cancel) {}
         } message: {
-            Text(errorAlert ?? "")
+            Text(detailAlert ?? "")
         }
         .alert(
             "Remove Skin?",
@@ -184,13 +184,22 @@ struct SkinBrowserView: View {
 
             if let error = installer.errors[skin.file] {
                 Button {
-                    errorAlert = error
+                    detailAlert = error
                 } label: {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .foregroundStyle(.orange)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Show the error from \(skin.name)")
+            } else if let notice = installer.notices[skin.file] {
+                Button {
+                    detailAlert = notice
+                } label: {
+                    Image(systemName: "exclamationmark.circle")
+                        .foregroundStyle(.yellow)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Show what \(skin.name) reported during install")
             }
         }
         .swipeActions(edge: .trailing) {

--- a/platforms/ios/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift
@@ -11,6 +11,43 @@ private enum DynamicActionRole {
     case holdFire
 }
 
+private struct SkinReplacePrompt: Identifiable {
+    let id = UUID()
+    let name: String
+    let existingSkinID: String
+}
+
+private enum SkinReplaceChoice {
+    case replace(String)
+    case keepBoth
+    case cancel
+}
+
+/// Holds the answer the import is waiting on. The view owns one, so leaving the
+/// screen with the dialog still up unblocks the import on the way out instead of
+/// parking it on a continuation nobody is left to resume.
+@MainActor
+private final class SkinReplaceGate {
+    private var continuation: CheckedContinuation<SkinReplaceChoice, Never>?
+
+    func wait() async -> SkinReplaceChoice {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    /// Answers at most once, whichever of the buttons or the dismissal gets here first.
+    func resume(_ choice: SkinReplaceChoice) {
+        guard let continuation else { return }
+        self.continuation = nil
+        continuation.resume(returning: choice)
+    }
+
+    deinit {
+        continuation?.resume(returning: .cancel)
+    }
+}
+
 struct VirtualPadSettingsView: View {
     @State private var settings = SettingsStore.shared
     @State private var dynamicSettings = DynamicThumbstickSettings.shared
@@ -28,6 +65,8 @@ struct VirtualPadSettingsView: View {
     @State private var skinPendingDelete: VPadSkinDescriptor?
     @State private var skinPendingRename: VPadSkinDescriptor?
     @State private var skinRenameDraft = ""
+    @State private var skinReplacePrompt: SkinReplacePrompt?
+    @State private var skinReplaceGate = SkinReplaceGate()
     @State private var automaticFireBlockedByHardcore = false
 
     var body: some View {
@@ -697,6 +736,37 @@ struct VirtualPadSettingsView: View {
         } message: { skin in
             Text("This removes the imported skin. Linked layout presets are kept.")
         }
+        .confirmationDialog(
+            "\(skinReplacePrompt?.name ?? "This skin") is already installed",
+            isPresented: Binding<Bool>(
+                get: { skinReplacePrompt != nil },
+                set: {
+                    if !$0 {
+                        skinReplacePrompt = nil
+                        // A tapped button gets there first. This only catches a
+                        // dialog that went away without one, which would
+                        // otherwise leave the import waiting forever.
+                        DispatchQueue.main.async { resumeSkinReplace(.cancel) }
+                    }
+                }
+            ),
+            presenting: skinReplacePrompt
+        ) { prompt in
+            Button("Replace") {
+                skinReplacePrompt = nil
+                resumeSkinReplace(.replace(prompt.existingSkinID))
+            }
+            Button("Keep Both") {
+                skinReplacePrompt = nil
+                resumeSkinReplace(.keepBoth)
+            }
+            Button("Cancel", role: .cancel) {
+                skinReplacePrompt = nil
+                resumeSkinReplace(.cancel)
+            }
+        } message: { _ in
+            Text("Replace it, or keep both copies?")
+        }
         .fullScreenCover(isPresented: $showLayoutEditor) {
             PadLayoutEditView(
                 onDismiss: { showLayoutEditor = false },
@@ -825,10 +895,26 @@ struct VirtualPadSettingsView: View {
                 messages.append("No usable skin files were imported from \(sourceURL.lastPathComponent).")
                 continue
             }
+
+            var replacingSkinID: String?
+            let intendedName = skinLibrary.intendedDisplayName(forExtractedSkinAt: archiveDirectory)
+            if let existing = skinLibrary.existingImportedSkin(matchingName: intendedName) {
+                switch await askAboutExistingSkin(named: intendedName, existingSkinID: existing.id) {
+                case .replace(let id):
+                    replacingSkinID = id
+                case .keepBoth:
+                    break
+                case .cancel:
+                    messages.append("Kept the existing '\(intendedName)'.")
+                    continue
+                }
+            }
+
             do {
                 let result = try await skinLibrary.importSkin(
                     from: archiveDirectory,
                     originalImportName: sourceURL.lastPathComponent,
+                    replacingSkinID: replacingSkinID,
                     layoutPresets: layoutPresets
                 )
                 latestResult = result
@@ -842,6 +928,15 @@ struct VirtualPadSettingsView: View {
             ? "No usable skin images were imported. Use loose button PNGs/JPGs/WebPs, a portrait/landscape controller image, or a zip skin pack containing image files."
             : messages.joined(separator: "\n\n")
         return (message, latestResult)
+    }
+
+    private func askAboutExistingSkin(named name: String, existingSkinID: String) async -> SkinReplaceChoice {
+        skinReplacePrompt = SkinReplacePrompt(name: name, existingSkinID: existingSkinID)
+        return await skinReplaceGate.wait()
+    }
+
+    private func resumeSkinReplace(_ choice: SkinReplaceChoice) {
+        skinReplaceGate.resume(choice)
     }
 
     private func isSkinArchive(_ url: URL) -> Bool {


### PR DESCRIPTION
Someone reported that reimporting a skin zip under the same name would not pick up a layout they had just added to it. Digging into the two zips they sent turned up something else: their manifest.json had a real tab character sitting inside a string, which is not legal JSON, so every parser in the app rejected the file and said nothing about it. The skin imported anyway, minus its layout.

### What changed

* A skin manifest with a stray control character in it still works. Authors hand edit these files and a tab where a space should be is enough to make the whole thing unreadable. It gets patched up on the way in, and the import tells you it had to, so you can go fix the file.
* A manifest that is broken past patching up now says so too. Before, a package with no manifest and a package with a manifest nobody could read were treated the same way, silently.
* The layout gets found even when the manifest does not name it, or names a file that is not in the zip. Naming the wrong file is the same mistake as naming none, and it is the case where looking for the layout helps most. If there is exactly one json in the package that reads as a layout, that is the one.
* Importing a skin you already have asks whether to replace it or keep both, instead of quietly making a second copy called "Neon 2". It matches on the name the skin gives itself, since the same skin gets zipped up under a new filename all the time.
* Dropping an updated zip into the SKINS folder actually takes now. It used to skip anything whose filename it had seen before, so an updated file with the old name was ignored on every launch. It compares the date on the file instead.
* Files that macOS hides inside a zip are skipped. Every file in a mac built zip gets a "._" twin, and those were eating into the limit on how many entries an import will read, so a skin with a lot of button art could quietly lose some of it.
* The Skins browser stops blaming your connection for things that are not your connection. A catalog that downloads fine and then fails to parse now says that, which is what happened last week when the community manifest picked up a few missing commas.
* Failures during a skin import read like sentences. They were coming out as "...error 1."

### Notes for reviewers

The extractor has to read a manifest before Swift ever sees the files, because it decides which json files are allowed out of the archive. So the repair walk exists twice, once in ARMSX2Bridge.mm and once in Swift. Each says where the other one is. Fixing only the Swift side would have changed nothing, since the layout was already being dropped at extraction.

The repair only substitutes bytes below 0x20 that sit inside a JSON string, and only after a strict parse has already failed. Nothing below 0x20 can be part of a multi byte character or half of an escape pair, so real escapes and non English text come through untouched. A structural problem like a missing comma is still a failure, deliberately: guessing at structure could mis read a skin.

The allowlist only widens to let loose json files out when the manifest named nothing, or could not be read, or named a file that is not actually in the archive. Swift picks the layout by decoding candidates and taking the one that works, and gives up if more than one does, so handing it spare json files from a package that was already correct would create exactly the ambiguity it refuses to guess at.

Replacing a skin parks the import while the dialog is up. That wait is owned by an object the view holds, so leaving the screen with the dialog open releases it and the import unblocks instead of hanging on to its staging folder forever.

Replacing a skin that came from the catalog drops its catalog id. The copy in the library is the user's file now, so the browser should go back to offering the download rather than claiming it is installed.

Built for device. The parsing and allowlist behaviour was checked against the two zips from the report plus a made up one that names a layout it does not contain. The parts that need a finger on the screen, the replace dialog and the new messages, have not been run.
