### PR TITLE
iOS: Optimize the Menu Runtime and Add Fluid Liquid Glass Game-Card Transitions

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1748,6 +1748,15 @@ VMBootResult VMManager::Initialize(const VMBootParameters& boot_params, Error* e
 	FullscreenUI::OnVMStarted();
 	UpdateInhibitScreensaver(EmuConfig.InhibitScreensaver);
 
+	// A BIOS-only boot has no game ELF or replacement-texture map to signal the
+	// normal readiness barriers. Its optional-resource teardown may begin once
+	// all VM subsystems above have finished initializing.
+	if (boot_params.filename.empty())
+	{
+		NotifyBootPatchesApplied();
+		NotifyTextureReplacementStartupComplete();
+	}
+
 	SetEmuThreadAffinities();
 
 	// do we want to load state?

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.h
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.h
@@ -111,6 +111,7 @@ typedef void (^ARMSX2RetroAchievementsCompletion)(BOOL success, NSString * _Nonn
 
 // Permanently releases the selected optional runtime resources for the current VM session.
 + (void)releaseNonEmulationResources:(NSUInteger)releaseFlags;
++ (BOOL)isEmulationOnlyModeActive;
 
 // Accessibility: structured device stats for the VoiceOver HUD mirror.
 + (nonnull NSDictionary<NSString *, id> *)deviceStatsForAccessibility;

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
@@ -3246,8 +3246,20 @@ static std::string ARMSX2PerGameSettingsPath(const std::string& serial, u32 crc)
     }
 
     Host::RunOnCPUThread([releaseFlags]() {
+        if (!VMManager::HasValidVM())
+            return;
+
         VMManager::ReleaseNonEssentialRuntimeResources(static_cast<u32>(releaseFlags));
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSNotificationCenter defaultCenter]
+                postNotificationName:@"ARMSX2iOSEmulationOnlyResourcesReleased"
+                object:nil];
+        });
     }, false);
+}
+
++ (BOOL)isEmulationOnlyModeActive {
+    return VMManager::IsEmulationOnlyMode();
 }
 
 // Apply OSD preset — sets ALL GSConfig flags to match the preset

--- a/platforms/ios/app/src/main/swift/Models/AppState.swift
+++ b/platforms/ios/app/src/main/swift/Models/AppState.swift
@@ -4,14 +4,32 @@
 import SwiftUI
 import UIKit
 
-/// A single rasterized library card retained only while a game crosses from the
-/// menu root to the live Metal surface. The card is animated above the existing
-/// menu background, which is released as soon as the transition finishes.
+enum GameplayLaunchCardStyle: Equatable {
+    case list
+    case grid
+    case coverFlow
+}
+
+/// Lightweight content used to rebuild the selected library card in SwiftUI.
+/// Only the already-decoded cover is retained; the menu hierarchy and full
+/// window are never rasterized for the transition.
 struct GameplayLaunchTransition: Identifiable {
     let id = UUID()
-    let snapshot: UIImage
     let sourceFrame: CGRect
     let cornerRadius: CGFloat
+    let style: GameplayLaunchCardStyle
+    let gameName: String
+    let title: String
+    let detail: String
+    let coverImage: UIImage?
+    let coverSize: CGSize
+    let isFavorite: Bool
+}
+
+struct PendingJITGameBoot {
+    let isoName: String
+    let launchTransition: GameplayLaunchTransition?
+    let requiresShutdown: Bool
 }
 
 struct EmulationOnlyPresentation: Equatable {
@@ -29,6 +47,7 @@ final class AppState: @unchecked Sendable {
     static let systemChromeNeedsUpdateNotification = Notification.Name("ARMSX2iOSSystemChromeNeedsUpdate")
     static let releaseMenuBackgroundResourcesNotification = Notification.Name("ARMSX2iOSReleaseMenuBackgroundResources")
     static let emulationOnlyStartupReadyNotification = Notification.Name("ARMSX2iOSEmulationOnlyStartupReady")
+    static let emulationOnlyResourcesReleasedNotification = Notification.Name("ARMSX2iOSEmulationOnlyResourcesReleased")
 
     enum Screen {
         case menu
@@ -39,6 +58,7 @@ final class AppState: @unchecked Sendable {
     var selectedTab: Int = 0
     var runningGameName: String? = nil
     var bootDisclaimerMessage: String?
+    var pendingJITGameBoot: PendingJITGameBoot?
     var gameplayLaunchTransition: GameplayLaunchTransition?
     var gameplayLaunchControlsVisible = true
     var gameplayLaunchBackgroundVisible = false
@@ -71,22 +91,25 @@ final class AppState: @unchecked Sendable {
             forName: NSNotification.Name("ARMSX2iOSVMDidShutdown"),
             object: nil, queue: .main
         ) { [weak self] _ in
-            self?.runningGameName = nil
             self?.cancelGameplayLaunchTransition()
             self?.isEmulationOnlyMode = false
             self?.emulationOnlyPresentation = .minimal
             self?.emulationOnlyStartupReady = false
             if let action = self?.pendingBootAction {
+                // A restart is one continuous menu session. Keep the current
+                // running identity until bootGame/bootBIOS replaces it so the
+                // Now Running glass card never disappears between VMs.
                 self?.pendingBootAction = nil
                 action()
             } else {
                 // No pending reboot — return to menu (VM crash / normal shutdown)
+                self?.runningGameName = nil
                 self?.restoreMenuSystemChrome()
                 self?.currentScreen = .menu
             }
         }
 
-        // [P48] Auto-boot: ObjC side posts this notification to switch UI to game screen
+        // Synchronize SwiftUI state when the native auto-boot path starts a VM.
         autoBootObserver = NotificationCenter.default.addObserver(
             forName: NSNotification.Name("ARMSX2iOSAutoBootDidStart"),
             object: nil, queue: .main
@@ -114,7 +137,27 @@ final class AppState: @unchecked Sendable {
         launchTransition: GameplayLaunchTransition? = nil
     ) -> Bool {
         guard requireBootableBIOS() else { return false }
+        guard ARMSX2Bridge.isJITAvailable() else {
+            pendingJITGameBoot = PendingJITGameBoot(
+                isoName: isoName,
+                launchTransition: launchTransition,
+                requiresShutdown: false
+            )
+            return false
+        }
 
+        return performBootGame(
+            isoName: isoName,
+            launchTransition: launchTransition
+        )
+    }
+
+    @discardableResult
+    private func performBootGame(
+        isoName: String,
+        launchTransition: GameplayLaunchTransition?
+    ) -> Bool {
+        pendingJITGameBoot = nil
         isEmulationOnlyMode = false
         emulationOnlyPresentation = .minimal
         emulationOnlyStartupReady = false
@@ -163,22 +206,18 @@ final class AppState: @unchecked Sendable {
         if ARMSX2Bridge.isVMRunning() {
             ARMSX2Bridge.setVMPaused(true)
         }
-        isEmulationOnlyMode = false
-        emulationOnlyPresentation = .minimal
         cancelGameplayLaunchTransition()
         restoreMenuSystemChrome()
         currentScreen = .menu
-        // [P44-2] Restore opaque background on hosting controller
+        // Notify the UIKit host to restore the menu presentation.
         NotificationCenter.default.post(name: NSNotification.Name("ARMSX2iOSReturnToMenu"), object: nil)
     }
 
     func returnToGame() {
         if runningGameName != nil {
-            isEmulationOnlyMode = false
-            emulationOnlyPresentation = .minimal
             cancelGameplayLaunchTransition()
             releaseMenuBackgroundResourcesForGameplay()
-            // [P44-2] Clear background so Metal surface shows through
+            // Make the hosting surface transparent before revealing Metal output.
             NotificationCenter.default.post(name: NSNotification.Name("ARMSX2iOSEnterGameScreen"), object: nil)
             currentScreen = .playing
             ARMSX2Bridge.setVMPaused(false)
@@ -190,8 +229,48 @@ final class AppState: @unchecked Sendable {
         launchTransition: GameplayLaunchTransition? = nil
     ) {
         guard requireBootableBIOS() else { return }
+        guard ARMSX2Bridge.isJITAvailable() else {
+            pendingJITGameBoot = PendingJITGameBoot(
+                isoName: isoName,
+                launchTransition: launchTransition,
+                requiresShutdown: true
+            )
+            return
+        }
+        performShutdownAndBoot(
+            isoName: isoName,
+            launchTransition: launchTransition
+        )
+    }
+
+    func continuePendingJITGameBoot() {
+        guard let request = pendingJITGameBoot else { return }
+        pendingJITGameBoot = nil
+        guard requireBootableBIOS() else { return }
+
+        if request.requiresShutdown {
+            performShutdownAndBoot(
+                isoName: request.isoName,
+                launchTransition: request.launchTransition
+            )
+        } else {
+            performBootGame(
+                isoName: request.isoName,
+                launchTransition: request.launchTransition
+            )
+        }
+    }
+
+    func cancelPendingJITGameBoot() {
+        pendingJITGameBoot = nil
+    }
+
+    private func performShutdownAndBoot(
+        isoName: String,
+        launchTransition: GameplayLaunchTransition?
+    ) {
         pendingBootAction = { [weak self] in
-            self?.bootGame(
+            self?.performBootGame(
                 isoName: isoName,
                 launchTransition: launchTransition
             )
@@ -217,10 +296,11 @@ final class AppState: @unchecked Sendable {
         }
     }
 
-    /// Permanently removes the in-game SwiftUI controls and menus for the current VM session.
-    /// A VM shutdown or a new boot resets this flag and restores the normal gameplay UI.
+    /// Records the reduced presentation for the active VM. The state deliberately
+    /// survives a temporary return to the menu and is reset only by VM shutdown or
+    /// the start of a new VM.
     func enterEmulationOnlyMode(presentation: EmulationOnlyPresentation) {
-        guard case .playing = currentScreen, emulationOnlyStartupReady else { return }
+        guard emulationOnlyStartupReady else { return }
         emulationOnlyPresentation = presentation
         isEmulationOnlyMode = true
     }

--- a/platforms/ios/app/src/main/swift/Models/CoverStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/CoverStore.swift
@@ -13,6 +13,14 @@ struct CoverGameInfo: Sendable {
     let hasCover: Bool
 }
 
+/// Immutable filename index used by one Game Library refresh. Each cover
+/// directory is enumerated once, regardless of the number of games.
+struct CoverLibraryLookupIndex {
+    fileprivate let managedDirectories: [URL]
+    fileprivate let fallbackDirectories: [URL]
+    fileprivate let filesByDirectory: [String: [String: URL]]
+}
+
 struct CoverDownloadSummary: Sendable {
     let downloaded: Int
     let skippedExisting: Int
@@ -75,6 +83,56 @@ final class CoverStore: @unchecked Sendable {
         let candidates = coverBaseCandidates(forGameName: gameName, metadata: metadata)
         for dir in coverSearchDirectories(gamePath: gamePath) {
             if let url = findCover(in: dir, matching: candidates) {
+                return url
+            }
+        }
+        return nil
+    }
+
+    func makeLibraryCoverLookupIndex(gamePaths: [URL]) -> CoverLibraryLookupIndex {
+        let managedDirectories = managedCoverDirectories()
+        let docs = URL(fileURLWithPath: ARMSX2Bridge.documentsDirectory(), isDirectory: true)
+        let iso = URL(fileURLWithPath: ARMSX2Bridge.isoDirectory(), isDirectory: true)
+        let fallbackDirectories = uniqueURLs([iso, docs])
+        let gameDirectories = gamePaths.map { $0.deletingLastPathComponent() }
+        let directories = uniqueURLs(
+            managedDirectories + gameDirectories + fallbackDirectories
+        )
+
+        var filesByDirectory: [String: [String: URL]] = [:]
+        filesByDirectory.reserveCapacity(directories.count)
+        for directory in directories {
+            filesByDirectory[directory.standardizedFileURL.path] =
+                coverFileLookup(in: directory)
+        }
+
+        return CoverLibraryLookupIndex(
+            managedDirectories: managedDirectories,
+            fallbackDirectories: fallbackDirectories,
+            filesByDirectory: filesByDirectory
+        )
+    }
+
+    func coverURL(
+        forGameName gameName: String,
+        gamePath: URL?,
+        metadata: [String: String],
+        using index: CoverLibraryLookupIndex
+    ) -> URL? {
+        let candidates = coverBaseCandidates(
+            forGameName: gameName,
+            metadata: metadata
+        )
+        var directories = index.managedDirectories
+        if let gamePath {
+            directories.append(gamePath.deletingLastPathComponent())
+        }
+        directories.append(contentsOf: index.fallbackDirectories)
+
+        for directory in uniqueURLs(directories) {
+            let key = directory.standardizedFileURL.path
+            guard let lookup = index.filesByDirectory[key] else { continue }
+            if let url = findCover(in: lookup, matching: candidates) {
                 return url
             }
         }
@@ -339,11 +397,16 @@ final class CoverStore: @unchecked Sendable {
     }
 
     private func findCover(in directory: URL, matching candidates: [String]) -> URL? {
+        findCover(in: coverFileLookup(in: directory), matching: candidates)
+    }
+
+    private func coverFileLookup(in directory: URL) -> [String: URL] {
         guard let files = try? fileManager.contentsOfDirectory(at: directory, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles]) else {
-            return nil
+            return [:]
         }
 
         var lookup: [String: URL] = [:]
+        lookup.reserveCapacity(files.count)
         for file in files {
             let ext = file.pathExtension.lowercased()
             guard Self.imageExtensions.contains(ext) else { continue }
@@ -352,7 +415,10 @@ final class CoverStore: @unchecked Sendable {
             }
             lookup[file.lastPathComponent.lowercased()] = file
         }
+        return lookup
+    }
 
+    private func findCover(in lookup: [String: URL], matching candidates: [String]) -> URL? {
         for candidate in candidates {
             let lower = candidate.lowercased()
             for ext in Self.imageExtensions {

--- a/platforms/ios/app/src/main/swift/Views/AnimatedLibraryBackgroundView.swift
+++ b/platforms/ios/app/src/main/swift/Views/AnimatedLibraryBackgroundView.swift
@@ -16,6 +16,7 @@ struct AnimatedLibraryBackgroundView: View {
     let fitMode: BackgroundFitMode
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var frames: [AnimatedBackgroundLoader.Frame] = []
+    @State private var staticImage: UIImage?
     @State private var loadFailed = false
 
     var body: some View {
@@ -26,8 +27,19 @@ struct AnimatedLibraryBackgroundView: View {
                 AnimatedFramePlayer(frames: frames, fitMode: fitMode)
             }
         }
-        .task(id: url.path) {
-            guard frames.isEmpty, !loadFailed else { return }
+        .task(id: "\(url.path)|\(reduceMotion)") {
+            if staticImage == nil {
+                let firstFrameLoader = Task.detached(priority: .utility) {
+                    AnimatedBackgroundLoader.staticImage(from: url)
+                }
+                staticImage = await withTaskCancellationHandler {
+                    await firstFrameLoader.value
+                } onCancel: {
+                    firstFrameLoader.cancel()
+                }
+            }
+
+            guard !reduceMotion, frames.isEmpty, !loadFailed else { return }
             // Decode off the MainActor so a large multi-frame image cannot
             // stall the UI while the library is presented.
 			let loader = Task.detached(priority: .utility) {
@@ -53,8 +65,8 @@ struct AnimatedLibraryBackgroundView: View {
     /// payload can't be played.
     private var staticFirstFrame: some View {
         GeometryReader { geometry in
-            if let image = AnimatedBackgroundLoader.staticImage(from: url) {
-                Image(uiImage: image)
+            if let staticImage {
+                Image(uiImage: staticImage)
                     .resizable()
                     .applyBackgroundFitMode(fitMode)
                     .frame(width: geometry.size.width, height: geometry.size.height)
@@ -162,6 +174,11 @@ private final class AnimatedBackgroundImageView: UIView {
         guard !releasedForGameplay, displayLink == nil, !frames.isEmpty,
               UIApplication.shared.applicationState != .background else { return }
         let link = CADisplayLink(target: self, selector: #selector(tick))
+        link.preferredFrameRateRange = CAFrameRateRange(
+            minimum: 10,
+            maximum: 30,
+            preferred: 30
+        )
         link.add(to: .main, forMode: .common)
         displayLink = link
     }
@@ -214,6 +231,7 @@ enum AnimatedBackgroundLoader {
     /// or CPU on handheld devices.
     static let maxFrames = 120
     static let maxFrameDimension: CGFloat = 1280
+    static let maxDecodedBytes = 160 * 1024 * 1024
 
     /// True when the file at `url` is a multi-frame image that the loader will
     /// animate. Used to decide between the animated and static render paths.
@@ -232,11 +250,16 @@ enum AnimatedBackgroundLoader {
 
         var frames: [Frame] = []
         frames.reserveCapacity(count)
+        var decodedBytes = 0
         for i in 0..<count {
 			guard !Task.isCancelled else { return [] }
             guard let cgImage = CGImageSourceCreateImageAtIndex(source, i, nil) else { continue }
             // Skip oversized frames to avoid memory spikes; treat as static.
             if CGFloat(cgImage.width) > maxFrameDimension || CGFloat(cgImage.height) > maxFrameDimension {
+                return []
+            }
+            decodedBytes += cgImage.bytesPerRow * cgImage.height
+            guard decodedBytes <= maxDecodedBytes else {
                 return []
             }
             let image = UIImage(cgImage: cgImage)

--- a/platforms/ios/app/src/main/swift/Views/BIOSListView.swift
+++ b/platforms/ios/app/src/main/swift/Views/BIOSListView.swift
@@ -3,12 +3,18 @@
 
 import SwiftUI
 import UniformTypeIdentifiers
+import UIKit
 
 struct BIOSListView: View {
     let embeddedInMenuNavigation: Bool
+    let ownsEmbeddedMenuToolbar: Bool
 
-    init(embeddedInMenuNavigation: Bool = false) {
+    init(
+        embeddedInMenuNavigation: Bool = false,
+        ownsEmbeddedMenuToolbar: Bool = true
+    ) {
         self.embeddedInMenuNavigation = embeddedInMenuNavigation
+        self.ownsEmbeddedMenuToolbar = ownsEmbeddedMenuToolbar
     }
 
     @State private var bioses: [ARMSX2BIOSInfo] = []
@@ -21,8 +27,12 @@ struct BIOSListView: View {
     @State private var showRestartAlert = false
     @State private var pendingBIOSImportURLs: [URL] = []
     @State private var existingBIOSImportFileNames: [String] = []
+    @State private var hasLoadedBIOSes = false
+    @State private var BIOSRefreshPending = true
+    @State private var BIOSRefreshTask: Task<Void, Never>?
     @State private var appState = AppState.shared
     @Environment(\.menuTabIsActive) private var menuTabIsActive
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
 
     private var backgroundConfigured: Bool {
         settings.hasCustomBackground && settings.backgroundEnabledInBIOS
@@ -32,6 +42,12 @@ struct BIOSListView: View {
         backgroundConfigured
     }
 
+    private var showsPageOwnedLargeTitle: Bool {
+        embeddedInMenuNavigation
+            && verticalSizeClass != .compact
+            && UIDevice.current.userInterfaceIdiom == .phone
+    }
+
     var body: some View {
         OptionalMenuNavigationStack(embedded: embeddedInMenuNavigation) {
             ZStack {
@@ -39,23 +55,60 @@ struct BIOSListView: View {
                     MenuBackgroundLayer(isActive: menuTabIsActive)
                 }
 
-                Group {
-                    if bioses.isEmpty {
-                        emptyState
-                    } else {
-                        List {
-                            ForEach(bioses, id: \.self) { bios in
-                                biosRow(bios)
-                                    .gameCardTintMenuBackgroundListRow(backgroundActive)
+                if bioses.isEmpty {
+                    GeometryReader { geometry in
+                        ScrollView {
+                            VStack(spacing: 0) {
+                                if showsPageOwnedLargeTitle {
+                                    EmbeddedMenuLargeTitle(
+                                        title: settings.localized("BIOS")
+                                    )
+                                }
+
+                                emptyState
+                                    .frame(
+                                        maxWidth: .infinity,
+                                        minHeight: max(
+                                            0,
+                                            geometry.size.height
+                                                - (showsPageOwnedLargeTitle ? 64 : 0)
+                                        ),
+                                        alignment: .center
+                                    )
+                                    // Align the BIOS icon with the Games
+                                    // empty-state icon in compact height.
+                                    .offset(
+                                        y: verticalSizeClass == .compact ? -32 : 0
+                                    )
                             }
                         }
-                        .scrollContentBackground(backgroundActive ? .hidden : .automatic)
-#if targetEnvironment(macCatalyst)
-                        .listStyle(.inset)
-#endif
+                        .contentMargins(.top, 0, for: .scrollContent)
+                        .scrollBounceBehavior(.always)
                     }
+                } else {
+                    List {
+                        if showsPageOwnedLargeTitle {
+                            EmbeddedMenuLargeTitle(
+                                title: settings.localized("BIOS")
+                            )
+                            .listRowInsets(EdgeInsets())
+                            .listRowSeparator(.hidden)
+                            .listRowBackground(Color.clear)
+                        }
+
+                        ForEach(bioses, id: \.filePath) { bios in
+                            biosRow(bios)
+                                .gameCardTintMenuBackgroundListRow(backgroundActive)
+                        }
+                    }
+                    .contentMargins(.top, 0, for: .scrollContent)
+                    .scrollContentBackground(backgroundActive ? .hidden : .automatic)
+                    .scrollBounceBehavior(.always)
+#if targetEnvironment(macCatalyst)
+                    .listStyle(.inset)
+#endif
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
             .stableMenuContentGlassContainer()
             .clearNavigationContainerBackground()
@@ -65,7 +118,7 @@ struct BIOSListView: View {
                 embedded: embeddedInMenuNavigation
             )
             .toolbar {
-                if !embeddedInMenuNavigation || menuTabIsActive {
+                if !embeddedInMenuNavigation || ownsEmbeddedMenuToolbar {
                 ToolbarItem(id: "menu.bootBIOS", placement: .topBarLeading) {
                     Button {
                         if appState.runningGameName == "BIOS" {
@@ -164,9 +217,26 @@ struct BIOSListView: View {
                 )
             }
         }
-        .onAppear { loadBIOSes() }
+        .onAppear {
+            if menuTabIsActive {
+                scheduleBIOSRefresh(after: .milliseconds(0))
+            }
+        }
+        .onChange(of: menuTabIsActive) { _, isActive in
+            guard isActive, BIOSRefreshPending || !hasLoadedBIOSes else {
+                return
+            }
+            scheduleBIOSRefresh(after: .milliseconds(0))
+        }
         .onReceive(NotificationCenter.default.publisher(for: InitialContentBootstrap.didChangeNotification)) { _ in
-            loadBIOSes()
+            BIOSRefreshPending = true
+            if menuTabIsActive {
+                scheduleBIOSRefresh(after: .milliseconds(120))
+            }
+        }
+        .onDisappear {
+            BIOSRefreshTask?.cancel()
+            BIOSRefreshTask = nil
         }
     }
 
@@ -236,7 +306,13 @@ struct BIOSListView: View {
                 NSLog("[ARMSX2 iOS BIOS] opening primary BIOS picker from empty state")
                 showBIOSImporter = true
             } label: {
-                Label(settings.localized("Import BIOS"), systemImage: "plus")
+                Label {
+                    Text(settings.localized("Import BIOS"))
+                } icon: {
+                    Image(systemName: "plus")
+                        .symbolRenderingMode(.monochrome)
+                        .foregroundStyle(.white)
+                }
             }
             .buttonStyle(.borderedProminent)
             Text(settings.localized("If one picker refuses to select your .bin/.rom file, try the other."))
@@ -245,7 +321,7 @@ struct BIOSListView: View {
                 .multilineTextAlignment(.center)
         }
         .padding()
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .frame(maxWidth: .infinity, minHeight: 240)
     }
 
     private func handleBIOSPickerResult(_ result: Result<[URL], Error>, source: String) {
@@ -308,8 +384,46 @@ struct BIOSListView: View {
     }
 
     private func loadBIOSes() {
-        bioses = ARMSX2Bridge.availableBIOSInfos()
-        defaultBIOS = ARMSX2Bridge.defaultBIOSName()
+        let loadedBIOSes = ARMSX2Bridge.availableBIOSInfos()
+        let loadedDefaultBIOS = ARMSX2Bridge.defaultBIOSName()
+        if !BIOSListsMatch(bioses, loadedBIOSes) {
+            bioses = loadedBIOSes
+        }
+        if defaultBIOS != loadedDefaultBIOS {
+            defaultBIOS = loadedDefaultBIOS
+        }
+        hasLoadedBIOSes = true
+        BIOSRefreshPending = false
+    }
+
+    /// Coalesces bootstrap notifications and avoids opening every BIOS file
+    /// while the retained BIOS page is hidden behind another tab.
+    private func scheduleBIOSRefresh(after delay: Duration) {
+        BIOSRefreshTask?.cancel()
+        BIOSRefreshTask = Task { @MainActor in
+            try? await Task.sleep(for: delay)
+            guard !Task.isCancelled, menuTabIsActive else {
+                BIOSRefreshPending = true
+                return
+            }
+            loadBIOSes()
+            BIOSRefreshTask = nil
+        }
+    }
+
+    private func BIOSListsMatch(
+        _ first: [ARMSX2BIOSInfo],
+        _ second: [ARMSX2BIOSInfo]
+    ) -> Bool {
+        guard first.count == second.count else { return false }
+        return zip(first, second).allSatisfy { lhs, rhs in
+            lhs.filePath == rhs.filePath
+                && lhs.fileName == rhs.fileName
+                && lhs.valid == rhs.valid
+                && lhs.regionName == rhs.regionName
+                && lhs.countryCode == rhs.countryCode
+                && lhs.descriptionText == rhs.descriptionText
+        }
     }
 
     private func nonBootableImportGuidance(for urls: [URL]) -> String? {

--- a/platforms/ios/app/src/main/swift/Views/Background/BackgroundContainerView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/BackgroundContainerView.swift
@@ -3,6 +3,7 @@
 
 import SwiftUI
 import AVKit
+import ImageIO
 
 struct BackgroundContainerView: View {
     @State private var settings = SettingsStore.shared
@@ -12,6 +13,7 @@ struct BackgroundContainerView: View {
     @Environment(\.colorSchemeContrast) private var colorSchemeContrast
     @State private var videoPoster: UIImage?
     @State private var isRenderingEnabled = true
+    @State private var inactiveReleaseTask: Task<Void, Never>?
 
     private var activeAsset: BackgroundAsset? {
         if size.width > size.height, let landscape = settings.backgroundLandscapeAsset { return landscape }
@@ -41,13 +43,13 @@ struct BackgroundContainerView: View {
                     let url = BackgroundStorage.fileURL(for: asset)
                     switch asset.kind {
                     case .image:
-                        backgroundImage(UIImage(contentsOfFile: url.path))
+                        StaticLibraryBackgroundImageView(
+                            url: url,
+                            fitMode: effectiveFitMode,
+                            size: size
+                        )
                     case .animatedImage:
-                        if reduceMotion {
-                            backgroundImage(UIImage(contentsOfFile: url.path))
-                        } else {
-                            animated(url)
-                        }
+                        animated(url)
                     case .video:
                         if reduceMotion {
                             backgroundImage(videoPoster)
@@ -63,16 +65,29 @@ struct BackgroundContainerView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .ignoresSafeArea()
         .onAppear {
+            inactiveReleaseTask?.cancel()
             isRenderingEnabled = true
         }
         .onReceive(NotificationCenter.default.publisher(for: UIScene.willDeactivateNotification)) { _ in
-            isRenderingEnabled = false
-            videoPoster = nil
+            inactiveReleaseTask?.cancel()
+            inactiveReleaseTask = Task { @MainActor in
+                // Allow the immediate captured frame to enter the hierarchy
+                // before releasing the inactive live surface.
+                try? await Task.sleep(for: .milliseconds(32))
+                guard !Task.isCancelled else { return }
+                isRenderingEnabled = false
+                videoPoster = nil
+                inactiveReleaseTask = nil
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: UIScene.didActivateNotification)) { _ in
+            inactiveReleaseTask?.cancel()
+            inactiveReleaseTask = nil
             isRenderingEnabled = true
         }
         .onReceive(NotificationCenter.default.publisher(for: AppState.releaseMenuBackgroundResourcesNotification)) { _ in
+            inactiveReleaseTask?.cancel()
+            inactiveReleaseTask = nil
             isRenderingEnabled = false
             videoPoster = nil
         }
@@ -109,6 +124,94 @@ struct BackgroundContainerView: View {
         } catch {
             videoPoster = nil
         }
+    }
+}
+
+/// Loads a screen-sized static wallpaper away from the main actor. The source
+/// image can be much larger than the display, so ImageIO downsamples it before
+/// UIKit and SwiftUI retain the decoded pixels.
+private struct StaticLibraryBackgroundImageView: View {
+    let url: URL
+    let fitMode: BackgroundFitMode
+    let size: CGSize
+    @State private var image: UIImage?
+
+    private var loadIdentity: String {
+        "\(url.path)|\(Int(size.width))x\(Int(size.height))"
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            if let image {
+                fitted(Image(uiImage: image))
+                    .frame(
+                        width: geometry.size.width,
+                        height: geometry.size.height
+                    )
+                    .clipped()
+            }
+        }
+        .task(id: loadIdentity) {
+            let scale = UIScreen.main.scale
+            let maximumPixelSize = max(
+                1,
+                Int(max(size.width, size.height) * scale)
+            )
+            let loader = Task.detached(priority: .utility) {
+                Self.downsampledImage(
+                    at: url,
+                    maximumPixelSize: maximumPixelSize,
+                    scale: scale
+                )
+            }
+            let loaded = await withTaskCancellationHandler {
+                await loader.value
+            } onCancel: {
+                loader.cancel()
+            }
+            guard !Task.isCancelled else { return }
+            image = loaded
+        }
+    }
+
+    @ViewBuilder
+    private func fitted(_ image: Image) -> some View {
+        switch fitMode {
+        case .fill:
+            image.resizable().scaledToFill()
+        case .fit:
+            image.resizable().scaledToFit()
+        case .stretch:
+            image.resizable()
+        }
+    }
+
+    private nonisolated static func downsampledImage(
+        at url: URL,
+        maximumPixelSize: Int,
+        scale: CGFloat
+    ) -> UIImage? {
+        let sourceOptions = [
+            kCGImageSourceShouldCache: false,
+        ] as CFDictionary
+        let thumbnailOptions = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize: maximumPixelSize,
+        ] as CFDictionary
+        guard let source = CGImageSourceCreateWithURL(
+            url as CFURL,
+            sourceOptions
+        ),
+        let thumbnail = CGImageSourceCreateThumbnailAtIndex(
+            source,
+            0,
+            thumbnailOptions
+        ) else {
+            return nil
+        }
+        return UIImage(cgImage: thumbnail, scale: scale, orientation: .up)
     }
 }
 

--- a/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicBackgrounds.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicBackgrounds.swift
@@ -207,7 +207,7 @@ struct MulticolorAmbientBackground: View {
             y: CGFloat(sin(time * 0.23)) * 130 + 180
           )
 
-        Canvas { context, size in
+        Canvas(rendersAsynchronously: true) { context, size in
           let particleColor = theme.ribbonColor(index: 2, time: time)
           for index in 0..<26 {
             let phase = Double(index) * 1.73
@@ -258,7 +258,7 @@ struct LightSpeedBackground: View {
           curvature: theme.sharedPaletteGradientCurvature
         )
 
-        Canvas { context, size in
+        Canvas(rendersAsynchronously: true) { context, size in
           let vanishingPoint = vanishingPoint(size: size, time: time)
 
           drawBackgroundNebulas(
@@ -546,7 +546,7 @@ struct SpatialRetroBackground: View {
             y: CGFloat(cos(time * 0.07)) * 80
           )
 
-        Canvas { context, size in
+        Canvas(rendersAsynchronously: true) { context, size in
           drawPerspectiveGrid(
             context: &context,
             size: size,
@@ -754,7 +754,7 @@ struct TowersOrbsBackground: View {
           curvature: theme.sharedPaletteGradientCurvature
         )
 
-        Canvas { context, size in
+        Canvas(rendersAsynchronously: true) { context, size in
           drawOrbitingOrbs(
             context: &context,
             size: size,
@@ -4032,7 +4032,7 @@ struct FaceButtonsBackground: View {
             )
         }
 
-        Canvas { context, size in
+        Canvas(rendersAsynchronously: true) { context, size in
           if showsLightBands && settings.backgrounds.faceButtonsShowsLightBands {
             drawWeavingLightBands(
               context: &context,
@@ -4407,7 +4407,7 @@ struct PlayStationPortableBlurBackground: View {
         )
 
         if settings.showsRibbons {
-          Canvas { context, size in
+          Canvas(rendersAsynchronously: true) { context, size in
             let ribbonCount = max(1, Int(settings.ribbonCount.rounded()))
             for index in 0..<ribbonCount {
               drawRibbon(
@@ -4608,7 +4608,7 @@ struct PlayStation3SplinesBackground: View {
           endRadius: 520
         )
 
-        Canvas { context, size in
+        Canvas(rendersAsynchronously: true) { context, size in
           if settings.showsParticles {
             drawParticles(
               context: &context,
@@ -4894,7 +4894,7 @@ struct PlayStation4ParticlesBackground: View {
           endRadius: 520
         )
 
-        Canvas { context, size in
+        Canvas(rendersAsynchronously: true) { context, size in
           if settings.showsParticles {
             drawParticles(
               context: &context,
@@ -5173,7 +5173,7 @@ struct PlayStation4WavesBackground: View {
         }
 
         if settings.showsParticles {
-          Canvas { context, size in
+          Canvas(rendersAsynchronously: true) { context, size in
             drawParticles(
               context: &context,
               size: size,
@@ -5184,7 +5184,7 @@ struct PlayStation4WavesBackground: View {
         }
 
         if showsWaves && settings.showsWaves {
-          Canvas { context, size in
+          Canvas(rendersAsynchronously: true) { context, size in
             drawWaves(
               context: &context,
               size: size,
@@ -5411,7 +5411,7 @@ struct PlayStationRibbonsBackground: View {
             y: CGFloat(sin(time * 0.06)) * 120 - 120
           )
 
-        Canvas { context, size in
+        Canvas(rendersAsynchronously: true) { context, size in
           if settings.showsPanels {
             drawLuminousPanels(
               context: &context,

--- a/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicEffects.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicEffects.swift
@@ -397,7 +397,7 @@ struct DynamicParticleOverlay: View {
     } else {
       TimelineView(.animation(minimumInterval: 1 / 30)) { timeline in
         let time = timeline.date.timeIntervalSinceReferenceDate
-        Canvas { context, size in
+        Canvas(rendersAsynchronously: true) { context, size in
           context.blendMode = .plusLighter
           drawParticles(
             context: &context,

--- a/platforms/ios/app/src/main/swift/Views/Background/Dynamic/PlayStation3XMBByMartShaderLibrary.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/Dynamic/PlayStation3XMBByMartShaderLibrary.swift
@@ -8,6 +8,7 @@ import Foundation
 enum PlayStation3XMBByMartShaderLibrary {
   private static var cachedLibrary: MTLLibrary?
   private static var activeRendererCount = 0
+  private static var releaseWhenUnused = false
 
   static func makeLibrary(device: MTLDevice) -> MTLLibrary? {
     if let cachedLibrary {
@@ -38,23 +39,42 @@ enum PlayStation3XMBByMartShaderLibrary {
 
   static func retainForRenderer() {
     activeRendererCount += 1
+    releaseWhenUnused = false
   }
 
   static func releaseForRenderer() {
     guard activeRendererCount > 0 else {
-      cachedLibrary = nil
+      if releaseWhenUnused {
+        cachedLibrary = nil
+        releaseWhenUnused = false
+      }
       return
     }
 
     activeRendererCount -= 1
-    if activeRendererCount == 0 {
+    if activeRendererCount == 0 && releaseWhenUnused {
       cachedLibrary = nil
+      releaseWhenUnused = false
     }
   }
 
+  /// Renderer handoffs between the menu and Appearance preview may briefly
+  /// reach zero active surfaces. Keep the compiled library across that handoff.
   static func releaseIfUnused() {
+    if activeRendererCount == 0 && releaseWhenUnused {
+      cachedLibrary = nil
+      releaseWhenUnused = false
+    }
+  }
+
+  /// Gameplay and background removal end the complete menu session, so the
+  /// shader cache can be released even if SwiftUI dismantles the MTKView later.
+  static func releaseSessionCache() {
     if activeRendererCount == 0 {
       cachedLibrary = nil
+      releaseWhenUnused = false
+    } else {
+      releaseWhenUnused = true
     }
   }
 

--- a/platforms/ios/app/src/main/swift/Views/Background/MenuBackgroundSupport.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/MenuBackgroundSupport.swift
@@ -23,9 +23,12 @@ final class PersistentMenuBackgroundHost: ObservableObject {
 
     @Published private(set) var rendererMounted: Bool
     @Published private(set) var presentationVisible = true
+    @Published private(set) var inactiveSnapshot: UIImage?
+    @Published private(set) var inactiveSnapshotOpacity = 0.0
     @Published private var exclusivePreviewDepth = 0
     private var menuBackgroundAvailable = true
     private var releasedForGameplay = false
+    private var snapshotReleaseTask: Task<Void, Never>?
 
     init() {
         let hasBackground = SettingsStore.shared.hasCustomBackground
@@ -39,6 +42,10 @@ final class PersistentMenuBackgroundHost: ObservableObject {
         menuBackgroundAvailable = isAvailable
         rendererMounted = isAvailable
             && !(exclusivePreviewDepth > 0 && SettingsStore.shared.dynamicBackgroundsEnabled)
+        if !isAvailable {
+            releaseInactiveSnapshot()
+            PlayStation3XMBByMartShaderLibrary.releaseSessionCache()
+        }
     }
 
     /// Starts a fresh renderer session only after gameplay released the previous
@@ -81,13 +88,56 @@ final class PersistentMenuBackgroundHost: ObservableObject {
         rendererMounted = false
     }
 
+    /// Keeps one rasterized frame visible while iOS deactivates the scene and
+    /// tears down live video, display-link, and Metal rendering. The image is
+    /// intentionally held only across that inactive interval.
+    func retainInactiveSnapshot(_ image: UIImage) {
+        guard menuBackgroundAvailable, rendererMounted else { return }
+        snapshotReleaseTask?.cancel()
+        snapshotReleaseTask = nil
+        inactiveSnapshot = image
+        // Capture immediately on suspension; crossfade only after live
+        // rendering resumes.
+        inactiveSnapshotOpacity = 1
+    }
+
+    /// Scene activation restarts the live renderer first. Once it has produced
+    /// frames again, crossfade the still image away and release its pixel storage.
+    func releaseInactiveSnapshotWhenRendererIsReady() {
+        snapshotReleaseTask?.cancel()
+        guard inactiveSnapshot != nil else { return }
+        // Keep the held frame fully visible while the live renderer begins its
+        // warm-up interval.
+        inactiveSnapshotOpacity = 1
+        snapshotReleaseTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(180))
+            guard !Task.isCancelled else { return }
+            withAnimation(.easeInOut(duration: 0.36)) {
+                self?.inactiveSnapshotOpacity = 0
+            }
+            try? await Task.sleep(for: .milliseconds(360))
+            guard !Task.isCancelled else { return }
+            self?.inactiveSnapshot = nil
+            self?.snapshotReleaseTask = nil
+        }
+    }
+
+    private func releaseInactiveSnapshot() {
+        snapshotReleaseTask?.cancel()
+        snapshotReleaseTask = nil
+        inactiveSnapshotOpacity = 0
+        inactiveSnapshot = nil
+    }
+
     /// The surrounding MenuTabView is also removed at gameplay start, ensuring
     /// SwiftUI dismantles video, animated-image, display-link, and Metal views.
     func release() {
         releasedForGameplay = true
         menuBackgroundAvailable = false
         exclusivePreviewDepth = 0
+        releaseInactiveSnapshot()
         suspend()
+        PlayStation3XMBByMartShaderLibrary.releaseSessionCache()
     }
 
     var shouldShowRenderer: Bool {
@@ -102,14 +152,208 @@ struct PersistentMenuBackgroundLayer: View {
     var body: some View {
         if host.rendererMounted {
             GeometryReader { geometry in
-                BackgroundContainerView(size: geometry.size)
+                ZStack {
+                    SnapshottingBackgroundRenderer(
+                        size: geometry.size,
+                        sessionStart: host.sessionStart,
+                        snapshotHost: host
+                    )
+
+                    if let snapshot = host.inactiveSnapshot {
+                        Image(uiImage: snapshot)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(
+                                width: geometry.size.width,
+                                height: geometry.size.height
+                            )
+                            .clipped()
+                            .opacity(host.inactiveSnapshotOpacity)
+                    }
+                }
             }
-            .environment(\.menuBackgroundSessionStart, host.sessionStart)
             .opacity(host.shouldShowRenderer ? 1 : 0)
             .ignoresSafeArea()
             .accessibilityHidden(true)
             .allowsHitTesting(false)
         }
+    }
+}
+
+/// Gives the persistent menu background its own UIKit subtree. Capturing this
+/// view therefore records only the background—not Games/BIOS/Settings chrome—
+/// before iOS suspends Metal, video, and display-link rendering.
+private struct SnapshottingBackgroundRenderer: UIViewControllerRepresentable {
+    let size: CGSize
+    let sessionStart: Date
+    let snapshotHost: PersistentMenuBackgroundHost
+
+    func makeUIViewController(
+        context: Context
+    ) -> BackgroundSnapshotHostingController {
+        BackgroundSnapshotHostingController(
+            size: size,
+            sessionStart: sessionStart,
+            snapshotHost: snapshotHost
+        )
+    }
+
+    func updateUIViewController(
+        _ controller: BackgroundSnapshotHostingController,
+        context: Context
+    ) {
+        controller.update(
+            size: size,
+            sessionStart: sessionStart,
+            snapshotHost: snapshotHost
+        )
+    }
+
+    static func dismantleUIViewController(
+        _ controller: BackgroundSnapshotHostingController,
+        coordinator: ()
+    ) {
+        controller.teardown()
+    }
+}
+
+@MainActor
+private final class BackgroundSnapshotHostingController: UIViewController {
+    private var backgroundController: UIHostingController<AnyView>?
+    private weak var snapshotHost: PersistentMenuBackgroundHost?
+    private var renderedSize: CGSize
+    private var renderedSessionStart: Date
+    private var observingLifecycle = false
+
+    init(
+        size: CGSize,
+        sessionStart: Date,
+        snapshotHost: PersistentMenuBackgroundHost
+    ) {
+        renderedSize = size
+        renderedSessionStart = sessionStart
+        self.snapshotHost = snapshotHost
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
+        installBackground(size: renderedSize, sessionStart: renderedSessionStart)
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationWillResignActive),
+            name: UIApplication.willResignActiveNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+        observingLifecycle = true
+    }
+
+    func update(
+        size: CGSize,
+        sessionStart: Date,
+        snapshotHost: PersistentMenuBackgroundHost
+    ) {
+        self.snapshotHost = snapshotHost
+        guard size != renderedSize || sessionStart != renderedSessionStart else {
+            return
+        }
+        renderedSize = size
+        renderedSessionStart = sessionStart
+        backgroundController?.rootView = backgroundRoot(
+            size: size,
+            sessionStart: sessionStart
+        )
+    }
+
+    func teardown() {
+        if observingLifecycle {
+            NotificationCenter.default.removeObserver(self)
+            observingLifecycle = false
+        }
+        if let backgroundController {
+            backgroundController.willMove(toParent: nil)
+            backgroundController.view.removeFromSuperview()
+            backgroundController.removeFromParent()
+        }
+        backgroundController = nil
+        snapshotHost = nil
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    private func installBackground(size: CGSize, sessionStart: Date) {
+        let controller = UIHostingController(
+            rootView: backgroundRoot(size: size, sessionStart: sessionStart)
+        )
+        controller.view.backgroundColor = .clear
+        addChild(controller)
+        view.addSubview(controller.view)
+        controller.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            controller.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            controller.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            controller.view.topAnchor.constraint(equalTo: view.topAnchor),
+            controller.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+        controller.didMove(toParent: self)
+        backgroundController = controller
+    }
+
+    private func backgroundRoot(
+        size: CGSize,
+        sessionStart: Date
+    ) -> AnyView {
+        AnyView(
+            BackgroundContainerView(size: size)
+                .environment(\.menuBackgroundSessionStart, sessionStart)
+        )
+    }
+
+    @objc private func applicationWillResignActive() {
+        guard let targetView = backgroundController?.view,
+              targetView.window != nil,
+              targetView.bounds.width > 0,
+              targetView.bounds.height > 0 else {
+            return
+        }
+
+        targetView.layoutIfNeeded()
+        let format = UIGraphicsImageRendererFormat.preferred()
+        format.scale = targetView.window?.screen.scale ?? 1
+        format.opaque = false
+        let renderer = UIGraphicsImageRenderer(
+            bounds: targetView.bounds,
+            format: format
+        )
+        let snapshot = renderer.image { context in
+            let captured = targetView.drawHierarchy(
+                in: targetView.bounds,
+                afterScreenUpdates: false
+            )
+            if !captured {
+                targetView.layer.render(in: context.cgContext)
+            }
+        }
+        snapshotHost?.retainInactiveSnapshot(snapshot)
+    }
+
+    @objc private func applicationDidBecomeActive() {
+        snapshotHost?.releaseInactiveSnapshotWhenRendererIsReady()
     }
 }
 
@@ -159,6 +403,63 @@ struct OptionalMenuNavigationStack<Content: View>: View {
     }
 }
 
+/// A page-owned replacement for UINavigationBar's large title on the retained
+/// Games/BIOS pages. One native large title cannot reliably track two live
+/// scroll views in the same NavigationStack; keeping the title in each page's
+/// scroll content makes its visibility and collapse state deterministic.
+struct EmbeddedMenuLargeTitle: View {
+    let title: String
+    @Environment(\.menuTabIsActive) private var menuTabIsActive
+    @Environment(\.menuLargeTitleNamespace) private var transitionNamespace
+    @Environment(\.menuLargeTitleMorphActive) private var morphActive
+
+    var body: some View {
+        titleContent
+            .modifier(
+                MenuLargeTitleMorphModifier(
+                    namespace: transitionNamespace,
+                    isEnabled: morphActive,
+                    isSource: menuTabIsActive
+                )
+            )
+    }
+
+    private var titleContent: some View {
+        HStack {
+            Text(title)
+                .font(.largeTitle.bold())
+                .foregroundStyle(.primary)
+                .contentTransition(.interpolate)
+                .accessibilityAddTraits(.isHeader)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 8)
+        .padding(.bottom, 6)
+    }
+}
+
+private struct MenuLargeTitleMorphModifier: ViewModifier {
+    let namespace: Namespace.ID?
+    let isEnabled: Bool
+    let isSource: Bool
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if isEnabled, let namespace {
+            content.matchedGeometryEffect(
+                id: "menu.largeTitle",
+                in: namespace,
+                properties: .frame,
+                anchor: .topLeading,
+                isSource: isSource
+            )
+        } else {
+            content
+        }
+    }
+}
+
 private struct OptionalMenuNavigationChromeModifier: ViewModifier {
     let title: String
     let backgroundHidden: Bool
@@ -194,6 +495,22 @@ private struct ClearNavigationContainerBackgroundModifier: ViewModifier {
 /// MenuTabView retains every tab page, so this container is not dismantled when
 /// another tab is selected.
 private struct StableMenuContentGlassContainerModifier: ViewModifier {
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            GlassEffectContainer(spacing: 0) {
+                content
+            }
+        } else {
+            content
+        }
+    }
+}
+
+/// Prevents a transient glass surface from joining the persistent menu-card
+/// effect group. Removing the transient surface then cannot cause every
+/// remaining card to rematerialize its Liquid Glass properties.
+private struct IsolatedMenuGlassContainerModifier: ViewModifier {
     @ViewBuilder
     func body(content: Content) -> some View {
         if #available(iOS 26.0, *) {
@@ -264,6 +581,10 @@ extension View {
 
     func stableMenuContentGlassContainer() -> some View {
         modifier(StableMenuContentGlassContainerModifier())
+    }
+
+    func isolatedMenuGlassContainer() -> some View {
+        modifier(IsolatedMenuGlassContainerModifier())
     }
 
     func clearNavigationContainerBackground() -> some View {

--- a/platforms/ios/app/src/main/swift/Views/Background/VideoBackgroundView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/VideoBackgroundView.swift
@@ -4,6 +4,29 @@
 import SwiftUI
 import AVKit
 
+/// Retains only the playhead for each configured local background video while
+/// iOS temporarily dismantles the inactive renderer. Gameplay teardown clears
+/// the entry so menu-only media state does not survive in emulation memory.
+@MainActor
+private final class BackgroundVideoPlaybackPositionStore {
+    static let shared = BackgroundVideoPlaybackPositionStore()
+    private var positions: [URL: CMTime] = [:]
+
+    func save(_ time: CMTime, for url: URL) {
+        let seconds = time.seconds
+        guard time.isValid, seconds.isFinite, seconds >= 0 else { return }
+        positions[url.standardizedFileURL] = time
+    }
+
+    func position(for url: URL) -> CMTime? {
+        positions[url.standardizedFileURL]
+    }
+
+    func clear(for url: URL) {
+        positions.removeValue(forKey: url.standardizedFileURL)
+    }
+}
+
 struct VideoBackgroundView: View {
     let url: URL
     let muted: Bool
@@ -30,6 +53,7 @@ private final class LoopingVideoView: UIView {
     private var playerLooper: AVPlayerLooper?
     private var player: AVQueuePlayer?
     private var currentURL: URL?
+    private var inactiveFrameView: UIImageView?
     private var releasedForGameplay = false
 
     deinit {
@@ -52,9 +76,8 @@ private final class LoopingVideoView: UIView {
         guard !releasedForGameplay else { return }
         let gravity = videoGravity(for: fitMode)
 
-        // Rebuild the player when the source changes so swapping the background
-        // (portrait ↔ landscape, or replacing a video) actually takes effect.
-        // The early-return-on-existing-player meant a second video was silently ignored.
+        // Recreate playback when the resolved source changes, including
+        // orientation-specific assets.
         if player != nil, currentURL != url {
 			teardown()
         }
@@ -82,27 +105,57 @@ private final class LoopingVideoView: UIView {
         layoutIfNeeded()
 
         NotificationCenter.default.addObserver(self, selector: #selector(pause), name: UIApplication.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(captureInactiveFrame), name: UIApplication.willResignActiveNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(pause), name: UIScene.willDeactivateNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(resumeIfReady), name: UIScene.didActivateNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(releaseResourcesForGameplay), name: AppState.releaseMenuBackgroundResourcesNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(adaptToPowerState), name: .NSProcessInfoPowerStateDidChange, object: nil)
-        adaptToPowerState()
+        if let resumeTime = BackgroundVideoPlaybackPositionStore.shared.position(
+            for: url
+        ), resumeTime.seconds > 0.01 {
+            queuePlayer.seek(
+                to: resumeTime,
+                toleranceBefore: .zero,
+                toleranceAfter: .zero
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    self?.resumeIfReady()
+                }
+            }
+        } else {
+            adaptToPowerState()
+        }
     }
 
-	func teardown() {
+	func teardown(preservePlaybackPosition: Bool = true) {
+        if preservePlaybackPosition,
+           let currentURL,
+           let player {
+            BackgroundVideoPlaybackPositionStore.shared.save(
+                player.currentTime(),
+                for: currentURL
+            )
+        }
         player?.pause()
         NotificationCenter.default.removeObserver(self)
         playerLayer?.removeFromSuperlayer()
+        inactiveFrameView?.removeFromSuperview()
+        inactiveFrameView = nil
         player = nil
         playerLooper = nil
         playerLayer = nil
 		currentURL = nil
     }
 
-    @objc private func pause() { player?.pause() }
+    @objc private func pause() {
+        player?.pause()
+        preserveCurrentPlaybackPosition()
+    }
 
     @objc private func resumeIfReady() {
         guard UIApplication.shared.applicationState != .background, !ProcessInfo.processInfo.isLowPowerModeEnabled else { return }
+        inactiveFrameView?.removeFromSuperview()
+        inactiveFrameView = nil
         // When this view remains mounted, AVQueuePlayer retains its current
         // item time while paused. Do not restart it after a temporary pause
         // such as Low Power Mode. A full inactive-scene teardown is handled by
@@ -110,9 +163,55 @@ private final class LoopingVideoView: UIView {
         player?.play()
     }
 
+    /// AVPlayerLayer content is not guaranteed to appear in a UIKit hierarchy
+    /// snapshot. Rasterize the current local-video frame into a normal UIImageView
+    /// first so the persistent background host captures video just like image and
+    /// dynamic backgrounds.
+    @objc private func captureInactiveFrame() {
+        guard let currentURL, let player, bounds.width > 0, bounds.height > 0 else {
+            return
+        }
+        BackgroundVideoPlaybackPositionStore.shared.save(
+            player.currentTime(),
+            for: currentURL
+        )
+
+        let generator = AVAssetImageGenerator(asset: AVURLAsset(url: currentURL))
+        generator.appliesPreferredTrackTransform = true
+        generator.maximumSize = CGSize(
+            width: bounds.width * (window?.screen.scale ?? UIScreen.main.scale),
+            height: bounds.height * (window?.screen.scale ?? UIScreen.main.scale)
+        )
+        guard let image = try? generator.copyCGImage(
+            at: player.currentTime(),
+            actualTime: nil
+        ) else {
+            return
+        }
+
+        inactiveFrameView?.removeFromSuperview()
+        let frameView = UIImageView(image: UIImage(cgImage: image))
+        frameView.frame = bounds
+        frameView.clipsToBounds = true
+        switch playerLayer?.videoGravity {
+        case .resizeAspect:
+            frameView.contentMode = .scaleAspectFit
+        case .resize:
+            frameView.contentMode = .scaleToFill
+        default:
+            frameView.contentMode = .scaleAspectFill
+        }
+        addSubview(frameView)
+        inactiveFrameView = frameView
+    }
+
     @objc private func releaseResourcesForGameplay() {
+        let releasedURL = currentURL
         releasedForGameplay = true
-        teardown()
+        teardown(preservePlaybackPosition: false)
+        if let releasedURL {
+            BackgroundVideoPlaybackPositionStore.shared.clear(for: releasedURL)
+        }
     }
 
     @objc private func adaptToPowerState() {
@@ -131,13 +230,23 @@ private final class LoopingVideoView: UIView {
         }
     }
 
+    private func preserveCurrentPlaybackPosition() {
+        guard let currentURL, let player else { return }
+        BackgroundVideoPlaybackPositionStore.shared.save(
+            player.currentTime(),
+            for: currentURL
+        )
+    }
+
     override func layoutSubviews() {
         super.layoutSubviews()
-        guard let playerLayer else { return }
         let resolved = bounds.isEmpty ? superview?.bounds ?? bounds : bounds
-        playerLayer.frame = resolved
-        playerLayer.setNeedsDisplay()
-        playerLayer.displayIfNeeded()
+        if let playerLayer, playerLayer.frame != resolved {
+            playerLayer.frame = resolved
+        }
+        if inactiveFrameView?.frame != resolved {
+            inactiveFrameView?.frame = resolved
+        }
     }
 }
 

--- a/platforms/ios/app/src/main/swift/Views/CoverThumbnailView.swift
+++ b/platforms/ios/app/src/main/swift/Views/CoverThumbnailView.swift
@@ -75,6 +75,86 @@ struct CoverThumbnailView: View {
     }
 }
 
+/// Bounds ImageIO work while allowing a complete visible row to decode at once.
+private actor CoverThumbnailDecodeLimiter {
+    private let maximumConcurrentDecodes: Int
+    private var activeDecodes = 0
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var nextWaiterIndex = 0
+
+    init(maximumConcurrentDecodes: Int) {
+        self.maximumConcurrentDecodes = max(1, maximumConcurrentDecodes)
+    }
+
+    func acquire() async {
+        if activeDecodes < maximumConcurrentDecodes {
+            activeDecodes += 1
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func release() {
+        if nextWaiterIndex < waiters.count {
+            let continuation = waiters[nextWaiterIndex]
+            nextWaiterIndex += 1
+            continuation.resume()
+            return
+        }
+
+        waiters.removeAll(keepingCapacity: true)
+        nextWaiterIndex = 0
+        activeDecodes = max(0, activeDecodes - 1)
+    }
+}
+
+/// Shares identical in-flight thumbnail requests and runs unique decodes
+/// through a small utility-priority pool.
+private actor CoverThumbnailDecodeCoordinator {
+    static let shared = CoverThumbnailDecodeCoordinator()
+
+    private struct Request {
+        let token: UUID
+        let task: Task<UIImage?, Never>
+    }
+
+    private let limiter = CoverThumbnailDecodeLimiter(
+        maximumConcurrentDecodes: 6
+    )
+    private var requests: [String: Request] = [:]
+
+    func image(
+        for key: String,
+        decode: @escaping @Sendable () -> UIImage?
+    ) async -> UIImage? {
+        if let request = requests[key] {
+            return await request.task.value
+        }
+
+        let token = UUID()
+        let limiter = self.limiter
+        let task: Task<UIImage?, Never> = Task.detached(priority: .userInitiated) {
+            await limiter.acquire()
+            guard !Task.isCancelled else {
+                await limiter.release()
+                return nil
+            }
+            let image = decode()
+            await limiter.release()
+            return Task.isCancelled ? nil : image
+        }
+        requests[key] = Request(token: token, task: task)
+
+        let image = await task.value
+        if requests[key]?.token == token {
+            requests.removeValue(forKey: key)
+        }
+        return image
+    }
+}
+
 final class CoverThumbnailCache: @unchecked Sendable {
     static let shared = CoverThumbnailCache()
 
@@ -95,6 +175,53 @@ final class CoverThumbnailCache: @unchecked Sendable {
         return cache.object(forKey: cacheKey(for: url, signature: signature, width: width, height: height, scale: scale))
     }
 
+    /// Returns the selected card's already-decoded cover when possible. A user
+    /// can tap before CoverThumbnailView's asynchronous task finishes, so the
+    /// transition performs one bounded downsample rather than showing a
+    /// placeholder or cancelling the animation.
+    func imageForGameplayTransition(
+        for url: URL,
+        signature: String?,
+        width: CGFloat,
+        height: CGFloat,
+        scale: CGFloat
+    ) -> UIImage? {
+        if let cached = cachedImage(
+            for: url,
+            signature: signature,
+            width: width,
+            height: height,
+            scale: scale
+        ) {
+            return cached
+        }
+
+        let sourceOptions = [
+            kCGImageSourceShouldCache: false,
+        ] as CFDictionary
+        let thumbnailOptions = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize:
+                max(1, Int(max(width, height) * scale)),
+        ] as CFDictionary
+
+        if let source = CGImageSourceCreateWithURL(
+            url as CFURL,
+            sourceOptions
+        ),
+           let cgImage = CGImageSourceCreateThumbnailAtIndex(
+            source,
+            0,
+            thumbnailOptions
+           ) {
+            return UIImage(cgImage: cgImage, scale: scale, orientation: .up)
+        }
+
+        return UIImage(contentsOfFile: url.path)
+    }
+
     func thumbnail(for url: URL, signature: String?, width: CGFloat, height: CGFloat, scale: CGFloat) async -> UIImage? {
         let key = cacheKey(for: url, signature: signature, width: width, height: height, scale: scale)
         guard let request = beginRequest(for: key) else { return nil }
@@ -105,29 +232,15 @@ final class CoverThumbnailCache: @unchecked Sendable {
 
         let path = url.path
         let maxPixelSize = max(1, Int(max(width, height) * scale))
-        let decodeTask = Task.detached(priority: .utility) {
-            guard !Task.isCancelled else { return nil as UIImage? }
-            let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
-            let thumbnailOptions = [
-                kCGImageSourceCreateThumbnailFromImageAlways: true,
-                kCGImageSourceCreateThumbnailWithTransform: true,
-                kCGImageSourceShouldCacheImmediately: true,
-                kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
-            ] as CFDictionary
-
-            guard let source = CGImageSourceCreateWithURL(url as CFURL, sourceOptions),
-                  let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions) else {
-                let fallback = UIImage(contentsOfFile: path)
-                return Task.isCancelled ? nil : fallback
-            }
-
-            guard !Task.isCancelled else { return nil }
-            return UIImage(cgImage: cgImage, scale: scale, orientation: .up)
-        }
-        let image = await withTaskCancellationHandler {
-            await decodeTask.value
-        } onCancel: {
-            decodeTask.cancel()
+        let image = await CoverThumbnailDecodeCoordinator.shared.image(
+            for: key as String
+        ) {
+            Self.decodeThumbnail(
+                at: url,
+                path: path,
+                maxPixelSize: maxPixelSize,
+                scale: scale
+            )
         }
 
         guard !Task.isCancelled, let image else { return nil }
@@ -135,6 +248,38 @@ final class CoverThumbnailCache: @unchecked Sendable {
         guard insert(image, for: key, cost: cost, generation: requestGeneration) else { return nil }
 
         return image
+    }
+
+    private static func decodeThumbnail(
+        at url: URL,
+        path: String,
+        maxPixelSize: Int,
+        scale: CGFloat
+    ) -> UIImage? {
+        guard !Task.isCancelled else { return nil }
+        let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
+        let thumbnailOptions = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+        ] as CFDictionary
+
+        guard let source = CGImageSourceCreateWithURL(
+            url as CFURL,
+            sourceOptions
+        ),
+              let cgImage = CGImageSourceCreateThumbnailAtIndex(
+                source,
+                0,
+                thumbnailOptions
+              ) else {
+            NSLog("[ARMSX2 iOS Covers] thumbnail decode failed %@", path)
+            return nil
+        }
+
+        guard !Task.isCancelled else { return nil }
+        return UIImage(cgImage: cgImage, scale: scale, orientation: .up)
     }
 
     static func signature(for url: URL?) -> String? {
@@ -148,8 +293,9 @@ final class CoverThumbnailCache: @unchecked Sendable {
     func activateForMenu() {
         stateLock.lock()
         defer { stateLock.unlock() }
-        guard !acceptsImages else { return }
-        generation &+= 1
+        if !acceptsImages {
+            generation &+= 1
+        }
         acceptsImages = true
     }
 

--- a/platforms/ios/app/src/main/swift/Views/GameListView.swift
+++ b/platforms/ios/app/src/main/swift/Views/GameListView.swift
@@ -38,7 +38,7 @@ enum RegionFlag {
     }
 }
 
-struct ISOEntry: Identifiable {
+struct ISOEntry: Identifiable, Equatable {
 	var id: String { bootPath ?? fileURL?.path ?? name }
 	let name: String
 	let fileURL: URL?
@@ -50,6 +50,63 @@ struct ISOEntry: Identifiable {
 	var isFavorite: Bool
 	var isExternal: Bool = false
 	var sourceName: String? = nil
+    let displayName: String
+    let sizeLabel: String
+    let regionFlag: String?
+    fileprivate let normalizedIdentifiers: Set<String>
+
+    init(
+        name: String,
+        fileURL: URL?,
+        bootPath: String?,
+        coverURL: URL?,
+        coverSignature: String?,
+        metadata: [String: String],
+        size: UInt64,
+        isFavorite: Bool,
+        isExternal: Bool = false,
+        sourceName: String? = nil
+    ) {
+        self.name = name
+        self.fileURL = fileURL
+        self.bootPath = bootPath
+        self.coverURL = coverURL
+        self.coverSignature = coverSignature
+        self.metadata = metadata
+        self.size = size
+        self.isFavorite = isFavorite
+        self.isExternal = isExternal
+        self.sourceName = sourceName
+        displayName = URL(fileURLWithPath: name)
+            .deletingPathExtension()
+            .lastPathComponent
+
+        let gigabytes = Double(size) / 1_073_741_824
+        if gigabytes >= 1 {
+            sizeLabel = String(format: "%.1f GB", gigabytes)
+        } else {
+            sizeLabel = String(
+                format: "%.0f MB",
+                Double(size) / 1_048_576
+            )
+        }
+
+        let region = metadata["region"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let flag = RegionFlag.emoji(for: region)
+        regionFlag = flag.isEmpty ? nil : flag
+
+        let identifierCandidates: [String?] = [
+            bootPath ?? fileURL?.path ?? name,
+            name,
+            fileURL?.path,
+        ]
+        let identifiers: [String] = identifierCandidates.compactMap { $0 }
+        normalizedIdentifiers = identifiers.reduce(into: Set<String>()) {
+            result, identifier in
+            result.formUnion(Self.normalizedIdentifierKeys(for: identifier))
+        }
+    }
 
 	var bootName: String {
 		isExternal ? (bootPath ?? fileURL?.path ?? name) : name
@@ -62,6 +119,17 @@ struct ISOEntry: Identifiable {
 	var coverInfo: CoverGameInfo {
 		CoverGameInfo(name: name, fileURL: fileURL, metadata: metadata, hasCover: coverURL != nil)
 	}
+
+    fileprivate static func normalizedIdentifierKeys(
+        for value: String
+    ) -> Set<String> {
+        let normalized = (value.removingPercentEncoding ?? value)
+            .replacingOccurrences(of: "\\", with: "/")
+            .lowercased()
+        guard !normalized.isEmpty else { return [] }
+        let fileName = (normalized as NSString).lastPathComponent
+        return fileName.isEmpty ? [normalized] : [normalized, fileName]
+    }
 }
 
 @MainActor
@@ -180,7 +248,7 @@ private extension View {
 
 @MainActor
 private final class GameLibrarySnapshot {
-	struct CachedGameMetadata: Codable {
+	struct CachedGameMetadata: Codable, Sendable {
 		let metadata: [String: String]
 		let modificationDate: Date?
 		let size: UInt64
@@ -196,6 +264,10 @@ private final class GameLibrarySnapshot {
 	// so a cold app launch does not rescan the whole library.
 	private var metadataCache: [String: CachedGameMetadata] = [:]
 	private var metadataCacheDirty = false
+	private let persistenceQueue = DispatchQueue(
+		label: "com.armsx2.ios.game-library-metadata",
+		qos: .utility
+	)
 
 	private static var persistenceURL: URL? {
 		let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
@@ -225,7 +297,12 @@ private final class GameLibrarySnapshot {
 
 	func update(_ entries: [ISOEntry]) {
 		orderedEntries = entries
-		entriesByID = Dictionary(entries.map { ($0.id, $0) }, uniquingKeysWith: { current, _ in current })
+		var updatedEntriesByID: [String: ISOEntry] = [:]
+		updatedEntriesByID.reserveCapacity(entries.count)
+		for entry in entries {
+			updatedEntriesByID[entry.id] = entry
+		}
+		entriesByID = updatedEntriesByID
 	}
 
 	func releaseEntriesForGameplay() {
@@ -254,29 +331,243 @@ private final class GameLibrarySnapshot {
 
 	/// Drops metadata for games no longer in the library so deleted files do not linger.
 	func purgeMetadata(keeping ids: Set<String>) {
-		let before = metadataCache.count
-		metadataCache = metadataCache.filter { ids.contains($0.key) }
-		if metadataCache.count != before {
-			metadataCacheDirty = true
+		let removedKeys = metadataCache.keys.filter { !ids.contains($0) }
+		guard !removedKeys.isEmpty else { return }
+		for key in removedKeys {
+			metadataCache.removeValue(forKey: key)
 		}
+		metadataCacheDirty = true
 	}
 
-	/// Writes the metadata cache to disk if it changed since the last save.
+	/// Copies dirty metadata and serializes it off the main thread. The serial
+	/// queue preserves write order when several library refreshes finish close together.
 	func persistMetadataCache() {
 		guard metadataCacheDirty else { return }
 		metadataCacheDirty = false
 		guard let url = Self.persistenceURL else { return }
-		try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-		guard let data = try? JSONEncoder().encode(metadataCache) else { return }
-		try? data.write(to: url, options: .atomic)
+		let snapshot = metadataCache
+		persistenceQueue.async {
+			try? FileManager.default.createDirectory(
+				at: url.deletingLastPathComponent(),
+				withIntermediateDirectories: true
+			)
+			guard let data = try? JSONEncoder().encode(snapshot) else { return }
+			try? data.write(to: url, options: .atomic)
+		}
+	}
+}
+
+private struct RunningCoverGlowPhase {
+    let radius: CGFloat
+    let x: CGFloat
+    let y: CGFloat
+    let opacity: Double
+
+    static let initial = RunningCoverGlowPhase(
+        radius: 9,
+        x: -0.5,
+        y: 0.5,
+        opacity: 0.35
+    )
+
+    static func random() -> RunningCoverGlowPhase {
+        RunningCoverGlowPhase(
+            radius: .random(in: 7.5...12.5),
+            x: .random(in: -2.25...2.25),
+            y: .random(in: -2.25...2.25),
+            opacity: .random(in: 0.20...0.45)
+        )
+    }
+}
+
+/// Animates only the active game's already-decoded cover. Randomized radius,
+/// intensity, and direction avoid the mechanical appearance of a fixed pulse
+/// without introducing a library-wide timeline or invalidating other cards.
+private struct RunningCoverNeonGlowModifier: ViewModifier {
+    let isRunning: Bool
+    @State private var phase = RunningCoverGlowPhase.initial
+
+    func body(content: Content) -> some View {
+        content
+            .shadow(
+                color: Color(red: 0.18, green: 1.0, blue: 0.28)
+                    .opacity(isRunning ? phase.opacity : 0),
+                radius: isRunning ? phase.radius : 0,
+                x: isRunning ? phase.x : 0,
+                y: isRunning ? phase.y : 0
+            )
+            .shadow(
+                color: Color(red: 0.48, green: 1.0, blue: 0.58)
+                    .opacity(isRunning ? phase.opacity * 0.76 : 0),
+                radius: isRunning ? phase.radius * 0.68 : 0,
+                x: isRunning ? -phase.x * 0.7 : 0,
+                y: isRunning ? -phase.y * 0.7 : 0
+            )
+            .animation(.easeOut(duration: 0.55), value: isRunning)
+            .task(id: isRunning) {
+                guard isRunning else {
+                    phase = .initial
+                    return
+                }
+
+                while !Task.isCancelled {
+                    let duration = Double.random(in: 0.8...1.35)
+                    withAnimation(.easeInOut(duration: duration)) {
+                        phase = .random()
+                    }
+                    try? await Task.sleep(
+                        for: .milliseconds(Int(duration * 1_000))
+                    )
+                }
+            }
+    }
+}
+
+/// Keeps transient library bookkeeping outside SwiftUI observation so scrolling
+/// and refresh guards do not invalidate every visible card.
+@MainActor
+private final class GameLibraryActivityState {
+    var isScrolling = false
+    var isLoading = false
+    private var scheduledReloadTask: Task<Void, Never>?
+    private var cachedRunningName: String?
+    private var cachedRunningIdentifiers: Set<String> = []
+
+    func scheduleReload(
+        after delay: Duration,
+        operation: @escaping @MainActor () -> Void
+    ) {
+        scheduledReloadTask?.cancel()
+        scheduledReloadTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: delay)
+            guard !Task.isCancelled else { return }
+            while self?.isScrolling == true {
+                try? await Task.sleep(for: .milliseconds(50))
+                guard !Task.isCancelled else { return }
+            }
+            operation()
+            self?.scheduledReloadTask = nil
+        }
+    }
+
+    func cancelScheduledReload() {
+        scheduledReloadTask?.cancel()
+        scheduledReloadTask = nil
+    }
+
+    func runningIdentifiers(for gameName: String?) -> Set<String> {
+        guard let gameName else {
+            cachedRunningName = nil
+            cachedRunningIdentifiers.removeAll(keepingCapacity: true)
+            return []
+        }
+        guard cachedRunningName != gameName else {
+            return cachedRunningIdentifiers
+        }
+        cachedRunningName = gameName
+        cachedRunningIdentifiers = ISOEntry.normalizedIdentifierKeys(
+            for: gameName
+        )
+        return cachedRunningIdentifiers
+    }
+}
+
+private struct GameLibraryScrollPhaseModifier: ViewModifier {
+    let activity: GameLibraryActivityState
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(iOS 18.0, *) {
+            content.onScrollPhaseChange { _, newPhase in
+                activity.isScrolling = newPhase.isScrolling
+            }
+        } else {
+            content
+        }
+    }
+}
+
+private extension View {
+    func trackGameLibraryScrollPhase(
+        _ activity: GameLibraryActivityState
+    ) -> some View {
+        modifier(
+            GameLibraryScrollPhaseModifier(activity: activity)
+        )
+    }
+}
+
+private struct RunningStatusText: View {
+    let isStopping: Bool
+    let runningLabel: String
+    let gameTitle: String
+    let stoppingLabel: String
+    let stoppingFont: Font
+    var centered = false
+
+    @ViewBuilder
+    var body: some View {
+        if isStopping {
+            Text(stoppingLabel)
+                .font(stoppingFont.bold())
+                .foregroundStyle(.red)
+                .lineLimit(1)
+                .minimumScaleFactor(0.72)
+                .multilineTextAlignment(.center)
+                .transition(
+                    .opacity
+                        .combined(with: .scale(scale: 0.82))
+                        .combined(with: .offset(x: 8))
+                )
+        } else {
+            VStack(
+                alignment: centered ? .center : .leading,
+                spacing: 3
+            ) {
+                Text(runningLabel)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(gameTitle)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(centered ? 2 : 1)
+                    .truncationMode(.tail)
+                    .multilineTextAlignment(centered ? .center : .leading)
+            }
+            .transition(
+                .opacity
+                    .combined(with: .scale(scale: 0.88))
+                    .combined(with: .offset(x: -8))
+            )
+        }
+	}
+}
+
+/// Releases the shared, menu-only portion of the game library independently of
+/// SwiftUI view-disappearance timing. The persisted metadata index remains on
+/// disk, so returning to the menu can rebuild entries without reopening every
+/// active disc image.
+@MainActor
+enum GameLibraryRuntimeResources {
+	static func activateForMenu() {
+		CoverThumbnailCache.shared.activateForMenu()
+	}
+
+	static func releaseForGameplay() {
+		GameLibrarySnapshot.shared.releaseEntriesForGameplay()
+		CoverThumbnailCache.shared.releaseForGameplay()
 	}
 }
 
 struct GameListView: View {
     let embeddedInMenuNavigation: Bool
+    let ownsEmbeddedMenuToolbar: Bool
 
-    init(embeddedInMenuNavigation: Bool = false) {
+    init(
+        embeddedInMenuNavigation: Bool = false,
+        ownsEmbeddedMenuToolbar: Bool = true
+    ) {
         self.embeddedInMenuNavigation = embeddedInMenuNavigation
+        self.ownsEmbeddedMenuToolbar = ownsEmbeddedMenuToolbar
     }
 
     @State private var games: [ISOEntry] = []
@@ -288,10 +579,10 @@ struct GameListView: View {
 	@State private var externalCoverAutoDownloadAttemptedIDs = Set<String>()
 	@State private var coverWorkTask: Task<Void, Never>?
 	@State private var showGameImporter = false
-	@State private var isLoadingGames = false
     @State private var showCoverImporter = false
     @State private var showCoverPhotoPicker = false
     @Environment(\.menuTabIsActive) private var menuTabIsActive
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
     @State private var showRestartAlert = false
     @State private var showStopAlert = false
     @State private var showCoverTemplateEditor = false
@@ -315,19 +606,19 @@ struct GameListView: View {
     @State private var showBackgroundAssetError = false
     @State private var gameplayLaunchCardRegistry = GameplayLaunchCardRegistry()
     @State private var favoriteAnimationValues: [String: Int] = [:]
-    @State private var favoriteReorderAnimationActive = false
-    @State private var favoriteReorderResetTask: Task<Void, Never>?
     @State private var nowRunningRemovalAnimationActive = false
     @State private var nowRunningRemovalResetTask: Task<Void, Never>?
-    @State private var nowRunningAlertDismissTask: Task<Void, Never>?
     @State private var departingRunningGameName: String?
     @State private var nowRunningCardOpacity = 1.0
+    @State private var nowRunningCardScale = 1.0
+    @State private var nowRunningStatusOpacity = 1.0
+    @State private var gameLibraryActivity = GameLibraryActivityState()
     @AppStorage("ARMSX2iOSGameLibraryLayout") private var libraryLayout = "grid"
     @AppStorage("ARMSX2iOSLandscapeCoverFlowEnabled") private var landscapeCoverFlowEnabled = true
 #if DEBUG
     @State private var ranBackgroundValidation = false
 #endif
-    // Background state is now kept in SettingsStore and rendered by BackgroundContainerView.
+    // SettingsStore owns background configuration; the shared container renders it.
     private var hasCustomBackground: Bool {
         settings.dynamicBackgroundsEnabled
             || settings.backgroundPrimaryAsset != nil
@@ -335,7 +626,53 @@ struct GameListView: View {
     }
 
     private var displayedRunningGameName: String? {
-        appState.runningGameName ?? departingRunningGameName
+        if let departingRunningGameName {
+            return departingRunningGameName
+        }
+        guard case .menu = appState.currentScreen else {
+            return nil
+        }
+        return appState.runningGameName
+    }
+
+    /// Departure values belong only to the retained stopping placeholder.
+    /// A normal running card always starts from its canonical appearance, so
+    /// cleanup never needs to reset animation state across the library tree.
+    private var displayedNowRunningCardOpacity: Double {
+        departingRunningGameName == nil ? 1 : nowRunningCardOpacity
+    }
+
+    private var displayedNowRunningCardScale: Double {
+        departingRunningGameName == nil ? 1 : nowRunningCardScale
+    }
+
+    private var displayedNowRunningStatusOpacity: Double {
+        departingRunningGameName == nil ? 1 : nowRunningStatusOpacity
+    }
+
+    private var showsPageOwnedLargeTitle: Bool {
+        embeddedInMenuNavigation
+            && verticalSizeClass != .compact
+            && UIDevice.current.userInterfaceIdiom == .phone
+    }
+
+    private func libraryPresentationIdentity(
+        for containerSize: CGSize
+    ) -> String {
+        let orientation = containerSize.width > containerSize.height
+            ? "landscape"
+            : "portrait"
+
+        if games.isEmpty && displayedRunningGameName == nil {
+            return "empty-\(orientation)"
+        }
+        if libraryLayout != "grid" {
+            return "list-\(orientation)"
+        }
+        if orientation == "landscape" && landscapeCoverFlowEnabled {
+            return "cover-flow-landscape"
+        }
+        return "grid-\(orientation)"
     }
 
     private struct CoverFlowMetrics {
@@ -384,7 +721,7 @@ struct GameListView: View {
                 GeometryReader { geo in
                     Group {
                         if games.isEmpty && displayedRunningGameName == nil {
-                            emptyState
+                            emptyLibrary(containerSize: geo.size)
                         } else if libraryLayout == "grid" && geo.size.width > geo.size.height && landscapeCoverFlowEnabled {
                             coverFlowLibrary(containerSize: geo.size)
                         } else if libraryLayout == "grid" {
@@ -396,6 +733,11 @@ struct GameListView: View {
 #endif
                         }
                     }
+                    // Portrait grids/lists and landscape cover flow use
+                    // different scroll axes. Give each presentation a stable
+                    // identity so rotation cannot reuse the previous
+                    // UIScrollView's content offset or alignment geometry.
+                    .id(libraryPresentationIdentity(for: geo.size))
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
             }
@@ -407,7 +749,7 @@ struct GameListView: View {
                 embedded: embeddedInMenuNavigation
             )
             .toolbar {
-                if !embeddedInMenuNavigation || menuTabIsActive {
+                if !embeddedInMenuNavigation || ownsEmbeddedMenuToolbar {
                 ToolbarItem(id: "menu.import", placement: .topBarTrailing) {
                     Button {
                         showGameImporter = true
@@ -490,7 +832,7 @@ struct GameListView: View {
                             .foregroundStyle(.blue)
                     }
                     .buttonStyle(.plain)
-                    .disabled(isLoadingGames)
+                    .disabled(gameLibraryActivity.isLoading)
                     .accessibilityLabel(settings.localized("Refresh"))
                 }
                 ToolbarItem(id: "menu.bootBIOS", placement: .topBarLeading) {
@@ -682,7 +1024,7 @@ struct GameListView: View {
                 importCoverPhoto(photoItem, forGameNamed: gameName)
             }
             .sheet(item: $gameInfoTarget) { game in
-                GameInfoPanel(game: game, coverStore: coverStore)
+                GameInfoPanel(game: game)
                     .presentationDetents([.medium, .large])
             }
             .sheet(item: $gameSettingsTarget) { game in
@@ -719,43 +1061,66 @@ struct GameListView: View {
             } message: {
                 Text(settings.localized("This will shut down the running game. All unsaved progress will be lost."))
             }
-			.onAppear {
-				CoverThumbnailCache.shared.activateForMenu()
-			externalLibrary.reload()
-			restoreCachedGamesIfNeeded()
-			loadGames(autoDownloadExternalCovers: true)
-			if settings.sanitizeBackgroundAssets() {
-				showBackgroundAssetError = true
-			}
+        .onAppear {
+            GameLibraryRuntimeResources.activateForMenu()
+            restoreCachedGamesIfNeeded()
+            scheduleLibraryReload(
+                after: .milliseconds(80),
+                autoDownloadExternalCovers: true
+            )
+            if settings.sanitizeBackgroundAssets() {
+                showBackgroundAssetError = true
+            }
 #if DEBUG
-			if !ranBackgroundValidation {
-				ranBackgroundValidation = true
-				BackgroundValidation.run()
-			}
+            if !ranBackgroundValidation {
+                ranBackgroundValidation = true
+                BackgroundValidation.run()
+            }
 #endif
-		}
-		.onReceive(NotificationCenter.default.publisher(for: ExternalGameLibrary.didChangeNotification)) { _ in
-			loadGames(autoDownloadExternalCovers: true)
-		}
-		.onReceive(NotificationCenter.default.publisher(for: InitialContentBootstrap.didChangeNotification)) { _ in
-			loadGames(autoDownloadExternalCovers: false)
-		}
-		.onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("ARMSX2iOSReturnToMenu"))) { _ in
-			restoreCachedGamesIfNeeded()
-			loadGames(autoDownloadExternalCovers: false)
-		}
-			.onDisappear {
-				guard case .playing = appState.currentScreen else { return }
-				releaseLibraryResourcesForGameplay()
-		}
+        }
+        .onReceive(NotificationCenter.default.publisher(for: ExternalGameLibrary.didChangeNotification)) { _ in
+            scheduleLibraryReload(
+                after: .milliseconds(120),
+                autoDownloadExternalCovers: true
+            )
+        }
+        .onReceive(NotificationCenter.default.publisher(for: InitialContentBootstrap.didChangeNotification)) { _ in
+            scheduleLibraryReload(
+                after: .milliseconds(120),
+                autoDownloadExternalCovers: false
+            )
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("ARMSX2iOSReturnToMenu"))) { _ in
+            restoreCachedGamesIfNeeded()
+            scheduleLibraryReload(
+                after: .milliseconds(80),
+                autoDownloadExternalCovers: false
+            )
+        }
+        .onDisappear {
+            guard case .playing = appState.currentScreen else { return }
+            releaseLibraryResourcesForGameplay()
+        }
     }
 
     private var listLibrary: some View {
         List {
+            if showsPageOwnedLargeTitle {
+                EmbeddedMenuLargeTitle(title: settings.localized("Games"))
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.clear)
+            }
+            if games.isEmpty && displayedRunningGameName == nil {
+                emptyState
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.clear)
+            }
             if let gameName = displayedRunningGameName {
                 vmStatusSection(
                     gameName: gameName,
-                    opacity: nowRunningCardOpacity
+                    opacity: displayedNowRunningCardOpacity,
+                    scale: displayedNowRunningCardScale
                 )
             }
             ForEach(games) { game in
@@ -763,16 +1128,43 @@ struct GameListView: View {
                     .menuBackgroundListRow(hasCustomBackground)
             }
         }
+        .contentMargins(.top, 0, for: .scrollContent)
         .scrollContentBackground(hasCustomBackground ? .hidden : .automatic)
+        .scrollDisabled(false)
+        .scrollBounceBehavior(.always)
+        .trackGameLibraryScrollPhase(gameLibraryActivity)
+        .transaction { transaction in
+            if transaction.isContinuous || gameLibraryActivity.isScrolling {
+                transaction.animation = nil
+            }
+        }
     }
 
     private var gridLibrary: some View {
         ScrollView {
             LazyVStack(spacing: 16) {
+                if showsPageOwnedLargeTitle {
+                    EmbeddedMenuLargeTitle(title: settings.localized("Games"))
+                }
+
+                if games.isEmpty && displayedRunningGameName == nil {
+                    emptyState
+                        .frame(minHeight: 300)
+                }
+
                 if let gameName = displayedRunningGameName {
                     vmStatusCard(gameName: gameName)
+                        .isolatedMenuGlassContainer()
                         .padding(.horizontal)
-                        .opacity(nowRunningCardOpacity)
+                        .compositingGroup()
+                        .scaleEffect(displayedNowRunningCardScale)
+                        .opacity(displayedNowRunningCardOpacity)
+                        .animation(
+                            .smooth(duration: 0.65, extraBounce: 0.04),
+                            value: displayedNowRunningCardScale
+                        )
+                        .animation(.linear(duration: 0.65), value: displayedNowRunningCardOpacity)
+                        .transition(.scale(scale: 0.86).combined(with: .opacity))
                 }
 
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: 142), spacing: 14, alignment: .top)], spacing: 18) {
@@ -783,7 +1175,16 @@ struct GameListView: View {
                 .padding(.horizontal)
                 .padding(.bottom, 20)
             }
-            .padding(.top, 12)
+            .padding(.top, showsPageOwnedLargeTitle ? 0 : 12)
+        }
+        .contentMargins(.top, 0, for: .scrollContent)
+        .scrollDisabled(false)
+        .scrollBounceBehavior(.always)
+        .trackGameLibraryScrollPhase(gameLibraryActivity)
+        .transaction { transaction in
+            if transaction.isContinuous || gameLibraryActivity.isScrolling {
+                transaction.animation = nil
+            }
         }
         .background(
             Group {
@@ -798,11 +1199,46 @@ struct GameListView: View {
                 }
             }
         )
-        .transaction { transaction in
-            if !favoriteReorderAnimationActive && !nowRunningRemovalAnimationActive {
-                transaction.animation = nil
+    }
+
+    private func emptyLibrary(containerSize: CGSize) -> some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                if showsPageOwnedLargeTitle {
+                    EmbeddedMenuLargeTitle(title: settings.localized("Games"))
+                }
+
+                emptyState
+                    .frame(
+                        maxWidth: .infinity,
+                        minHeight: max(
+                            300,
+                            containerSize.height
+                                - (showsPageOwnedLargeTitle ? 64 : 0)
+                        ),
+                        alignment: .center
+                    )
             }
         }
+        .contentMargins(.top, 0, for: .scrollContent)
+        .scrollDisabled(false)
+        .scrollBounceBehavior(.always)
+        .background(
+            Group {
+                if hasCustomBackground {
+                    Color.clear
+                } else {
+                    LinearGradient(
+                        colors: [
+                            Color(.systemGroupedBackground),
+                            Color(.secondarySystemGroupedBackground),
+                        ],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                }
+            }
+        )
     }
 
     private func coverFlowLibrary(containerSize: CGSize) -> some View {
@@ -811,9 +1247,32 @@ struct GameListView: View {
 
         return ScrollView(.horizontal, showsIndicators: false) {
             LazyHStack(alignment: .center, spacing: metrics.itemSpacing) {
+                if games.isEmpty && displayedRunningGameName == nil {
+                    emptyState
+                        .frame(
+                            width: max(
+                                0,
+                                containerSize.width - (metrics.horizontalPadding * 2)
+                            ),
+                            height: max(
+                                0,
+                                availableHeight - (metrics.verticalPadding * 2)
+                            )
+                        )
+                }
+
                 if let gameName = displayedRunningGameName {
                     vmStatusCoverCard(gameName: gameName, metrics: metrics)
-                        .opacity(nowRunningCardOpacity)
+                        .isolatedMenuGlassContainer()
+                        .compositingGroup()
+                        .scaleEffect(displayedNowRunningCardScale)
+                        .opacity(displayedNowRunningCardOpacity)
+                        .animation(
+                            .smooth(duration: 0.65, extraBounce: 0.04),
+                            value: displayedNowRunningCardScale
+                        )
+                        .animation(.linear(duration: 0.65), value: displayedNowRunningCardOpacity)
+                        .transition(.scale(scale: 0.86).combined(with: .opacity))
                 }
 
                 ForEach(games) { game in
@@ -828,8 +1287,20 @@ struct GameListView: View {
             .padding(.horizontal, metrics.horizontalPadding)
             .padding(.vertical, metrics.verticalPadding)
         }
+        .scrollDisabled(false)
+        .scrollBounceBehavior(.always, axes: .horizontal)
+        .trackGameLibraryScrollPhase(gameLibraryActivity)
+        .transaction { transaction in
+            if transaction.isContinuous || gameLibraryActivity.isScrolling {
+                transaction.animation = nil
+            }
+        }
         .frame(height: availableHeight)
         .frame(maxHeight: .infinity, alignment: .top)
+        // The persistent bottom bar shortens the layout proposal. Offset by
+        // half the navigation/top-bar imbalance to keep the library visually
+        // centered in the complete landscape display.
+        .offset(y: 30)
         .background(
             Group {
                 if hasCustomBackground {
@@ -843,11 +1314,6 @@ struct GameListView: View {
                 }
             }
         )
-        .transaction { transaction in
-            if !favoriteReorderAnimationActive && !nowRunningRemovalAnimationActive {
-                transaction.animation = nil
-            }
-        }
     }
 
     /// Clean display title for the running game, preferring the library entry over the raw path.
@@ -872,117 +1338,158 @@ struct GameListView: View {
 
     private func vmStatusSection(
         gameName: String,
-        opacity: Double
+        opacity: Double,
+        scale: Double
     ) -> some View {
-        Section {
-            // Resume row — tap anywhere to return to game
+        let isStopping = nowRunningRemovalAnimationActive
+
+        return Section {
             Button {
                 appState.returnToGame()
             } label: {
                 HStack {
-                    Image(systemName: "play.circle.fill")
-                        .foregroundStyle(.green)
-                        .font(.title)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(settings.localized("Now Running"))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        Text(displayTitle(forRunningName: gameName))
-                            .font(.body)
-                            .fontWeight(.semibold)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
+                    HStack(spacing: 8) {
+                        Image(
+                            systemName: isStopping
+                                ? "stop.circle.fill"
+                                : "play.circle.fill"
+                        )
+                            .foregroundStyle(isStopping ? .red : .green)
+                            .font(.title)
+                            .contentTransition(.symbolEffect(.replace))
+
+                        RunningStatusText(
+                            isStopping: isStopping,
+                            runningLabel: settings.localized("Now Running"),
+                            gameTitle: displayTitle(forRunningName: gameName),
+                            stoppingLabel: settings.localized("Stopping..."),
+                            stoppingFont: .title2
+                        )
                     }
-                    Spacer()
-                    Text(settings.localized("Resume"))
-                        .font(.subheadline)
-                        .fontWeight(.medium)
-                    Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
+                    .opacity(displayedNowRunningStatusOpacity)
+                    .animation(.easeInOut(duration: 0.3), value: displayedNowRunningStatusOpacity)
+
+                    if !isStopping {
+                        Spacer()
+                        HStack(spacing: 6) {
+                            Text(settings.localized("Resume"))
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                            Image(systemName: "chevron.right")
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
+                        }
+                        .transition(.opacity.combined(with: .scale(scale: 0.9)))
+                    }
                 }
+                .frame(
+                    maxWidth: .infinity,
+                    alignment: isStopping ? .center : .leading
+                )
                 .padding(.vertical, 6)
+                .animation(
+                    .smooth(duration: 0.42, extraBounce: 0.02),
+                    value: isStopping
+                )
             }
+            .disabled(isStopping)
             .tint(.primary)
             .menuBackgroundListRow(hasCustomBackground)
+            .compositingGroup()
+            .scaleEffect(scale)
             .opacity(opacity)
+            .animation(.linear(duration: 0.65), value: opacity)
+            .animation(
+                .smooth(duration: 0.65, extraBounce: 0.04),
+                value: scale
+            )
 
-            // Stop button — separate row with confirmation alert
-            Button(role: .destructive) {
-                showStopAlert = true
-            } label: {
-                HStack {
-                    Spacer()
-                    Label(settings.localized("Stop Emulation"), systemImage: "stop.circle")
-                        .font(.subheadline)
-                    Spacer()
+            if !isStopping {
+                Button(role: .destructive) {
+                    showStopAlert = true
+                } label: {
+                    HStack {
+                        Spacer()
+                        Label(settings.localized("Stop Emulation"), systemImage: "stop.circle")
+                            .font(.subheadline)
+                        Spacer()
+                    }
                 }
+                .menuBackgroundListRow(hasCustomBackground)
+                .compositingGroup()
+                .scaleEffect(scale)
+                .opacity(opacity)
+                .transition(.opacity.combined(with: .scale(scale: 0.9)))
+                .animation(.linear(duration: 0.65), value: opacity)
+                .animation(
+                    .smooth(duration: 0.65, extraBounce: 0.04),
+                    value: scale
+                )
             }
-            .menuBackgroundListRow(hasCustomBackground)
-            .opacity(opacity)
         }
     }
 
     private func gameRow(_ game: ISOEntry) -> some View {
         let running = isRunning(game)
-        return HStack(spacing: 4) {
-            Button {
-                open(game)
-            } label: {
-                HStack(spacing: 12) {
-                    coverThumbnail(for: game, running: running)
+        return Button {
+            open(game)
+        } label: {
+            HStack(spacing: 12) {
+                coverThumbnail(for: game, running: running)
 
-                    VStack(alignment: .leading, spacing: 4) {
-                        HStack(spacing: 6) {
-                            Text(coverStore.displayName(forGameName: game.name))
-                                .font(.body)
-                                .fontWeight(.medium)
-                                .foregroundStyle(.primary)
-                                .lineLimit(2)
-                                .multilineTextAlignment(.leading)
-                                .fixedSize(horizontal: false, vertical: true)
-                                .layoutPriority(1)
-                            if running {
-                                Image(systemName: "circle.fill")
-                                    .font(.system(size: 8))
-                                    .foregroundStyle(.green)
-                                    .accessibilityLabel(settings.localized("Running"))
-                                    .fixedSize()
-                            }
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        Text(game.displayName)
+                            .font(.body)
+                            .fontWeight(.medium)
+                            .foregroundStyle(.primary)
+                            .lineLimit(2)
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .layoutPriority(1)
+                        if running {
+                            Image(systemName: "circle.fill")
+                                .font(.system(size: 8))
+                                .foregroundStyle(.green)
+                                .accessibilityLabel(settings.localized("Running"))
+                                .fixedSize()
                         }
-                        HStack(spacing: 8) {
-                            Text(formatSize(game.size))
-                            Text(game.name.pathExtensionLabel)
-                            if game.isExternal {
-                                Label(settings.localized("External"), systemImage: "externaldrive")
-                            }
-                            if let flag = regionFlagText(for: game) {
-                                Text(flag).accessibilityLabel(settings.localized("Region"))
-                            }
-                        }
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
                     }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .layoutPriority(1)
-                    Spacer()
-                    Image(systemName: running ? "play.fill" : "chevron.right")
-                        .foregroundStyle(running ? .green : .secondary)
-                        .font(.caption)
-                        .accessibilityHidden(true)
+                    HStack(spacing: 8) {
+                        Text(game.sizeLabel)
+                        Text(game.name.pathExtensionLabel)
+                        if game.isExternal {
+                            Label(settings.localized("External"), systemImage: "externaldrive")
+                        }
+                        if let flag = game.regionFlag {
+                            Text(flag).accessibilityLabel(settings.localized("Region"))
+                        }
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
                 }
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(.primary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .layoutPriority(1)
+                Spacer()
 
-            favoriteButton(
-                for: game,
-                foreground: game.isFavorite ? .yellow : .gray
-            )
+                favoriteButton(
+                    for: game,
+                    foreground: game.isFavorite ? .yellow : .gray
+                )
+
+                Image(systemName: running ? "play.fill" : "chevron.right")
+                    .foregroundStyle(running ? .green : .secondary)
+                    .font(.caption)
+                    .accessibilityHidden(true)
+            }
         }
+        .buttonStyle(.plain)
+        .foregroundStyle(.primary)
         .contextMenu {
             gameContextMenu(for: game)
+        } preview: {
+            gameContextMenuPreview(for: game)
         }
         .registerGameplayLaunchCard(
             for: game.id,
@@ -992,17 +1499,17 @@ struct GameListView: View {
 
     private func gameGridCard(_ game: ISOEntry) -> some View {
         let running = isRunning(game)
-        return ZStack(alignment: .topTrailing) {
-            Button {
-                open(game)
-            } label: {
+        return Button {
+            open(game)
+        } label: {
+            ZStack(alignment: .topTrailing) {
                 VStack(alignment: .center, spacing: 10) {
                     coverThumbnail(for: game, width: 126, height: 189, running: running)
                         .frame(maxWidth: .infinity)
 
                     VStack(alignment: .center, spacing: 4) {
                         HStack(alignment: .firstTextBaseline, spacing: 5) {
-                            Text(coverStore.displayName(forGameName: game.name))
+                            Text(game.displayName)
                                 .font(.subheadline.weight(.semibold))
                                 .foregroundStyle(.primary)
                                 .lineLimit(2)
@@ -1021,12 +1528,12 @@ struct GameListView: View {
                         .frame(minHeight: 38, alignment: .top)
                         HStack(spacing: 6) {
                             Text(game.name.pathExtensionLabel)
-                            Text(formatSize(game.size))
+                            Text(game.sizeLabel)
                             if game.isExternal {
                                 Image(systemName: "externaldrive")
                                     .accessibilityLabel(settings.localized("External"))
                             }
-                            if let flag = regionFlagText(for: game), !flag.isEmpty {
+                            if let flag = game.regionFlag {
                                 Text(flag).accessibilityLabel(settings.localized("Region"))
                             }
                         }
@@ -1038,23 +1545,24 @@ struct GameListView: View {
                 }
                 .padding(12)
                 .frame(maxWidth: .infinity, minHeight: 268, alignment: .top)
-            }
-            .buttonStyle(.plain)
-            .zIndex(0)
 
-            favoriteButton(
-                for: game,
-                font: .callout.weight(.semibold),
-                foreground: game.isFavorite ? .yellow : .white.opacity(0.86),
-                backgroundOpacity: 0.36,
-                padding: 6
-            )
-            .padding(12)
-            .zIndex(2)
+                favoriteButton(
+                    for: game,
+                    font: .callout.weight(.semibold),
+                    foreground: game.isFavorite ? .yellow : .white.opacity(0.86),
+                    backgroundOpacity: 0.36,
+                    padding: 6
+                )
+                .padding(12)
+                .zIndex(2)
+            }
+            .glassSurface(clear: true, cornerRadius: 18)
         }
-        .glassSurface(clear: true, cornerRadius: 18)
+        .buttonStyle(.plain)
         .contextMenu {
             gameContextMenu(for: game)
+        } preview: {
+            gameContextMenuPreview(for: game)
         }
         .registerGameplayLaunchCard(
             for: game.id,
@@ -1064,10 +1572,10 @@ struct GameListView: View {
 
     private func coverFlowCard(_ game: ISOEntry, metrics: CoverFlowMetrics) -> some View {
         let running = isRunning(game)
-        return ZStack(alignment: .topTrailing) {
-            Button {
-                open(game)
-            } label: {
+        return Button {
+            open(game)
+        } label: {
+            ZStack(alignment: .topTrailing) {
                 VStack(spacing: metrics.cardSpacing) {
                     coverThumbnail(
                         for: game,
@@ -1078,7 +1586,7 @@ struct GameListView: View {
                     .shadow(color: running ? .clear : .black.opacity(0.28), radius: 18, y: 10)
 
                     VStack(spacing: 4) {
-                        Text(coverStore.displayName(forGameName: game.name))
+                        Text(game.displayName)
                             .font((metrics.isCompact ? Font.subheadline : Font.headline).weight(.semibold))
                             .multilineTextAlignment(.center)
                             .lineLimit(2)
@@ -1086,8 +1594,8 @@ struct GameListView: View {
                             .frame(maxWidth: .infinity, alignment: .center)
                             .frame(minHeight: metrics.isCompact ? 38 : 46, alignment: .top)
                         HStack(spacing: 4) {
-                            Text(game.isExternal ? "\(game.name.pathExtensionLabel)  \(formatSize(game.size))  \(settings.localized("External"))" : "\(game.name.pathExtensionLabel)  \(formatSize(game.size))")
-                            if let flag = regionFlagText(for: game) {
+                            Text(game.isExternal ? "\(game.name.pathExtensionLabel)  \(game.sizeLabel)  \(settings.localized("External"))" : "\(game.name.pathExtensionLabel)  \(game.sizeLabel)")
+                            if let flag = game.regionFlag {
                                 Text(flag).accessibilityLabel(settings.localized("Region"))
                             }
                         }
@@ -1097,23 +1605,24 @@ struct GameListView: View {
                     .frame(width: metrics.textWidth)
                 }
                 .padding(metrics.cardPadding)
-            }
-            .buttonStyle(.plain)
-            .zIndex(0)
 
-            favoriteButton(
-                for: game,
-                font: (metrics.isCompact ? Font.subheadline : Font.headline).weight(.semibold),
-                foreground: game.isFavorite ? .yellow : .white.opacity(0.88),
-                backgroundOpacity: 0.48,
-                padding: metrics.favoritePadding
-            )
-            .padding(metrics.cardPadding + metrics.favoriteInset)
-            .zIndex(2)
+                favoriteButton(
+                    for: game,
+                    font: (metrics.isCompact ? Font.subheadline : Font.headline).weight(.semibold),
+                    foreground: game.isFavorite ? .yellow : .white.opacity(0.88),
+                    backgroundOpacity: 0.48,
+                    padding: metrics.favoritePadding
+                )
+                .padding(metrics.cardPadding + metrics.favoriteInset)
+                .zIndex(2)
+            }
+            .glassSurface(clear: true, cornerRadius: metrics.cornerRadius)
         }
-        .glassSurface(clear: true, cornerRadius: metrics.cornerRadius)
+        .buttonStyle(.plain)
         .contextMenu {
             gameContextMenu(for: game)
+        } preview: {
+            gameContextMenuPreview(for: game)
         }
         .registerGameplayLaunchCard(
             for: game.id,
@@ -1162,79 +1671,132 @@ struct GameListView: View {
 		height: CGFloat = 87,
 		running: Bool
 	) -> some View {
-		CoverThumbnailView(
+        CoverThumbnailView(
             gameName: game.name,
             coverURL: game.coverURL,
             coverSignature: game.coverSignature,
             width: width,
             height: height
         )
-		.shadow(
-			color: running ? .green.opacity(0.7) : .clear,
-			radius: running ? 12 : 0,
-			y: running ? 4 : 0
-		)
+        .modifier(
+            RunningCoverNeonGlowModifier(
+                isRunning: running && !nowRunningRemovalAnimationActive
+            )
+        )
     }
 
     private func vmStatusCard(gameName: String) -> some View {
-        HStack(spacing: 12) {
-            Image(systemName: "play.circle.fill")
-                .font(.title2)
-                .foregroundStyle(.green)
-            VStack(alignment: .leading, spacing: 3) {
-                Text(settings.localized("Now Running"))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Text(displayTitle(forRunningName: gameName))
-                    .font(.subheadline.weight(.semibold))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
+        let isStopping = nowRunningRemovalAnimationActive
+
+        return HStack(spacing: 12) {
+            HStack(spacing: 8) {
+                Image(
+                    systemName: isStopping
+                        ? "stop.circle.fill"
+                        : "play.circle.fill"
+                )
+                    .font(.title2)
+                    .foregroundStyle(isStopping ? .red : .green)
+                    .contentTransition(.symbolEffect(.replace))
+
+                RunningStatusText(
+                    isStopping: isStopping,
+                    runningLabel: settings.localized("Now Running"),
+                    gameTitle: displayTitle(forRunningName: gameName),
+                    stoppingLabel: settings.localized("Stopping..."),
+                    stoppingFont: .title2
+                )
             }
-            Spacer()
-            Button(settings.localized("Resume")) {
-                appState.returnToGame()
+            .opacity(displayedNowRunningStatusOpacity)
+            .animation(.easeInOut(duration: 0.3), value: displayedNowRunningStatusOpacity)
+
+            if !isStopping {
+                Spacer()
+                HStack(spacing: 8) {
+                    Button(settings.localized("Resume")) {
+                        appState.returnToGame()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    Button(role: .destructive) {
+                        showStopAlert = true
+                    } label: {
+                        Image(systemName: "stop.circle")
+                    }
+                    .buttonStyle(.bordered)
+                }
+                .transition(.opacity.combined(with: .scale(scale: 0.9)))
             }
-            .buttonStyle(.borderedProminent)
-            Button(role: .destructive) {
-                showStopAlert = true
-            } label: {
-                Image(systemName: "stop.circle")
-            }
-            .buttonStyle(.bordered)
         }
+        .frame(
+            maxWidth: .infinity,
+            alignment: isStopping ? .center : .leading
+        )
         .padding()
-			.glassSurface(clear: true, cornerRadius: 18)
+        .animation(
+            .smooth(duration: 0.42, extraBounce: 0.02),
+            value: isStopping
+        )
+        .glassSurface(
+            clear: true,
+            materializeTransition: true,
+            cornerRadius: 18
+        )
     }
 
     private func vmStatusCoverCard(gameName: String, metrics: CoverFlowMetrics) -> some View {
-        VStack(spacing: metrics.isCompact ? 9 : 14) {
-            Image(systemName: "play.circle.fill")
-                .font(.system(size: metrics.statusIconSize))
-                .foregroundStyle(.green)
-            Text(settings.localized("Now Running"))
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-            Text(displayTitle(forRunningName: gameName))
-                .font((metrics.isCompact ? Font.subheadline : Font.headline).weight(.semibold))
-                .lineLimit(2)
-                .multilineTextAlignment(.center)
-            HStack(spacing: 8) {
-                Button(settings.localized("Resume")) {
-                    appState.returnToGame()
-                }
-                .buttonStyle(.borderedProminent)
-                Button(role: .destructive) {
-                    showStopAlert = true
-                } label: {
-                    Image(systemName: "stop.circle")
-                }
-                .buttonStyle(.bordered)
+        let isStopping = nowRunningRemovalAnimationActive
+
+        return VStack(spacing: metrics.isCompact ? 9 : 14) {
+            VStack(spacing: metrics.isCompact ? 7 : 10) {
+                Image(
+                    systemName: isStopping
+                        ? "stop.circle.fill"
+                        : "play.circle.fill"
+                )
+                    .font(.system(size: metrics.statusIconSize))
+                    .foregroundStyle(isStopping ? .red : .green)
+                    .contentTransition(.symbolEffect(.replace))
+
+                RunningStatusText(
+                    isStopping: isStopping,
+                    runningLabel: settings.localized("Now Running"),
+                    gameTitle: displayTitle(forRunningName: gameName),
+                    stoppingLabel: settings.localized("Stopping..."),
+                    stoppingFont: metrics.isCompact ? .headline : .title3,
+                    centered: true
+                )
             }
-            .controlSize(metrics.isCompact ? .small : .regular)
+            .opacity(displayedNowRunningStatusOpacity)
+            .animation(.easeInOut(duration: 0.3), value: displayedNowRunningStatusOpacity)
+
+            if !isStopping {
+                HStack(spacing: 8) {
+                    Button(settings.localized("Resume")) {
+                        appState.returnToGame()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    Button(role: .destructive) {
+                        showStopAlert = true
+                    } label: {
+                        Image(systemName: "stop.circle")
+                    }
+                    .buttonStyle(.bordered)
+                }
+                .controlSize(metrics.isCompact ? .small : .regular)
+                .transition(.opacity.combined(with: .scale(scale: 0.9)))
+            }
         }
         .frame(width: metrics.statusWidth, height: metrics.statusHeight)
         .padding(metrics.cardPadding)
-			.glassSurface(clear: true, cornerRadius: metrics.cornerRadius)
+        .animation(
+            .smooth(duration: 0.42, extraBounce: 0.02),
+            value: isStopping
+        )
+        .glassSurface(
+            clear: true,
+            materializeTransition: true,
+            cornerRadius: metrics.cornerRadius
+        )
     }
 
 	@ViewBuilder
@@ -1396,52 +1958,220 @@ struct GameListView: View {
 
     @MainActor
     private func makeGameplayLaunchTransition(
-        for game: ISOEntry
+        for game: ISOEntry,
+        respectingLaunchAnimationSetting: Bool = true
     ) -> GameplayLaunchTransition? {
-        guard settings.gameCardZoomAnimationEnabled else {
-            return nil
-        }
-        guard let cardView = gameplayLaunchCardRegistry.view(for: game.id),
-              let window = cardView.window else {
+        guard !respectingLaunchAnimationSetting
+            || settings.gameCardZoomAnimationEnabled else {
             return nil
         }
 
-        let sourceFrame = cardView
-            .convert(cardView.bounds, to: window)
-            .intersection(window.bounds)
-        guard !sourceFrame.isNull,
-              sourceFrame.width > 2,
-              sourceFrame.height > 2
-        else {
+        let cardView = gameplayLaunchCardRegistry.view(for: game.id)
+        guard let window = cardView?.window ?? activeMenuWindow() else {
             return nil
         }
 
-        let format = UIGraphicsImageRendererFormat()
-        format.scale = window.screen.scale
-        format.opaque = false
-        let renderer = UIGraphicsImageRenderer(size: sourceFrame.size, format: format)
-        let snapshot = renderer.image { _ in
-            window.drawHierarchy(
-                in: window.bounds.offsetBy(
-                    dx: -sourceFrame.minX,
-                    dy: -sourceFrame.minY
-                ),
-                afterScreenUpdates: false
-            )
-        }
-
+        let usesCoverFlow = libraryLayout == "grid"
+            && landscapeCoverFlowEnabled
+            && window.bounds.width > window.bounds.height
+        let style: GameplayLaunchCardStyle
+        let coverSize: CGSize
         let cornerRadius: CGFloat
-        if libraryLayout == "grid" {
-            cornerRadius = landscapeCoverFlowEnabled ? 24 : 18
+        if usesCoverFlow {
+            let metrics = CoverFlowMetrics(containerSize: window.bounds.size)
+            style = .coverFlow
+            coverSize = CGSize(
+                width: metrics.coverWidth,
+                height: metrics.coverHeight
+            )
+            cornerRadius = metrics.cornerRadius
+        } else if libraryLayout == "grid" {
+            style = .grid
+            coverSize = CGSize(width: 126, height: 189)
+            cornerRadius = 18
         } else {
+            style = .list
+            coverSize = CGSize(width: 58, height: 87)
             cornerRadius = 14
         }
 
+        let sourceFrame: CGRect
+        if let cardView,
+           cardView.window === window {
+            let candidate = cardView
+                .convert(cardView.bounds, to: window)
+                .intersection(window.bounds)
+            sourceFrame = isValidGameplayLaunchFrame(candidate)
+                ? candidate
+                : fallbackGameplayLaunchFrame(
+                    style: style,
+                    coverSize: coverSize,
+                    in: window.bounds
+                )
+        } else {
+            sourceFrame = fallbackGameplayLaunchFrame(
+                style: style,
+                coverSize: coverSize,
+                in: window.bounds
+            )
+        }
+
+        let coverImage = game.coverURL.flatMap {
+            CoverThumbnailCache.shared.imageForGameplayTransition(
+                for: $0,
+                signature: game.coverSignature,
+                width: coverSize.width,
+                height: coverSize.height,
+                scale: window.screen.scale
+            )
+        }
+        let detailParts = [
+            game.name.pathExtensionLabel,
+            game.sizeLabel,
+            game.isExternal ? settings.localized("External") : nil,
+            game.regionFlag,
+        ].compactMap { $0 }
+
         return GameplayLaunchTransition(
-            snapshot: snapshot,
             sourceFrame: sourceFrame,
-            cornerRadius: cornerRadius
+            cornerRadius: cornerRadius,
+            style: style,
+            gameName: game.name,
+            title: game.displayName,
+            detail: detailParts.joined(separator: "  "),
+            coverImage: coverImage,
+            coverSize: coverSize,
+            isFavorite: game.isFavorite
         )
+    }
+
+    /// Supplies a larger live SwiftUI target for the system context-menu zoom.
+    /// Reusing the launch card keeps its glass, cover, text, and star in one
+    /// composited surface instead of scaling a rasterized snapshot.
+    @ViewBuilder
+    private func gameContextMenuPreview(for game: ISOEntry) -> some View {
+        if let transition = makeGameplayLaunchTransition(
+            for: game,
+            respectingLaunchAnimationSetting: false
+        ) {
+            let sourceSize = contextMenuPreviewSourceSize(
+                for: game,
+                transition: transition
+            )
+            let scale = contextMenuPreviewScale(
+                for: transition.style,
+                sourceSize: sourceSize
+            )
+
+            FluidGameplayLaunchCard(
+                transition: transition,
+                showsUnselectedFavoriteIndicator: true
+            )
+                .frame(width: sourceSize.width, height: sourceSize.height)
+                .scaleEffect(scale)
+                .frame(
+                    width: sourceSize.width * scale,
+                    height: sourceSize.height * scale
+                )
+                .shadow(
+                    color: .black.opacity(0.32),
+                    radius: 22,
+                    y: 12
+                )
+        } else {
+            EmptyView()
+        }
+    }
+
+    private func contextMenuPreviewSourceSize(
+        for game: ISOEntry,
+        transition: GameplayLaunchTransition
+    ) -> CGSize {
+        if let view = gameplayLaunchCardRegistry.view(for: game.id) {
+            let size = view.bounds.size
+            if size.width > 2,
+               size.height > 2,
+               size.width.isFinite,
+               size.height.isFinite {
+                return size
+            }
+        }
+        return transition.sourceFrame.size
+    }
+
+    private func contextMenuPreviewScale(
+        for style: GameplayLaunchCardStyle,
+        sourceSize: CGSize
+    ) -> CGFloat {
+        let desiredScale: CGFloat
+        switch style {
+        case .list:
+            desiredScale = 1.06
+        case .grid:
+            desiredScale = 1.20
+        case .coverFlow:
+            desiredScale = 1.14
+        }
+
+        let viewport = activeMenuWindow()?.bounds.size
+            ?? UIScreen.main.bounds.size
+        let widthLimit = (viewport.width * 0.88) / max(sourceSize.width, 1)
+        let heightLimit = (viewport.height * 0.76) / max(sourceSize.height, 1)
+        return max(1, min(desiredScale, min(widthLimit, heightLimit)))
+    }
+
+    @MainActor
+    private func activeMenuWindow() -> UIWindow? {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .first(where: { $0.isKeyWindow })
+    }
+
+    private func isValidGameplayLaunchFrame(_ frame: CGRect) -> Bool {
+        !frame.isNull
+            && !frame.isInfinite
+            && frame.origin.x.isFinite
+            && frame.origin.y.isFinite
+            && frame.width.isFinite
+            && frame.height.isFinite
+            && frame.width > 2
+            && frame.height > 2
+    }
+
+    private func fallbackGameplayLaunchFrame(
+        style: GameplayLaunchCardStyle,
+        coverSize: CGSize,
+        in windowBounds: CGRect
+    ) -> CGRect {
+        let size: CGSize
+        switch style {
+        case .list:
+            size = CGSize(
+                width: max(120, windowBounds.width - 32),
+                height: 112
+            )
+        case .grid:
+            size = CGSize(
+                width: min(180, max(142, windowBounds.width * 0.42)),
+                height: 268
+            )
+        case .coverFlow:
+            size = CGSize(
+                width: coverSize.width + 24,
+                height: min(
+                    windowBounds.height * 0.82,
+                    coverSize.height + 88
+                )
+            )
+        }
+
+        return CGRect(
+            x: windowBounds.midX - size.width / 2,
+            y: windowBounds.midY - size.height / 2,
+            width: size.width,
+            height: size.height
+        ).intersection(windowBounds)
     }
 
     private var emptyState: some View {
@@ -1472,87 +2202,148 @@ struct GameListView: View {
 				.multilineTextAlignment(.center)
         }
         .padding()
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .frame(maxWidth: .infinity, minHeight: 240)
     }
 
-	private func loadGames(autoDownloadExternalCovers: Bool = false, forceMetadataRefresh: Bool = false) {
-		guard !isLoadingGames else { return }
-		isLoadingGames = true
-		defer { isLoadingGames = false }
+    private func loadGames(
+        autoDownloadExternalCovers: Bool = false,
+        forceMetadataRefresh: Bool = false
+    ) {
+        guard !gameLibraryActivity.isLoading else { return }
+        gameLibraryActivity.isLoading = true
+        defer { gameLibraryActivity.isLoading = false }
 
-		let fm = FileManager.default
-		let allowFullMetadata = appState.runningGameName == nil
-		let existingGames = GameLibrarySnapshot.shared.existingEntries(merging: games)
-		externalLibrary.reload()
-		games = ARMSX2Bridge.availableISOEntries().compactMap { rawEntry -> ISOEntry? in
-			guard let name = rawEntry["name"] as? String,
-			      let path = rawEntry["path"] as? String else {
-				return nil
-			}
-			let external = (rawEntry["external"] as? NSNumber)?.boolValue ?? (rawEntry["external"] as? Bool ?? false)
-			let source = rawEntry["source"] as? String
-			let bootName = external ? path : name
-			let attrs = try? fm.attributesOfItem(atPath: path)
-			let size = attrs?[.size] as? UInt64 ?? 0
-			let modificationDate = attrs?[.modificationDate] as? Date
-			let fav = ARMSX2Bridge.isFavorite(bootName)
-			let fileURL = URL(fileURLWithPath: path)
-			let entryID = external ? path : fileURL.path
-			let metadata: [String: String]
-			if forceMetadataRefresh && allowFullMetadata {
-				metadata = ARMSX2Bridge.gameMetadata(forISO: bootName)
-				GameLibrarySnapshot.shared.storeMetadata(metadata, modificationDate: modificationDate, size: size, for: entryID)
-			} else if !allowFullMetadata {
-				if let existing = existingGames[entryID] {
-					metadata = existing.metadata
-				} else if let cached = GameLibrarySnapshot.shared.cachedMetadata(
-					for: entryID,
-					modificationDate: modificationDate,
-					size: size
-				) {
-					metadata = cached
-				} else {
-					metadata = ["fileTitle": (name as NSString).deletingPathExtension]
-				}
-			} else if let cached = GameLibrarySnapshot.shared.cachedMetadata(for: entryID, modificationDate: modificationDate, size: size) {
-				metadata = cached
-			} else {
-				metadata = ARMSX2Bridge.gameMetadata(forISO: bootName)
-				GameLibrarySnapshot.shared.storeMetadata(metadata, modificationDate: modificationDate, size: size, for: entryID)
-			}
-			let coverURL = coverStore.coverURL(forGameName: name, gamePath: fileURL, metadata: metadata)
-			let existingCover = retainedCover(from: existingGames[entryID])
-			let resolvedCoverURL = coverURL ?? existingCover?.url
-			let coverSignature = CoverThumbnailCache.signature(for: resolvedCoverURL) ?? existingCover?.signature
-			return ISOEntry(
-				name: name,
-				fileURL: fileURL,
-				bootPath: external ? path : nil,
-				coverURL: resolvedCoverURL,
-				coverSignature: coverSignature,
-				metadata: metadata,
-				size: size,
-				isFavorite: fav,
-				isExternal: external,
-				sourceName: source
-			)
-		}.sorted { a, b in
-			if a.isFavorite != b.isFavorite { return a.isFavorite }
-			return a.name.localizedCaseInsensitiveCompare(b.name) == .orderedAscending
-		}
+        let fm = FileManager.default
+        let allowFullMetadata = appState.runningGameName == nil
+        let existingGames = GameLibrarySnapshot.shared.existingEntries(
+            merging: games
+        )
+        externalLibrary.reload()
+        let rawEntries = ARMSX2Bridge.availableISOEntries()
+        let coverLookupIndex = coverStore.makeLibraryCoverLookupIndex(
+            gamePaths: rawEntries.compactMap { rawEntry in
+                guard let path = rawEntry["path"] as? String else { return nil }
+                return URL(fileURLWithPath: path)
+            }
+        )
+        let loadedGames = rawEntries.compactMap { rawEntry -> ISOEntry? in
+            guard let name = rawEntry["name"] as? String,
+                  let path = rawEntry["path"] as? String else {
+                return nil
+            }
+            let external = (rawEntry["external"] as? NSNumber)?.boolValue
+                ?? (rawEntry["external"] as? Bool ?? false)
+            let source = rawEntry["source"] as? String
+            let bootName = external ? path : name
+            let attrs = try? fm.attributesOfItem(atPath: path)
+            let size = attrs?[.size] as? UInt64 ?? 0
+            let modificationDate = attrs?[.modificationDate] as? Date
+            let favorite = ARMSX2Bridge.isFavorite(bootName)
+            let fileURL = URL(fileURLWithPath: path)
+            let entryID = external ? path : fileURL.path
+            let metadata: [String: String]
 
-		if !allowFullMetadata {
-			NSLog("[ARMSX2 iOS GameList] skipped full ISO metadata refresh while VM is active")
-		}
+            if forceMetadataRefresh && allowFullMetadata {
+                metadata = ARMSX2Bridge.gameMetadata(forISO: bootName)
+                GameLibrarySnapshot.shared.storeMetadata(
+                    metadata,
+                    modificationDate: modificationDate,
+                    size: size,
+                    for: entryID
+                )
+            } else if !allowFullMetadata {
+                if let existing = existingGames[entryID] {
+                    metadata = existing.metadata
+                } else if let cached = GameLibrarySnapshot.shared.cachedMetadata(
+                    for: entryID,
+                    modificationDate: modificationDate,
+                    size: size
+                ) {
+                    metadata = cached
+                } else {
+                    metadata = [
+                        "fileTitle": (name as NSString).deletingPathExtension
+                    ]
+                }
+            } else if let cached = GameLibrarySnapshot.shared.cachedMetadata(
+                for: entryID,
+                modificationDate: modificationDate,
+                size: size
+            ) {
+                metadata = cached
+            } else {
+                metadata = ARMSX2Bridge.gameMetadata(forISO: bootName)
+                GameLibrarySnapshot.shared.storeMetadata(
+                    metadata,
+                    modificationDate: modificationDate,
+                    size: size,
+                    for: entryID
+                )
+            }
 
-		GameLibrarySnapshot.shared.purgeMetadata(keeping: Set(games.map { $0.id }))
-		GameLibrarySnapshot.shared.update(games)
-		GameLibrarySnapshot.shared.persistMetadataCache()
+            let coverURL = coverStore.coverURL(
+                forGameName: name,
+                gamePath: fileURL,
+                metadata: metadata,
+                using: coverLookupIndex
+            )
+            let existingCover = retainedCover(from: existingGames[entryID])
+            let resolvedCoverURL = coverURL ?? existingCover?.url
+            let coverSignature = CoverThumbnailCache.signature(
+                for: resolvedCoverURL
+            ) ?? existingCover?.signature
 
-		if autoDownloadExternalCovers {
-			autoDownloadExternalCoversIfNeeded()
-		}
-	}
+            return ISOEntry(
+                name: name,
+                fileURL: fileURL,
+                bootPath: external ? path : nil,
+                coverURL: resolvedCoverURL,
+                coverSignature: coverSignature,
+                metadata: metadata,
+                size: size,
+                isFavorite: favorite,
+                isExternal: external,
+                sourceName: source
+            )
+        }.sorted { first, second in
+            if first.isFavorite != second.isFavorite {
+                return first.isFavorite
+            }
+            return first.name.localizedCaseInsensitiveCompare(second.name)
+                == .orderedAscending
+        }
+
+        if !allowFullMetadata {
+            NSLog("[ARMSX2 iOS GameList] skipped full ISO metadata refresh while VM is active")
+        }
+
+        if loadedGames != games {
+            games = loadedGames
+        }
+        GameLibrarySnapshot.shared.purgeMetadata(
+            keeping: Set(loadedGames.lazy.map(\.id))
+        )
+        GameLibrarySnapshot.shared.update(loadedGames)
+        GameLibrarySnapshot.shared.persistMetadataCache()
+
+        if autoDownloadExternalCovers {
+            autoDownloadExternalCoversIfNeeded()
+        }
+    }
+
+    /// Library-change notifications can arrive in bursts while files and
+    /// covers are imported. Refresh once, after scrolling settles, so a disk
+    /// scan cannot interrupt an active gesture or deceleration.
+    private func scheduleLibraryReload(
+        after delay: Duration,
+        autoDownloadExternalCovers: Bool
+    ) {
+        gameLibraryActivity.scheduleReload(after: delay) {
+            loadGames(
+                autoDownloadExternalCovers: autoDownloadExternalCovers
+            )
+        }
+    }
 
 	private func restoreCachedGamesIfNeeded() {
 		guard games.isEmpty else { return }
@@ -1680,69 +2471,82 @@ struct GameListView: View {
 	private func releaseLibraryResourcesForGameplay() {
 		coverWorkTask?.cancel()
 		coverWorkTask = nil
-        favoriteReorderResetTask?.cancel()
-        favoriteReorderResetTask = nil
         nowRunningRemovalResetTask?.cancel()
         nowRunningRemovalResetTask = nil
-        nowRunningAlertDismissTask?.cancel()
-        nowRunningAlertDismissTask = nil
         favoriteAnimationValues.removeAll(keepingCapacity: false)
-        favoriteReorderAnimationActive = false
         nowRunningRemovalAnimationActive = false
         departingRunningGameName = nil
         nowRunningCardOpacity = 1
+        nowRunningCardScale = 1
+        nowRunningStatusOpacity = 1
+        gameLibraryActivity.isScrolling = false
+        gameLibraryActivity.cancelScheduledReload()
         gameplayLaunchCardRegistry.removeAll()
 			games.removeAll(keepingCapacity: false)
 		externalCoverAutoDownloadAttemptedIDs.removeAll(keepingCapacity: false)
-		GameLibrarySnapshot.shared.releaseEntriesForGameplay()
-			CoverThumbnailCache.shared.releaseForGameplay()
+		GameLibraryRuntimeResources.releaseForGameplay()
 		}
 
     private func scheduleStopRunningGame() {
         showStopAlert = false
-        nowRunningAlertDismissTask?.cancel()
-        nowRunningAlertDismissTask = Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(240))
-            guard !Task.isCancelled else { return }
-            nowRunningAlertDismissTask = nil
-            stopRunningGame()
-        }
-    }
-
-    private func stopRunningGame() {
         guard !nowRunningRemovalAnimationActive,
               let runningGameName = appState.runningGameName else {
             return
         }
 
         nowRunningRemovalResetTask?.cancel()
+        nowRunningCardOpacity = 1
+        nowRunningCardScale = 1
+        nowRunningStatusOpacity = 1
         departingRunningGameName = runningGameName
-        nowRunningRemovalAnimationActive = true
-        appState.runningGameName = nil
-        ARMSX2Bridge.requestVMStop()
+        withAnimation(.smooth(duration: 0.42, extraBounce: 0.02)) {
+            // Enter a visible stopping state immediately after confirmation:
+            // play becomes stop, actions dissolve, and both labels morph into
+            // one prominent status before the whole glass card leaves.
+            nowRunningRemovalAnimationActive = true
+        }
 
         nowRunningRemovalResetTask = Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(16))
+            // Let the status morph complete, fade its foreground away, then
+            // collapse the complete composited glass surface to zero pixels.
+            try? await Task.sleep(for: .milliseconds(420))
             guard !Task.isCancelled else { return }
 
-            withAnimation(.easeOut(duration: 0.30)) {
-                nowRunningCardOpacity = 0
+            withAnimation(.easeInOut(duration: 0.3)) {
+                nowRunningStatusOpacity = 0
             }
             try? await Task.sleep(for: .milliseconds(320))
             guard !Task.isCancelled else { return }
 
-            withAnimation(.easeInOut(duration: 0.30)) {
+            withAnimation(.easeInOut(duration: 0.65)) {
+                nowRunningCardOpacity = 0
+                nowRunningCardScale = 0
+            }
+            try? await Task.sleep(for: .milliseconds(700))
+            guard !Task.isCancelled else { return }
+
+            // Stop the VM as soon as the card's own departure completes. Keep
+            // the now-invisible layout placeholder alive while a drag or
+            // deceleration is active, so removing it cannot move the content
+            // underneath the user's finger.
+            appState.runningGameName = nil
+            ARMSX2Bridge.requestVMStop()
+
+            while gameLibraryActivity.isScrolling {
+                try? await Task.sleep(for: .milliseconds(50))
+                guard !Task.isCancelled else { return }
+            }
+
+            withAnimation(.smooth(duration: 0.52, extraBounce: 0.02)) {
                 departingRunningGameName = nil
             }
-            try? await Task.sleep(for: .milliseconds(320))
+            try? await Task.sleep(for: .milliseconds(540))
             guard !Task.isCancelled else { return }
 
-            var transaction = Transaction()
-            transaction.disablesAnimations = true
-            withTransaction(transaction) {
-                nowRunningCardOpacity = 1
-                nowRunningRemovalAnimationActive = false
-            }
+            // The collapsed values remain private to the departed placeholder.
+            // Clearing only the phase flag avoids a second transaction through
+            // every persistent game-card glass surface.
+            nowRunningRemovalAnimationActive = false
             nowRunningRemovalResetTask = nil
         }
     }
@@ -1753,7 +2557,6 @@ struct GameListView: View {
         let updatedValue = !current
 		ARMSX2Bridge.setFavorite(key, favorite: updatedValue)
 
-        favoriteReorderAnimationActive = true
         withAnimation(.spring(response: 0.46, dampingFraction: 0.82)) {
             favoriteAnimationValues[game.id, default: 0] += 1
             if let index = games.firstIndex(where: { $0.id == game.id }) {
@@ -1769,14 +2572,6 @@ struct GameListView: View {
 
         GameLibrarySnapshot.shared.update(games)
         UISelectionFeedbackGenerator().selectionChanged()
-
-        favoriteReorderResetTask?.cancel()
-        favoriteReorderResetTask = Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(600))
-            guard !Task.isCancelled else { return }
-            favoriteReorderAnimationActive = false
-            favoriteReorderResetTask = nil
-        }
 	}
 
 	private func clearGameCache(_ game: ISOEntry) {
@@ -1806,45 +2601,12 @@ struct GameListView: View {
 	}
 
 	private func isRunning(_ game: ISOEntry) -> Bool {
-		guard let runningGameName = appState.runningGameName else {
-			return false
-		}
-
-		return Self.gameIdentifiersMatch(runningGameName, game.bootName)
-			|| Self.gameIdentifiersMatch(runningGameName, game.name)
-			|| game.fileURL.map { Self.gameIdentifiersMatch(runningGameName, $0.path) } == true
-	}
-
-	private static func gameIdentifiersMatch(_ first: String, _ second: String) -> Bool {
-		let normalizedFirst = (first.removingPercentEncoding ?? first)
-			.replacingOccurrences(of: "\\", with: "/")
-		let normalizedSecond = (second.removingPercentEncoding ?? second)
-			.replacingOccurrences(of: "\\", with: "/")
-		if normalizedFirst.caseInsensitiveCompare(normalizedSecond) == .orderedSame {
-			return true
-		}
-
-		let firstFileName = (normalizedFirst as NSString).lastPathComponent
-		let secondFileName = (normalizedSecond as NSString).lastPathComponent
-		return !firstFileName.isEmpty
-			&& firstFileName.caseInsensitiveCompare(secondFileName) == .orderedSame
-	}
-
-	/// Region flag emoji for a game's metadata, or nil when unknown so the
-	/// caller can omit it instead of rendering a placeholder.
-	private func regionFlagText(for game: ISOEntry) -> String? {
-		let region = game.metadata["region"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-		let flag = RegionFlag.emoji(for: region)
-		return flag.isEmpty ? nil : flag
-	}
-
-    private func formatSize(_ bytes: UInt64) -> String {
-        let gb = Double(bytes) / 1_073_741_824
-        if gb >= 1.0 {
-            return String(format: "%.1f GB", gb)
-        }
-        let mb = Double(bytes) / 1_048_576
-        return String(format: "%.0f MB", mb)
+        let runningIdentifiers = gameLibraryActivity.runningIdentifiers(
+            for: appState.runningGameName
+        )
+        return !runningIdentifiers.isDisjoint(
+            with: game.normalizedIdentifiers
+        )
     }
 
 }
@@ -1854,7 +2616,6 @@ private struct GameInfoPanel: View {
     @State private var settings = SettingsStore.shared
 
     let game: ISOEntry
-    let coverStore: CoverStore
 
     var body: some View {
         NavigationStack {
@@ -1870,7 +2631,7 @@ private struct GameInfoPanel: View {
                         )
 
                         VStack(alignment: .leading, spacing: 6) {
-                            Text(coverStore.displayName(forGameName: game.name))
+                            Text(game.displayName)
                                 .font(.headline)
                             Text(game.name)
                                 .font(.caption)
@@ -1897,7 +2658,7 @@ private struct GameInfoPanel: View {
                         Text(game.name.pathExtensionLabel)
                     }
                     LabeledContent(settings.localized("Size")) {
-                        Text(formatSize(game.size))
+                        Text(game.sizeLabel)
                     }
                 }
 
@@ -1928,15 +2689,6 @@ private struct GameInfoPanel: View {
     private func metadataValue(_ key: String) -> String {
         let value = game.metadata[key]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return value.isEmpty ? settings.localized("Unknown") : value
-    }
-
-    private func formatSize(_ bytes: UInt64) -> String {
-        let gb = Double(bytes) / 1_073_741_824
-        if gb >= 1.0 {
-            return String(format: "%.1f GB", gb)
-        }
-        let mb = Double(bytes) / 1_048_576
-        return String(format: "%.0f MB", mb)
     }
 }
 

--- a/platforms/ios/app/src/main/swift/Views/GameScreenView.swift
+++ b/platforms/ios/app/src/main/swift/Views/GameScreenView.swift
@@ -258,6 +258,8 @@ struct GameScreenView: View {
     // key them on this to force a fresh layout on a flip.
     @State private var screenIsLandscape = true
     @State private var emulationOnlyTransitionTask: Task<Void, Never>?
+    @State private var emulationOnlyActivationInFlight = false
+    @State private var pendingEmulationOnlyPresentation: EmulationOnlyPresentation?
 
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -489,8 +491,15 @@ struct GameScreenView: View {
             Text(settings.localized("Restart the current game? Unsaved progress will be lost."))
         }
         .onAppear {
-            FrameTimeDynamicResolutionController.shared.resumeAfterEmulationOnlyMode()
-            GameEventHaptics.shared.prepareForGameplaySession()
+            let nativeEmulationOnlyMode = ARMSX2Bridge.isEmulationOnlyModeActive()
+            // Returning to the same stripped VM must not recreate services that
+            // Emulation-Only Mode already released.
+            if !appState.isEmulationOnlyMode && nativeEmulationOnlyMode {
+                restoreEmulationOnlyPresentation()
+            } else if !appState.isEmulationOnlyMode {
+                FrameTimeDynamicResolutionController.shared.resumeAfterEmulationOnlyMode()
+                GameEventHaptics.shared.prepareForGameplaySession()
+            }
             enterGameplaySystemChromeMode()
             syncFullscreenStateFromWindow()
             applyInitialFullscreenPreference()
@@ -562,6 +571,13 @@ struct GameScreenView: View {
         .onReceive(NotificationCenter.default.publisher(for: runtimeMenuStateChangedNotification)) { _ in
             refreshRuntimeMenuState()
         }
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: AppState.emulationOnlyResourcesReleasedNotification
+            )
+        ) { _ in
+            finishEmulationOnlyActivation()
+        }
         .onReceive(NotificationCenter.default.publisher(for: .GCControllerDidConnect)) { _ in
             refreshExternalControllerConnectionState()
             enterEmulationOnlyModeIfReady()
@@ -618,7 +634,8 @@ struct GameScreenView: View {
               appState.emulationOnlyStartupReady,
               !appState.isEmulationOnlyMode,
               ARMSX2Bridge.isVMRunning(),
-              emulationOnlyTransitionTask == nil
+              emulationOnlyTransitionTask == nil,
+              !emulationOnlyActivationInFlight
         else {
             return
         }
@@ -647,25 +664,64 @@ struct GameScreenView: View {
         guard settings.emulationOnlyModeEnabled,
               appState.emulationOnlyStartupReady,
               !appState.isEmulationOnlyMode,
-              ARMSX2Bridge.isVMRunning()
+              ARMSX2Bridge.isVMRunning(),
+              !emulationOnlyActivationInFlight
         else {
             return
         }
 
+        pendingEmulationOnlyPresentation = makeEmulationOnlyPresentation()
+        emulationOnlyActivationInFlight = true
+        ARMSX2Bridge.releaseNonEmulationResources(emulationOnlyNativeReleaseFlags)
+    }
+
+    @MainActor
+    private func restoreEmulationOnlyPresentation() {
+        guard ARMSX2Bridge.isVMRunning(),
+              ARMSX2Bridge.isEmulationOnlyModeActive(),
+              !appState.isEmulationOnlyMode
+        else {
+            return
+        }
+
+        pendingEmulationOnlyPresentation = makeEmulationOnlyPresentation()
+        emulationOnlyActivationInFlight = true
+        finishEmulationOnlyActivation()
+    }
+
+    @MainActor
+    private func makeEmulationOnlyPresentation() -> EmulationOnlyPresentation {
         let hasExternalController = !GCController.controllers().isEmpty
         let keepsVirtualControls =
             !hasExternalController ||
             (!settings.emulationOnlyDisableVirtualControls && effectiveVirtualPadVisible)
         let keepsQuickMenu = !settings.emulationOnlyDisableQuickMenu
-        let presentation = EmulationOnlyPresentation(
+        return EmulationOnlyPresentation(
             showsVirtualControls: keepsVirtualControls,
             showsQuickMenu: keepsQuickMenu,
             padLayoutSnapshot: keepsVirtualControls ? effectivePadLayoutSnapshot : nil,
             padSkinDescriptor: keepsVirtualControls ? effectivePadSkinDescriptor : nil
         )
+    }
+
+    @MainActor
+    private func finishEmulationOnlyActivation() {
+        guard emulationOnlyActivationInFlight,
+              let presentation = pendingEmulationOnlyPresentation
+        else {
+            return
+        }
+
+        emulationOnlyActivationInFlight = false
+        pendingEmulationOnlyPresentation = nil
+        guard ARMSX2Bridge.isVMRunning(),
+              appState.emulationOnlyStartupReady
+        else {
+            return
+        }
 
         overlayRoute = .hidden
-        if keepsQuickMenu {
+        if presentation.showsQuickMenu {
             menuButtonHidden = false
         }
         statusBanner.cancelDismiss()
@@ -676,7 +732,7 @@ struct GameScreenView: View {
         runtimePerGameSettings = nil
         runtimePadLayoutIdentity = nil
 
-        if !keepsVirtualControls {
+        if !presentation.showsVirtualControls {
             ARMSX2VirtualPadMaskImageCache.releaseForEmulationOnlyMode()
             HapticManager.releaseForEmulationOnlyMode()
         }
@@ -689,7 +745,6 @@ struct GameScreenView: View {
             FrameTimeDynamicResolutionController.shared.suspendForEmulationOnlyMode()
         }
 
-        ARMSX2Bridge.releaseNonEmulationResources(emulationOnlyNativeReleaseFlags)
         ARMSX2Bridge.setVMPaused(false)
         appState.enterEmulationOnlyMode(presentation: presentation)
     }

--- a/platforms/ios/app/src/main/swift/Views/RootView.swift
+++ b/platforms/ios/app/src/main/swift/Views/RootView.swift
@@ -12,6 +12,14 @@ private struct MenuBackgroundSessionStartEnvironmentKey: EnvironmentKey {
     static let defaultValue = Date()
 }
 
+private struct MenuLargeTitleNamespaceEnvironmentKey: EnvironmentKey {
+    static let defaultValue: Namespace.ID? = nil
+}
+
+private struct MenuLargeTitleMorphActiveEnvironmentKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
 extension EnvironmentValues {
     var menuTabIsActive: Bool {
         get { self[MenuTabIsActiveEnvironmentKey.self] }
@@ -22,6 +30,16 @@ extension EnvironmentValues {
         get { self[MenuBackgroundSessionStartEnvironmentKey.self] }
         set { self[MenuBackgroundSessionStartEnvironmentKey.self] = newValue }
     }
+
+    var menuLargeTitleNamespace: Namespace.ID? {
+        get { self[MenuLargeTitleNamespaceEnvironmentKey.self] }
+        set { self[MenuLargeTitleNamespaceEnvironmentKey.self] = newValue }
+    }
+
+    var menuLargeTitleMorphActive: Bool {
+        get { self[MenuLargeTitleMorphActiveEnvironmentKey.self] }
+        set { self[MenuLargeTitleMorphActiveEnvironmentKey.self] = newValue }
+    }
 }
 
 struct RootView: View {
@@ -29,7 +47,17 @@ struct RootView: View {
     @State private var settings = SettingsStore.shared
     @State private var fileImporter = FileImportHandler.shared
     @State private var showBootSplash = true
-    @StateObject private var backgroundHost = PersistentMenuBackgroundHost()
+    // The background layer observes renderer state directly. Keeping only the
+    // host reference here prevents snapshot/visibility publications from
+    // invalidating the complete menu hierarchy.
+    @State private var backgroundHost = PersistentMenuBackgroundHost()
+
+    private var menuScreenActive: Bool {
+        if case .menu = appState.currentScreen {
+            return true
+        }
+        return false
+    }
 
     var body: some View {
         ZStack {
@@ -46,10 +74,24 @@ struct RootView: View {
                     appState.gameplayLaunchTransition != nil ? 80 : 0
                 )
 
-            switch appState.currentScreen {
-            case .menu:
+            // Keep the menu hierarchy alive for the launch transition so the
+            // library fades behind the live SwiftUI card instead of vanishing
+            // on the same update that starts the VM.
+            if menuScreenActive || appState.gameplayLaunchTransition != nil {
                 MenuTabView(backgroundHost: backgroundHost)
-            case .playing:
+                    .opacity(menuScreenActive ? 1 : 0)
+                    .animation(
+                        .easeOut(duration: 0.34),
+                        value: menuScreenActive
+                    )
+                    .allowsHitTesting(menuScreenActive)
+                    .accessibilityHidden(!menuScreenActive)
+                    .zIndex(
+                        appState.gameplayLaunchTransition == nil ? 1 : 85
+                    )
+            }
+
+            if case .playing = appState.currentScreen {
                 if appState.isEmulationOnlyMode &&
                     !appState.emulationOnlyPresentation.showsQuickMenu {
                     EmulationOnlyGameView()
@@ -93,6 +135,11 @@ struct RootView: View {
             )
         ) { _ in
             backgroundHost.release()
+            // These stores outlive the tab hierarchy. Explicitly discard their
+            // decoded images and presentation-only state instead of depending
+            // exclusively on the selected tab's onDisappear ordering.
+            GameLibraryRuntimeResources.releaseForGameplay()
+            PatchStore.shared.releasePresentationResources()
         }
         .onOpenURL { url in
             if !ARMSX2DeepLinkHandler.handle(url) {
@@ -117,12 +164,30 @@ struct RootView: View {
         } message: {
             Text(settings.localized(appState.bootDisclaimerMessage ?? "BIOS not yet imported."))
         }
+        .alert(
+            "⚠️ \(settings.localized("JIT Access Not Detected"))",
+            isPresented: Binding(
+                get: { appState.pendingJITGameBoot != nil },
+                set: { if !$0 { appState.cancelPendingJITGameBoot() } }
+            )
+        ) {
+            Button(settings.localized("Cancel"), role: .cancel) {
+                appState.cancelPendingJITGameBoot()
+            }
+            Button(settings.localized("Continue")) {
+                appState.continuePendingJITGameBoot()
+            }
+        } message: {
+            Text(settings.localized(
+                "JIT access is not available. Match the StikDebug script to the JIT Script setting in Emulator settings."
+            ))
+        }
     }
 }
 
-/// Animates one rasterized Liquid Glass library card while the real menu tree is
-/// already being dismantled underneath it. The live Metal view mounts immediately,
-/// and the card cross-fades away as soon as the VM reaches its running state.
+/// Rebuilds the selected card as a live SwiftUI Liquid Glass surface while the
+/// menu tree is dismantled underneath it. The cover and text scale with the
+/// glass geometry, then the complete surface fades into the live Metal view.
 private struct GameplayLaunchOverlay: View {
     let transition: GameplayLaunchTransition
     let onRevealGameplay: () -> Void
@@ -149,18 +214,10 @@ private struct GameplayLaunchOverlay: View {
                 Color.black
                     .opacity(zoomed && !reduceMotion ? 0.14 : 0)
 
-                Image(uiImage: transition.snapshot)
-                    .resizable()
-                    .interpolation(.high)
+                FluidGameplayLaunchCard(transition: transition)
                     .frame(
                         width: transition.sourceFrame.width,
                         height: transition.sourceFrame.height
-                    )
-                    .clipShape(
-                        RoundedRectangle(
-                            cornerRadius: transition.cornerRadius,
-                            style: .continuous
-                        )
                     )
                     .scaleEffect(zoomed && !reduceMotion ? destinationScale : 1)
                     .position(zoomed && !reduceMotion ? destinationCenter : sourceCenter)
@@ -200,9 +257,13 @@ private struct GameplayLaunchOverlay: View {
 
     @MainActor
     private func revealWhenEmulationIsRunning() async {
-        // Preserve enough time for the zoom to read visually, but never keep the
-        // overlay over a game intro while waiting for optional startup work.
-        try? await Task.sleep(nanoseconds: 240_000_000)
+        // The spring settles in roughly 0.42 seconds. Keeping the overlay for
+        // 1.42 seconds leaves the fully zoomed Liquid Glass card readable for
+        // approximately one second without delaying the VM boot itself.
+        let minimumDisplayNanoseconds: UInt64 = reduceMotion
+            ? 240_000_000
+            : 1_420_000_000
+        try? await Task.sleep(nanoseconds: minimumDisplayNanoseconds)
         guard !Task.isCancelled else { return }
 
         for _ in 0..<24 where !ARMSX2Bridge.isVMRunning() {
@@ -222,12 +283,130 @@ private struct GameplayLaunchOverlay: View {
     }
 }
 
+struct FluidGameplayLaunchCard: View {
+    let transition: GameplayLaunchTransition
+    var showsUnselectedFavoriteIndicator = false
+
+    var body: some View {
+        Group {
+            switch transition.style {
+            case .list:
+                listContent
+            case .grid, .coverFlow:
+                coverContent
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .overlay(alignment: .topTrailing) {
+            if transition.isFavorite || showsUnselectedFavoriteIndicator {
+                Image(systemName: transition.isFavorite ? "star.fill" : "star")
+                    .font(.callout.weight(.semibold))
+                    .foregroundStyle(
+                        transition.isFavorite ? .yellow : .white.opacity(0.86)
+                    )
+                    .padding(10)
+                    .shadow(color: .black.opacity(0.28), radius: 4, y: 2)
+            }
+        }
+        .glassSurface(clear: true, cornerRadius: transition.cornerRadius)
+        .clipShape(
+            RoundedRectangle(
+                cornerRadius: transition.cornerRadius,
+                style: .continuous
+            )
+        )
+    }
+
+    private var listContent: some View {
+        HStack(spacing: 12) {
+            cover
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(transition.title)
+                    .font(.body.weight(.medium))
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                Text(transition.detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Image(systemName: "chevron.right")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(12)
+    }
+
+    private var coverContent: some View {
+        VStack(spacing: transition.style == .coverFlow ? 8 : 10) {
+            cover
+                .shadow(color: .black.opacity(0.28), radius: 18, y: 10)
+
+            VStack(spacing: 4) {
+                Text(transition.title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+                Text(transition.detail)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .padding(transition.style == .coverFlow ? 8 : 12)
+    }
+
+    private var cover: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color(.secondarySystemGroupedBackground))
+
+            if let image = transition.coverImage {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                VStack(spacing: 6) {
+                    Image(
+                        systemName: transition.gameName.lowercased().hasSuffix(".chd")
+                            ? "archivebox"
+                            : "opticaldisc"
+                    )
+                    .font(.system(size: 24, weight: .medium))
+                    Text(
+                        transition.gameName.lowercased().hasSuffix(".chd")
+                            ? "CHD"
+                            : "PS2"
+                    )
+                    .font(.caption2.bold())
+                }
+                .foregroundStyle(.secondary)
+            }
+        }
+        .frame(
+            width: transition.coverSize.width,
+            height: transition.coverSize.height
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+}
+
 struct MenuTabView: View {
     @State private var settings = SettingsStore.shared
     @State private var selectedTab = 0
+    @State private var activeLibraryTab = 0
     @State private var settingsRootResetRequest = 0
-    @ObservedObject var backgroundHost: PersistentMenuBackgroundHost
+    @State private var menuLargeTitleMorphActive = false
+    @State private var menuLargeTitleMorphResetTask: Task<Void, Never>?
+    let backgroundHost: PersistentMenuBackgroundHost
+    @Namespace private var largeTitleNamespace
     @Environment(\.layoutDirection) private var layoutDirection
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
 
     private var biosBackgroundActive: Bool { settings.hasCustomBackground && settings.backgroundEnabledInBIOS }
     private var settingsBackgroundActive: Bool { settings.hasCustomBackground && settings.backgroundEnabledInSettings }
@@ -251,6 +430,11 @@ struct MenuTabView: View {
         20
     }
 
+    private var usesPageOwnedLibraryLargeTitle: Bool {
+        verticalSizeClass != .compact
+            && UIDevice.current.userInterfaceIdiom == .phone
+    }
+
     private var tabSelection: Binding<Int> {
         Binding(
             get: { selectedTab },
@@ -260,8 +444,21 @@ struct MenuTabView: View {
 
     private func selectTab(_ tab: Int) {
         guard (0...2).contains(tab), tab != selectedTab else { return }
+        menuLargeTitleMorphResetTask?.cancel()
+        menuLargeTitleMorphActive = true
         withAnimation(.easeInOut(duration: 0.24)) {
+            // Retain the last library toolbar state while the separate Settings
+            // navigation surface fades in.
+            if tab <= 1 {
+                activeLibraryTab = tab
+            }
             selectedTab = tab
+        }
+        menuLargeTitleMorphResetTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(280))
+            guard !Task.isCancelled else { return }
+            menuLargeTitleMorphActive = false
+            menuLargeTitleMorphResetTask = nil
         }
     }
 
@@ -298,31 +495,62 @@ struct MenuTabView: View {
                 .tint(.blue)
 #else
                 ZStack {
-                    // Games and BIOS share one persistent native navigation bar.
-                    // Stable toolbar IDs let the system morph its Liquid Glass
-                    // shapes while both tab pages remain mounted underneath.
+                    // Games and BIOS share one persistent navigation owner.
+                    // Their matching toolbar IDs therefore remain the same native
+                    // Liquid Glass controls and morph between tab configurations.
                     NavigationStack {
                         ZStack {
-                            GameListView(embeddedInMenuNavigation: true)
+                            GameListView(
+                                embeddedInMenuNavigation: true,
+                                ownsEmbeddedMenuToolbar: activeLibraryTab == 0
+                            )
                                 .environment(\.menuTabIsActive, selectedTab == 0)
                                 .retainedMenuTabPage(0, selection: selectedTab)
 
                             SafeAreaProtectedMenuTabContent(
                                 appliesLegacyLandscapeInsets: !biosBackgroundActive
                             ) {
-                                BIOSListView(embeddedInMenuNavigation: true)
+                                BIOSListView(
+                                    embeddedInMenuNavigation: true,
+                                    ownsEmbeddedMenuToolbar: activeLibraryTab == 1
+                                )
                             }
                             .environment(\.menuTabIsActive, selectedTab == 1)
                             .retainedMenuTabPage(1, selection: selectedTab)
                         }
                         .navigationTitle(
-                            settings.localized(selectedTab == 1 ? "BIOS" : "Games")
+                            settings.localized(
+                                usesPageOwnedLibraryLargeTitle
+                                    ? ""
+                                    : (activeLibraryTab == 1 ? "BIOS" : "Games")
+                            )
                         )
                         .toolbarBackground(
-                            (selectedTab == 0
+                            (activeLibraryTab == 0
                                 ? settings.hasCustomBackground
                                 : biosBackgroundActive) ? .hidden : .automatic,
                             for: .navigationBar
+                        )
+                        .navigationBarTitleDisplayMode(
+                            usesPageOwnedLibraryLargeTitle ? .inline : .large
+                        )
+                        .toolbar {
+                            if verticalSizeClass == .compact {
+                                ToolbarItem(id: "menu.collapsedTitle", placement: .principal) {
+                                    Text(
+                                        settings.localized(
+                                            activeLibraryTab == 1 ? "BIOS" : "Games"
+                                        )
+                                    )
+                                        .font(.headline)
+                                        .lineLimit(1)
+                                }
+                            }
+                        }
+                    }
+                    .safeAreaInset(edge: .top) {
+                        Color.clear.frame(
+                            height: usesPageOwnedLibraryLargeTitle ? 6 : 0
                         )
                     }
                     .retainedMenuPage(isActive: selectedTab != 2)
@@ -342,6 +570,11 @@ struct MenuTabView: View {
                     )
                     .frame(width: 0, height: 0)
                 }
+                .environment(\.menuLargeTitleNamespace, largeTitleNamespace)
+                .environment(
+                    \.menuLargeTitleMorphActive,
+                    menuLargeTitleMorphActive
+                )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .tint(.blue)
                 .contentMargins(
@@ -350,25 +583,50 @@ struct MenuTabView: View {
                     for: .scrollContent
                 )
                 .safeAreaInset(edge: .bottom, spacing: tabBarContentSpacing) {
-                    NativeMenuTabBar(
-                        selection: tabSelection,
-                        titles: [
-                            settings.localized("Games"),
-                            settings.localized("BIOS"),
-                            settings.localized("Settings"),
-                        ],
-                        onReselect: { tab in
-                            guard tab == 2 else { return }
-                            settingsRootResetRequest += 1
+                    Group {
+                        if #available(iOS 26.0, *) {
+                            NativeMenuTabBar(
+                                selection: tabSelection,
+                                isCompactHeight: verticalSizeClass == .compact,
+                                titles: [
+                                    settings.localized("Games"),
+                                    settings.localized("BIOS"),
+                                    settings.localized("Settings"),
+                                ],
+                                onReselect: { tab in
+                                    guard tab == 2 else { return }
+                                    settingsRootResetRequest += 1
+                                }
+                            )
+                            // Align the native iOS 26 tab bar with compact-height content.
+                            .offset(
+                                y: verticalSizeClass == .compact ? 24.5 : 0
+                            )
+                        } else {
+                            LegacyGlassMenuTabBar(
+                                selection: tabSelection,
+                                titles: [
+                                    settings.localized("Games"),
+                                    settings.localized("BIOS"),
+                                    settings.localized("Settings"),
+                                ],
+                                onReselect: { tab in
+                                    guard tab == 2 else { return }
+                                    settingsRootResetRequest += 1
+                                }
+                            )
+                            // Raise the legacy compact tab bar above the home indicator.
+                            .offset(
+                                y: verticalSizeClass == .compact ? -6 : 0
+                            )
                         }
-                    )
+                    }
                     .zIndex(1_000)
                 }
 #endif
             }
         }
         .environment(\.menuBackgroundHost, backgroundHost)
-        .environment(\.menuBackgroundSessionStart, backgroundHost.sessionStart)
         .onAppear {
             backgroundHost.reactivateForMenu(isAvailable: settings.hasCustomBackground)
             backgroundHost.setPresentationVisible(selectedTabShowsBackground)
@@ -382,8 +640,125 @@ struct MenuTabView: View {
         .onChange(of: selectedTabShowsBackground) { _, showsBackground in
             backgroundHost.setPresentationVisible(showsBackground)
         }
+        .onDisappear {
+            menuLargeTitleMorphResetTask?.cancel()
+            menuLargeTitleMorphResetTask = nil
+            menuLargeTitleMorphActive = false
+        }
     }
 }
+
+#if !targetEnvironment(macCatalyst)
+/// iOS 17/18 does not provide the floating Liquid Glass tab bar used by iOS 26.
+/// Keep one compact, orientation-independent glass capsule so landscape uses
+/// the same centered icon-over-label layout and dimensions as portrait.
+private struct LegacyGlassMenuTabBar: View {
+    @Binding var selection: Int
+    let titles: [String]
+    let onReselect: (Int) -> Void
+    @Namespace private var selectionNamespace
+
+    private let systemImages = [
+        "gamecontroller",
+        "cpu",
+        "gearshape",
+    ]
+
+    private let selectionSpring = Animation.spring(
+        response: 0.5,
+        dampingFraction: 0.7,
+        blendDuration: 0.18
+    )
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(systemImages.indices, id: \.self) { index in
+                Button {
+                    if selection == index {
+                        onReselect(index)
+                    } else {
+                        selection = index
+                        UISelectionFeedbackGenerator().selectionChanged()
+                    }
+                } label: {
+                    VStack(spacing: 1) {
+                        Image(systemName: systemImages[index])
+                            .font(.system(size: 20, weight: .medium))
+                            .symbolRenderingMode(.monochrome)
+                            .scaleEffect(selection == index ? 1.06 : 1)
+
+                        Text(titles.indices.contains(index) ? titles[index] : "")
+                            .font(.system(size: 10, weight: .semibold))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.8)
+                    }
+                    .foregroundStyle(
+                        selection == index
+                            ? Color.blue
+                            : Color.secondary
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .contentShape(Capsule())
+                    .background {
+                        if selection == index {
+                            Capsule()
+                                .fill(.ultraThinMaterial)
+                                .overlay {
+                                    Capsule()
+                                        .fill(Color.blue.opacity(0.075))
+                                }
+                                .overlay {
+                                    Capsule()
+                                        .stroke(
+                                            Color.blue.opacity(0.2),
+                                            lineWidth: 0.65
+                                        )
+                                }
+                                .matchedGeometryEffect(
+                                    id: "legacy.tab.selection",
+                                    in: selectionNamespace
+                                )
+                        }
+                    }
+                }
+                .buttonStyle(LegacyGlassTabButtonStyle())
+                .accessibilityLabel(
+                    titles.indices.contains(index) ? titles[index] : ""
+                )
+                .accessibilityAddTraits(
+                    selection == index ? .isSelected : []
+                )
+            }
+        }
+        .padding(4)
+        .frame(width: 276)
+        .frame(height: 50)
+        .background(.ultraThinMaterial, in: Capsule())
+        .overlay {
+            Capsule()
+                .stroke(Color.primary.opacity(0.13), lineWidth: 0.65)
+        }
+        .shadow(color: .black.opacity(0.12), radius: 12, y: 5)
+        .animation(selectionSpring, value: selection)
+    }
+}
+
+private struct LegacyGlassTabButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.94 : 1)
+            .opacity(configuration.isPressed ? 0.78 : 1)
+            .animation(
+                .spring(
+                    response: 0.25,
+                    dampingFraction: 0.62,
+                    blendDuration: 0.08
+                ),
+                value: configuration.isPressed
+            )
+    }
+}
+#endif
 
 private extension View {
     /// Changes only presentation state. The page remains attached to the same
@@ -412,6 +787,7 @@ private extension View {
 /// remains a foreground sibling rather than being composited below tab content.
 private struct NativeMenuTabBar: UIViewRepresentable {
     @Binding var selection: Int
+    let isCompactHeight: Bool
     let titles: [String]
     let onReselect: (Int) -> Void
 
@@ -425,19 +801,25 @@ private struct NativeMenuTabBar: UIViewRepresentable {
         Coordinator(selection: $selection, onReselect: onReselect)
     }
 
-    func makeUIView(context: Context) -> UITabBar {
-        let tabBar = UITabBar()
+    func makeUIView(context: Context) -> LegacyCompatibleMenuTabBar {
+        let tabBar = LegacyCompatibleMenuTabBar()
         tabBar.delegate = context.coordinator
+        configureAppearance(of: tabBar)
         tabBar.items = makeItems()
         if let items = tabBar.items, items.indices.contains(selection) {
             tabBar.selectedItem = items[selection]
         }
+        tabBar.setSelectedIndex(selection, animated: false)
         return tabBar
     }
 
-    func updateUIView(_ tabBar: UITabBar, context: Context) {
+    func updateUIView(
+        _ tabBar: LegacyCompatibleMenuTabBar,
+        context: Context
+    ) {
         context.coordinator.selection = $selection
         context.coordinator.onReselect = onReselect
+        configureAppearance(of: tabBar)
 
         if tabBar.items?.count != systemImages.count {
             tabBar.items = makeItems()
@@ -446,17 +828,18 @@ private struct NativeMenuTabBar: UIViewRepresentable {
         if let items = tabBar.items {
             for index in items.indices where titles.indices.contains(index) {
                 items[index].title = titles[index]
-                items[index].image = UIImage(systemName: systemImages[index])
+                items[index].image = itemImage(at: index)
             }
             if items.indices.contains(selection) {
                 tabBar.selectedItem = items[selection]
             }
         }
+        tabBar.setSelectedIndex(selection, animated: true)
     }
 
     func sizeThatFits(
         _ proposal: ProposedViewSize,
-        uiView: UITabBar,
+        uiView: LegacyCompatibleMenuTabBar,
         context: Context
     ) -> CGSize? {
         let width = proposal.width ?? uiView.bounds.width
@@ -470,9 +853,332 @@ private struct NativeMenuTabBar: UIViewRepresentable {
         systemImages.indices.map { index in
             UITabBarItem(
                 title: titles.indices.contains(index) ? titles[index] : nil,
-                image: UIImage(systemName: systemImages[index]),
+                image: itemImage(at: index),
                 tag: index
             )
+        }
+    }
+
+    private func itemImage(at index: Int) -> UIImage? {
+        let configuration = UIImage.SymbolConfiguration(
+            pointSize: isCompactHeight ? 25 : 23,
+            weight: .regular
+        )
+        return UIImage(
+            systemName: systemImages[index],
+            withConfiguration: configuration
+        )
+    }
+
+    private func configureAppearance(of tabBar: LegacyCompatibleMenuTabBar) {
+        tabBar.tintColor = .systemBlue
+        tabBar.isTranslucent = true
+        tabBar.isOpaque = false
+        tabBar.backgroundColor = .clear
+        tabBar.backgroundImage = UIImage()
+        tabBar.shadowImage = UIImage()
+        tabBar.isCompactHeightLayout = isCompactHeight
+
+        let appearance = tabBar.standardAppearance.copy()
+        appearance.configureWithTransparentBackground()
+        appearance.backgroundColor = .clear
+        appearance.backgroundEffect = nil
+        appearance.shadowColor = .clear
+
+        if isCompactHeight {
+            let normalFont = UIFont.systemFont(ofSize: 13, weight: .regular)
+            let selectedFont = UIFont.systemFont(ofSize: 13, weight: .semibold)
+            appearance.inlineLayoutAppearance.normal.titleTextAttributes[
+                .font
+            ] = normalFont
+            appearance.inlineLayoutAppearance.selected.titleTextAttributes[
+                .font
+            ] = selectedFont
+            appearance.compactInlineLayoutAppearance.normal.titleTextAttributes[
+                .font
+            ] = normalFont
+            appearance.compactInlineLayoutAppearance.selected.titleTextAttributes[
+                .font
+            ] = selectedFont
+        }
+
+        if #available(iOS 26.0, *) {
+            // Tint UIKit's own Liquid Glass selection pill instead of replacing
+            // it. Its blur, refraction, morph, and press effects remain native.
+            appearance.selectionIndicatorImage = nil
+            appearance.selectionIndicatorTintColor =
+                UIColor.systemBlue.withAlphaComponent(0.18)
+            tabBar.usesLegacySelectionPill = false
+        } else {
+            // iOS 17/18 has no native floating tab capsule. Suppress UIKit's
+            // rectangular bar/indicator and render a material outer pill with
+            // a live, animated monochrome-blue selection pill below.
+            appearance.selectionIndicatorImage = UIImage()
+            appearance.selectionIndicatorTintColor = .clear
+            tabBar.usesLegacySelectionPill = true
+
+            let layouts = [
+                appearance.stackedLayoutAppearance,
+                appearance.inlineLayoutAppearance,
+                appearance.compactInlineLayoutAppearance,
+            ]
+            for layout in layouts {
+                layout.normal.iconColor = .secondaryLabel
+                layout.normal.titleTextAttributes[.foregroundColor] =
+                    UIColor.secondaryLabel
+                layout.selected.iconColor = .systemBlue
+                layout.selected.titleTextAttributes[.foregroundColor] =
+                    UIColor.systemBlue
+            }
+        }
+        tabBar.standardAppearance = appearance
+        tabBar.scrollEdgeAppearance = appearance
+    }
+
+    final class LegacyCompatibleMenuTabBar: UITabBar {
+        var isCompactHeightLayout = false {
+            didSet {
+                guard oldValue != isCompactHeightLayout else { return }
+                setNeedsLayout()
+            }
+        }
+
+        var usesLegacySelectionPill = false {
+            didSet {
+                legacyBarPill.isHidden = !usesLegacySelectionPill
+                legacySelectionPill.isHidden = !usesLegacySelectionPill
+                setNeedsLayout()
+            }
+        }
+
+        private let legacyBarPill = LegacyBarPillView()
+        private let legacySelectionPill = LegacySelectionPillView()
+        private var selectedIndex = 0
+
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+            legacyBarPill.isHidden = true
+            legacyBarPill.isUserInteractionEnabled = false
+            legacySelectionPill.isHidden = true
+            legacySelectionPill.isUserInteractionEnabled = false
+            addSubview(legacyBarPill)
+            addSubview(legacySelectionPill)
+        }
+
+        required init?(coder: NSCoder) {
+            super.init(coder: coder)
+            legacyBarPill.isHidden = true
+            legacyBarPill.isUserInteractionEnabled = false
+            legacySelectionPill.isHidden = true
+            legacySelectionPill.isUserInteractionEnabled = false
+            addSubview(legacyBarPill)
+            addSubview(legacySelectionPill)
+        }
+
+        func setSelectedIndex(_ index: Int, animated: Bool) {
+            let changed = selectedIndex != index
+            selectedIndex = index
+            updateLegacySelectionPill(
+                animated: animated && changed && window != nil
+            )
+        }
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            updateLegacyBarLayout()
+            updateLegacySelectionPill(animated: false)
+        }
+
+        private var legacyBarFrame: CGRect {
+            let maximumWidth: CGFloat = isCompactHeightLayout ? 420 : 360
+            let proportionalWidth = bounds.width * 0.84
+            let width = min(
+                max(0, bounds.width - 24),
+                proportionalWidth,
+                maximumWidth
+            )
+            return CGRect(
+                x: (bounds.width - width) / 2,
+                y: 2,
+                width: width,
+                height: max(0, bounds.height - 4)
+            )
+        }
+
+        private func legacyItemControls() -> [UIControl] {
+            subviews
+                .compactMap { $0 as? UIControl }
+                .sorted { $0.frame.minX < $1.frame.minX }
+        }
+
+        private func updateLegacyBarLayout() {
+            guard usesLegacySelectionPill else {
+                setSystemBarBackgroundHidden(false)
+                return
+            }
+
+            setSystemBarBackgroundHidden(true)
+            let barFrame = legacyBarFrame
+            legacyBarPill.frame = barFrame
+            legacyBarPill.updateCornerRadius(barFrame.height / 2)
+
+            let itemControls = legacyItemControls()
+            guard !itemControls.isEmpty else { return }
+            let contentFrame = barFrame.insetBy(dx: 8, dy: 0)
+            let itemWidth = contentFrame.width / CGFloat(itemControls.count)
+            for (index, control) in itemControls.enumerated() {
+                control.frame = CGRect(
+                    x: contentFrame.minX + (CGFloat(index) * itemWidth),
+                    y: contentFrame.minY,
+                    width: itemWidth,
+                    height: contentFrame.height
+                )
+            }
+
+            insertSubview(legacyBarPill, at: 0)
+            if let firstItem = itemControls.first {
+                insertSubview(legacySelectionPill, belowSubview: firstItem)
+            }
+        }
+
+        private func setSystemBarBackgroundHidden(_ hidden: Bool) {
+            for view in subviews {
+                let className = NSStringFromClass(type(of: view))
+                if className.contains("BarBackground") {
+                    view.isHidden = hidden
+                }
+            }
+        }
+
+        private func updateLegacySelectionPill(animated: Bool) {
+            guard usesLegacySelectionPill else { return }
+
+            let itemControls = legacyItemControls()
+            guard itemControls.indices.contains(selectedIndex) else {
+                return
+            }
+
+            if let firstItem = itemControls.first {
+                insertSubview(legacySelectionPill, belowSubview: firstItem)
+            }
+
+            let itemFrame = itemControls[selectedIndex].frame
+            // Slightly overlap each slot so the selected pill feels broader
+            // than the icon/title pair while remaining inside the outer pill.
+            let proposedFrame = itemFrame.insetBy(dx: -5, dy: 4)
+            let targetFrame = proposedFrame.intersection(
+                legacyBarFrame.insetBy(dx: 4, dy: 4)
+            )
+            legacySelectionPill.updateCornerRadius(
+                max(0, targetFrame.height / 2)
+            )
+
+            let updates = {
+                self.legacySelectionPill.frame = targetFrame
+                self.legacySelectionPill.alpha = 1
+            }
+            if animated {
+                UIView.animate(
+                    withDuration: 0.36,
+                    delay: 0,
+                    usingSpringWithDamping: 0.82,
+                    initialSpringVelocity: 0.18,
+                    options: [.beginFromCurrentState, .allowUserInteraction],
+                    animations: updates
+                )
+            } else {
+                updates()
+            }
+        }
+    }
+
+    final class LegacyBarPillView: UIView {
+        private let materialView = UIVisualEffectView(
+            effect: UIBlurEffect(style: .systemUltraThinMaterial)
+        )
+
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+            isOpaque = false
+
+            layer.shadowColor = UIColor.black.cgColor
+            layer.shadowOpacity = 0.2
+            layer.shadowRadius = 14
+            layer.shadowOffset = CGSize(width: 0, height: 6)
+
+            materialView.isUserInteractionEnabled = false
+            materialView.clipsToBounds = true
+            addSubview(materialView)
+        }
+
+        required init?(coder: NSCoder) {
+            nil
+        }
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            materialView.frame = bounds
+            layer.shadowPath = UIBezierPath(
+                roundedRect: bounds,
+                cornerRadius: layer.cornerRadius
+            ).cgPath
+        }
+
+        func updateCornerRadius(_ radius: CGFloat) {
+            layer.cornerRadius = radius
+            materialView.layer.cornerRadius = radius
+            materialView.layer.borderWidth = 0.65
+            materialView.layer.borderColor =
+                UIColor.separator.withAlphaComponent(0.22).cgColor
+            setNeedsLayout()
+        }
+    }
+
+    final class LegacySelectionPillView: UIView {
+        private let materialView = UIVisualEffectView(
+            effect: UIBlurEffect(style: .systemUltraThinMaterial)
+        )
+        private let blueTintView = UIView()
+
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+            isOpaque = false
+
+            layer.shadowColor = UIColor.systemBlue.cgColor
+            layer.shadowOpacity = 0.1
+            layer.shadowRadius = 8
+            layer.shadowOffset = CGSize(width: 0, height: 2)
+
+            materialView.isUserInteractionEnabled = false
+            materialView.clipsToBounds = true
+            addSubview(materialView)
+
+            blueTintView.backgroundColor =
+                UIColor.systemBlue.withAlphaComponent(0.11)
+            materialView.contentView.addSubview(blueTintView)
+        }
+
+        required init?(coder: NSCoder) {
+            nil
+        }
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            materialView.frame = bounds
+            blueTintView.frame = materialView.bounds
+            layer.shadowPath = UIBezierPath(
+                roundedRect: bounds,
+                cornerRadius: layer.cornerRadius
+            ).cgPath
+        }
+
+        func updateCornerRadius(_ radius: CGFloat) {
+            layer.cornerRadius = radius
+            materialView.layer.cornerRadius = radius
+            materialView.layer.borderWidth = 0.75
+            materialView.layer.borderColor =
+                UIColor.systemBlue.withAlphaComponent(0.2).cgColor
+            setNeedsLayout()
         }
     }
 
@@ -654,7 +1360,11 @@ private struct SafeAreaProtectedMenuTabContent<Content: View>: View {
         // key-window insets. On iOS 26+ SwiftUI gets it right, and padding again would
         // double-inset the column. Tabs that draw their own edge-to-edge background skip
         // this wrapper entirely (see MenuTabView).
-        GeometryReader { geometry in
+        if !appliesLegacyLandscapeInsets {
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            GeometryReader { geometry in
             let isLandscapePhone = geometry.size.width > geometry.size.height
                 && UIDevice.current.userInterfaceIdiom == .phone
             let systemProvidesInset = geometry.safeAreaInsets.leading > 0
@@ -678,9 +1388,10 @@ private struct SafeAreaProtectedMenuTabContent<Content: View>: View {
                 .onChange(of: geometry.size) { _, _ in
                     safeAreaInsets = KeyWindowSafeArea.horizontalInsets()
                 }
-        }
-        .onAppear {
-            safeAreaInsets = KeyWindowSafeArea.horizontalInsets()
+            }
+            .onAppear {
+                safeAreaInsets = KeyWindowSafeArea.horizontalInsets()
+            }
         }
     }
 }

--- a/platforms/ios/app/src/main/swift/Views/Settings/AppearanceSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/AppearanceSettingsView.swift
@@ -123,7 +123,7 @@ struct AppearanceSettingsView: View {
                     Label(settings.localized("Clear Liquid Glass UI"), systemImage: "rectangle.on.rectangle")
                 }
                 Toggle(isOn: $settings.gameCardZoomAnimationEnabled) {
-                    Label(settings.localized("Game card zoom animation"), systemImage: "rectangle.inset.filled.and.person.filled")
+                    Label(settings.localized("Game-Card Zoom Animation"), systemImage: "rectangle.inset.filled.and.person.filled")
                 }
             } header: {
                 Text(settings.localized("Interface"))

--- a/platforms/ios/app/src/main/swift/Views/Settings/SettingsRootView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/SettingsRootView.swift
@@ -6,6 +6,10 @@ import SwiftUI
 import UIKit
 #endif
 
+private enum SettingsStaticInfo {
+    static let buildVersion = ARMSX2Bridge.buildVersion()
+}
+
 private enum SettingsPane: String, CaseIterable, Identifiable {
     case language
     case appearance
@@ -114,12 +118,14 @@ private enum SettingsPane: String, CaseIterable, Identifiable {
 struct SettingsRootView: View {
     let resetToRootRequest: Int
     @State private var settings = SettingsStore.shared
-    @State private var jitAvailable = ARMSX2Bridge.isJITAvailable()
-    @State private var noJITFallbackActive = ARMSX2Bridge.isNoJITFallbackActive()
+    @State private var jitAvailable = false
+    @State private var noJITFallbackActive = false
+    @State private var hasLoadedJITStatus = false
     @State private var stikDebugOpenFailed = false
     @State private var stikDebugOpenInProgress = false
     @State private var navigationPath: [SettingsPane] = []
     @Environment(\.menuTabIsActive) private var menuTabIsActive
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
 #if targetEnvironment(macCatalyst)
     @State private var selectedPane: SettingsPane? = .emulator
 #endif
@@ -134,6 +140,12 @@ struct SettingsRootView: View {
 
     private var backgroundActive: Bool {
         backgroundConfigured
+    }
+
+    private var showsPageOwnedLargeTitle: Bool {
+        navigationPath.isEmpty
+            && verticalSizeClass != .compact
+            && UIDevice.current.userInterfaceIdiom == .phone
     }
 
     var body: some View {
@@ -159,7 +171,14 @@ struct SettingsRootView: View {
             }
 
             List {
-            Section(settings.localized("Interface")) {
+            if showsPageOwnedLargeTitle {
+                EmbeddedMenuLargeTitle(title: settings.localized("Settings"))
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.clear)
+            }
+
+            Section {
                 NavigationLink(value: SettingsPane.language) {
                     Label(settings.localized("Language"), systemImage: "globe")
                 }
@@ -168,6 +187,8 @@ struct SettingsRootView: View {
                     Label(settings.localized("Appearance"), systemImage: "paintpalette")
                 }
                 .gameCardTintMenuBackgroundListRow(backgroundActive)
+            } header: {
+                Text(settings.localized("Interface"))
             }
 
             Section(settings.localized("Emulation")) {
@@ -271,7 +292,7 @@ struct SettingsRootView: View {
                 HStack {
                     Text(settings.localized("Version"))
                     Spacer()
-                    Text(ARMSX2Bridge.buildVersion())
+                    Text(SettingsStaticInfo.buildVersion)
                         .foregroundStyle(.secondary)
                         .font(.caption)
                 }
@@ -283,6 +304,7 @@ struct SettingsRootView: View {
                 .gameCardTintMenuBackgroundListRow(backgroundActive)
             }
         }
+        .contentMargins(.top, 0, for: .scrollContent)
         .scrollContentBackground(backgroundActive ? .hidden : .automatic)
         }
         .stableMenuContentGlassContainer()
@@ -291,16 +313,32 @@ struct SettingsRootView: View {
         // underneath it, making both interfaces appear at once.
         .opacity(navigationPath.isEmpty ? 1 : 0)
         .clearNavigationContainerBackground()
-        .navigationTitle(settings.localized("Settings"))
-        .toolbarBackground(backgroundActive ? .hidden : .automatic, for: .navigationBar)
+        .navigationTitle(
+            showsPageOwnedLargeTitle ? "" : settings.localized("Settings")
+        )
+        .toolbarBackground(
+            backgroundActive ? .hidden : .automatic,
+            for: .navigationBar
+        )
         .navigationBarTitleDisplayMode(.inline)
         .safeAreaInset(edge: .top) {
             Color.clear.frame(height: 6)
         }
-        .onAppear(perform: refreshJITStatus)
+        .onAppear {
+            if menuTabIsActive {
+                refreshJITStatus()
+            }
+        }
+        .onChange(of: menuTabIsActive) { _, isActive in
+            if isActive && !hasLoadedJITStatus {
+                refreshJITStatus()
+            }
+        }
 #if canImport(UIKit)
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
-            refreshJITStatus()
+            if menuTabIsActive {
+                refreshJITStatus()
+            }
         }
 #endif
         .navigationDestination(for: SettingsPane.self) { pane in
@@ -391,6 +429,7 @@ struct SettingsRootView: View {
     private func refreshJITStatus() {
         jitAvailable = ARMSX2Bridge.isJITAvailable()
         noJITFallbackActive = ARMSX2Bridge.isNoJITFallbackActive()
+        hasLoadedJITStatus = true
     }
 
     @ViewBuilder
@@ -476,7 +515,7 @@ private struct SettingsAboutView: View {
                 HStack {
                     Text(settings.localized("Version"))
                     Spacer()
-                    Text(ARMSX2Bridge.buildVersion())
+                    Text(SettingsStaticInfo.buildVersion)
                         .foregroundStyle(.secondary)
                         .font(.caption)
                 }
@@ -489,6 +528,10 @@ private struct SettingsAboutView: View {
 private struct NetworkSettingsView: View {
     @State private var settings = SettingsStore.shared
     @State private var hosts: [DNSHost] = []
+    @State private var lastPersistedHosts: [DNSHost] = []
+    @State private var networkAdapters: [String] = []
+    @State private var hasLoadedHosts = false
+    @State private var hostSaveTask: Task<Void, Never>?
 
     var body: some View {
         Form {
@@ -524,7 +567,7 @@ private struct NetworkSettingsView: View {
                     }
 
                     Picker(settings.localized("Adapter"), selection: $settings.dev9EthDevice) {
-                        ForEach(ARMSX2Bridge.dev9NetworkAdapters(), id: \.self) { adapter in
+                        ForEach(networkAdapters, id: \.self) { adapter in
                             Text(adapter).tag(adapter)
                         }
                     }
@@ -583,8 +626,24 @@ private struct NetworkSettingsView: View {
             }
         }
         .navigationTitle(settings.localized("Network"))
-        .onAppear { loadHosts() }
-        .onChange(of: hosts) { _, _ in saveHosts() }
+        .onAppear {
+            loadNetworkAdaptersIfNeeded()
+            loadHosts()
+        }
+        .onChange(of: hosts) { _, newHosts in
+            guard hasLoadedHosts, newHosts != lastPersistedHosts else {
+                return
+            }
+            scheduleHostSave()
+        }
+        .onDisappear {
+            flushPendingHostSave()
+        }
+#if canImport(UIKit)
+        .onReceive(NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)) { _ in
+            flushPendingHostSave()
+        }
+#endif
     }
 
     @ViewBuilder
@@ -627,6 +686,37 @@ private struct NetworkSettingsView: View {
             i += 1
         }
         hosts = loaded
+        lastPersistedHosts = loaded
+        hasLoadedHosts = true
+    }
+
+    private func loadNetworkAdaptersIfNeeded() {
+        guard networkAdapters.isEmpty else { return }
+        var loaded = ARMSX2Bridge.dev9NetworkAdapters()
+        if !settings.dev9EthDevice.isEmpty,
+           !loaded.contains(settings.dev9EthDevice) {
+            loaded.insert(settings.dev9EthDevice, at: 0)
+        }
+        networkAdapters = loaded
+    }
+
+    /// Text fields can publish on every keystroke. Coalescing those writes
+    /// avoids repeatedly rewriting every DEV9 host section while typing.
+    private func scheduleHostSave() {
+        hostSaveTask?.cancel()
+        hostSaveTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(400))
+            guard !Task.isCancelled else { return }
+            saveHosts()
+            hostSaveTask = nil
+        }
+    }
+
+    private func flushPendingHostSave() {
+        hostSaveTask?.cancel()
+        hostSaveTask = nil
+        guard hasLoadedHosts, hosts != lastPersistedHosts else { return }
+        saveHosts()
     }
 
     private func saveHosts() {
@@ -644,6 +734,7 @@ private struct NetworkSettingsView: View {
             ARMSX2Bridge.setINIString(sec, key: "Address", value: host.address)
             ARMSX2Bridge.setINIBool(sec, key: "Enabled", value: host.enabled)
         }
+        lastPersistedHosts = hosts
     }
 }
 


### PR DESCRIPTION
# iOS: Optimize the Menu Runtime and Add Fluid Liquid Glass Game-Card Transitions

## Summary

This pull request improves the iOS menu and gameplay handoff while preserving the existing emulator behavior.

The main changes are:

- Keep one shared menu background alive across Games, BIOS, and Settings instead of recreating it during normal tab changes.
- Preserve video-background playback position and audio continuity.
- Hold a temporary background-only frame while iOS suspends the live renderer, then release that frame after the renderer resumes.
- Reduce Game Library work during scrolling, refreshes, cover lookup, and thumbnail decoding.
- Add live SwiftUI Fluid Zoom transitions for game launches and game-card context menus.
- Make the enlarged context-menu card use interactive Clear Liquid Glass instead of an opaque preview.
- Improve the Now Running card, running-cover glow, large-title behavior, BIOS presentation, and retained native tab interface.
- Gate game boot when JIT access is unavailable and present a useful warning instead of entering an unusable boot.
- Finish Emulation-Only Mode only after its native resource teardown completes, including BIOS-only boots.

The changes are limited to the files included in this archive.

## Comparison Against Master

This report and archive were regenerated after fetching the latest remote master branch.

- Base: `origin/master`
- Base commit: `7b89374919d0`
- Local `HEAD`: `7b89374919d0`
- Working-tree difference: 19 modified files
- Diff size: 3,218 insertions and 605 deletions
- Added or deleted tracked files: none

Because local `HEAD` and the fetched remote master are the same commit, every file in the ZIP represents an uncommitted modification directly against the current master base. Older ZIP files, IPA products, generated Xcode files, and unrelated untracked documents are not included.

## Complete User-Facing Changelog

### Quality-of-Life Guidance

The app now gives users a clear result at the points where setup or lifecycle state previously appeared to do nothing:

- Starting a game or using **Boot BIOS** without a bootable BIOS presents **“BIOS not yet imported.”**
- Starting or restarting a game without JIT presents **“JIT Access Not Detected”** and explains how to match the StikDebug script to the JIT Script setting.
- A normal tap on a game card remains the direct Play action; it is separated from the favorite control and long-press context menu.
- Returning to the menu while a VM is active presents a stable **Now Running** card with Resume and Stop actions.
- Confirming Stop immediately changes the running presentation into an animated **Stopping…** state so shutdown no longer looks like an ignored or abrupt action.

### Fixed

- Fixed the black background shown after putting the app in the app switcher and returning.
- Fixed custom video backgrounds restarting from zero during normal menu/background lifecycle changes.
- Fixed the Game Library's empty, portrait, grid, list, and landscape cover-flow alignment.
- Fixed stale scroll position and layout reuse after rotating between portrait and landscape.
- Restored the intended iPad navigation-tab placement rather than applying compact iPhone placement.
- Fixed the enlarged selected-game preview using an opaque background; it now uses interactive Clear Liquid Glass with transparent hosting.
- Fixed Game-Card Zoom failing on first launch, before a thumbnail finishes, after confirming **Restart VM**, in list mode, in portrait grid, or in landscape cover flow.
- Fixed the selected cover image missing during Game-Card Zoom by performing a bounded selected-card downsample when necessary.
- Fixed the library disappearing abruptly beneath the zoom; it now fades while emulation starts immediately.
- Fixed long-press context menus so the complete card, cover, text, favorite state, tint, transparency, and Liquid Glass surface enlarge together.
- Fixed the favorite star being placed behind the card or replacing the main card interaction.
- Fixed **Now Running** appearing during the initial transition into gameplay; it is retained for the menu return state.
- Fixed **Now Running** disappearing between a running VM and a confirmed replacement VM.
- Fixed the **Now Running** card snapping away or causing the remaining Game Library glass to rematerialize.
- Fixed the running-cover highlight by scoping a fading neon-green glow to only the active game's decoded cover.
- Fixed Games, BIOS, and Settings large-title positions being inconsistent between empty and populated states.
- Fixed retained Games/BIOS titles disappearing after pull-to-scroll and tab changes.
- Fixed the compact toolbar title colliding with **Boot BIOS**.
- Fixed toolbar/title changes briefly showing the wrong tab name.
- Fixed the Games/BIOS/Settings page transition so large titles and shared toolbar controls morph or fade instead of abruptly replacing one another.
- Fixed the iOS 17/18 navigation bar appearing as an opaque rectangular strip instead of a compact floating pill.
- Fixed the selected iOS 17/18 tab indicator being too dark, too narrow, or unanimated.
- Fixed tab content drawing under the foreground native tab bar.
- Fixed tab navigation being limited to taps by adding guarded left/right swipe navigation.
- Fixed hidden retained BIOS and Settings pages performing unnecessary work before their first activation.
- Fixed BIOS-only Emulation-Only startup waiting indefinitely for game-specific patch/texture barriers.
- Fixed Emulation-Only Mode removing its SwiftUI presentation before native optional-resource teardown finishes.

### Added

- Added instant VM startup while the Fluid Game-Card Zoom animation runs independently above the menu-to-game transition.
- Added a live SwiftUI Fluid Zoom card for normal game launches.
- Added a live SwiftUI Liquid Glass context-menu preview for long-pressed cards.
- Added a new compact, translucent, pill-shaped navigation tab bar for iOS 17/18.
- Added a spring-animated, monochrome-blue selected-tab pill for iOS 17/18.
- Added native tab-bar handling for iOS 26 while retaining the platform Liquid Glass selection behavior.
- Added swipe-left and swipe-right navigation between Games, BIOS, and Settings, including right-to-left layout support.
- Added gesture arbitration so tab swipes do not steal sliders, controls, navigation-edge gestures, or horizontal Game Library scrolling.
- Added page-owned Games, BIOS, and Settings titles with matched-geometry morphing during tab changes.
- Added persistent Games/BIOS toolbar ownership so **Boot BIOS** and toolbar symbols morph through the shared navigation hierarchy.
- Added a single persistent background renderer shared by the retained menu tabs.
- Added a background-only suspension snapshot system to avoid a black frame in the app switcher.
- Added live-renderer warm-up followed by snapshot fade and pixel-memory release after returning to the app.
- Added current-frame capture support for local video backgrounds.
- Added video playhead preservation across pause, backgrounding, and renderer recreation.
- Added downsampled static wallpaper loading and bounded animated-wallpaper decoding.
- Added a multi-stage **Now Running → Stopping…** transition with symbol replacement, action fade, text morph, glass shrink, and final removal.
- Added an isolated transient glass container so removing **Now Running** does not change the remaining card material.
- Added per-running-cover randomized neon glow animation with teardown fade.
- Added a **JIT Access Not Detected** boot gate that retains the requested game until the user retries or cancels.
- Added indexed cover lookup, coordinated thumbnail decoding, refresh coalescing, and metadata caching for the Game Library.
- Added native completion notification handling for Emulation-Only optional-resource teardown.

## User-Visible Changes

### Fluid Game-Card Zoom

Selecting a game can now transition from the actual library card into gameplay using a live SwiftUI card rather than an enlarged screenshot.

The transition carries:

- The decoded cover image.
- Game title and file information.
- List, grid, or landscape cover-flow geometry.
- The card's corner radius.
- Favorite state.
- Clear Liquid Glass styling.

The VM boot starts immediately; the menu fade and zoom run as presentation work above it. The live card remains visible long enough for the zoom to complete and then fades into the active emulation surface. The transition does not retain the entire Games screen.

The existing **Game-Card Zoom Animation** setting continues to control the game-launch transition.

The transition builder also handles the cases that previously skipped or lost the animation:

- The first game tapped after launch.
- A cover whose asynchronous thumbnail has not completed.
- A game started from list mode.
- A game started from portrait grid mode.
- A game started from landscape cover flow.
- A replacement game started after confirming **Restart VM**.

### Context-Menu Card Preview

Long-pressing a game card uses SwiftUI's custom context-menu preview path:

- The cover, text, favorite indicator, padding, and glass surface scale together.
- The system context menu performs the lift and return transition.
- The enlarged card is rebuilt as live SwiftUI content rather than scaling a stale rasterized snapshot.
- The preview explicitly receives the Clear Liquid Glass preference because the system renders it in a separate context-menu host.
- The preview uses interactive glass behavior, transparent hosting, the existing app tint environment, and the same continuous corner geometry.
- The previous custom dark outer shadow was removed so the preview does not appear to have an opaque background.

This work applies to list cards, portrait grid cards, and landscape cover-flow cards.

### Favorite Controls

The favorite button remains part of the complete card hierarchy and stays above the cover and Liquid Glass surface.

Favorite changes use symbol animation without replacing the card's main tap target or context-menu interaction.

### Now Running

The retained Now Running card has a dedicated stopping presentation:

- The running controls transition into a stopping state.
- Status content fades before removal.
- The Liquid Glass card scales and fades to zero.
- The remaining library is isolated from the transient card's glass container so its glass properties do not snap when removal completes.
- Restarting into a different game preserves the running-card continuity instead of briefly removing it between VMs.

The active game's cover receives a randomized neon-green glow. Only the running cover owns this animation, avoiding a library-wide animation timeline. The glow fades when the game stops.

### JIT Boot Warning

Game launch now checks JIT availability before starting or restarting a VM.

When JIT access is missing, the app presents:

> JIT Access Not Detected

with the guidance:

> JIT access is not available. Match the StikDebug script to the JIT Script setting in Emulator settings.

The pending request retains the selected game and its launch transition so the boot can continue after JIT access becomes available. Cancelling clears that request.

### BIOS Setup Warning

Game and BIOS-only boot paths share one bootable-BIOS check. If no valid BIOS has been imported, the request does not enter a black or incomplete gameplay screen; the app presents:

> BIOS not yet imported.

This applies whether the user starts from a game card or the always-available **Boot BIOS** control.

### Direct Game-Card Interaction

The complete card is the primary Play button:

- Tap starts or resumes the selected game.
- Tap on the star changes favorite state.
- Long press presents Game Info, Per-Game Settings, Cheats & Patches, Covers, Disc Path where applicable, cache clearing, and deletion actions.

The nested controls retain separate hit targets without turning a normal Play tap into a brief zoom-only action.

## Game Library Performance

### Indexed Cover Lookup

A library refresh now builds one immutable filename index for the relevant cover directories.

Previously, cover resolution could enumerate the same directories for each game. The new lookup:

1. Enumerates each unique managed, game-local, and fallback directory once.
2. Normalizes filenames into an in-memory dictionary.
3. Resolves every game against that snapshot.

This reduces filesystem enumeration as the library grows.

### Bounded and Shared Thumbnail Decoding

Cover thumbnail decoding now uses a shared coordinator:

- Identical in-flight requests share one decode task.
- Unique ImageIO decodes are bounded to six concurrent operations.
- Decoding runs away from the main actor.
- Completed images still enter the existing thumbnail cache.
- A generation guard prevents late decoding work from repopulating a cache released for gameplay.

When a selected cover has not finished its asynchronous thumbnail task, the Fluid Zoom transition performs one bounded downsample for that selected card. This avoids a missing cover without forcing every card to decode synchronously.

### Cached Display Metadata

Frequently rendered game-card strings and identifiers are computed when `ISOEntry` is created:

- Display title.
- Formatted size.
- Region flag.
- Normalized running-game identifiers.

This avoids repeating path, formatting, and normalization work during SwiftUI body evaluation.

### Refresh and Persistence Work

The library runtime now:

- Defers or coalesces reload work while the user is actively scrolling.
- Avoids assigning an identical game list.
- Builds dictionaries with reserved capacity.
- Purges removed metadata without recreating the complete dictionary.
- Serializes the persistent metadata snapshot on a utility queue.
- Keeps transient loading, scrolling, and running-identifier bookkeeping outside SwiftUI observation.

These changes reduce full-library invalidations and main-thread file work.

### Rotation and Layout State

Portrait grid/list and landscape cover-flow presentations use separate stable identities. Rotation therefore does not reuse an incompatible scroll view's content offset or alignment geometry.

The library remains scrollable, respects the native tab bar, and uses page-owned large titles where the retained shared navigation hierarchy cannot reliably manage independent large-title state.

Landscape cover flow computes an orientation-specific available height and visual offset rather than inheriting portrait padding. Empty Games and BIOS presentations keep their content centered while still allowing intentional pull/bounce behavior.

## Background Runtime and Continuity

### One Persistent Renderer

The menu root owns one `PersistentMenuBackgroundHost`. Games, BIOS, and Settings reveal or hide that renderer; normal tab selection does not create a renderer per tab.

This retains:

- Dynamic Background time and renderer state.
- Video player position and audio.
- Animated background state.
- XMB palette and shader continuity.

Tabs where **Show Background In** is disabled hide the presentation without resetting a configured video.

### Backgrounding Snapshot

Before iOS suspends Metal, video, and display-link rendering, a dedicated UIKit subtree captures only the background.

The captured frame:

- Does not include menu cards, navigation titles, toolbars, or the native tab bar.
- Is shown immediately while the scene is inactive.
- Remains visible while the resumed live renderer warms up.
- Fades away after activation.
- Is removed from memory after the fade.
- Is also discarded when the background is removed or gameplay starts.

Video backgrounds first provide a rasterizable current frame because `AVPlayerLayer` content is not guaranteed to appear in a normal UIKit hierarchy snapshot.

### Video Playback Position

Local background videos save their current playhead when paused or suspended and restore it when recreated. The position is cleared only when the background session is explicitly released, preventing normal app backgrounding from restarting the video at zero.

### Static and Animated Image Memory

Static wallpapers are downsampled with ImageIO to approximately the active display size on a utility task instead of retaining the full source image.

Animated backgrounds:

- Load a static first frame independently.
- Avoid animated decode when Reduce Motion is enabled.
- Bound total decoded frame memory.
- Use a capped display-link range.
- Cancel decoding and release frames when the menu background is released.

### Dynamic Background Drawing

Eligible SwiftUI `Canvas` effects render asynchronously, reducing main-thread drawing pressure while preserving each effect's existing update rate and visual configuration.

The PlayStation 3 XMB shader library remains cached during short menu/Appearance renderer handoffs, but the cache is explicitly eligible for release at the end of the menu session or when gameplay replaces the menu.

## Navigation, Titles, and Tabs

### Retained Menu Pages

Games and BIOS share one persistent `NavigationStack`; Settings remains a retained sibling. Switching tabs changes visibility, hit testing, accessibility, and z-order without destroying and rebuilding every page.

This allows:

- Stable Liquid Glass identity.
- Persistent Games/BIOS toolbar ownership.
- No opaque rematerialization of retained page content.
- Fewer tab-change reloads.
- Correct return-to-root behavior when the selected Settings tab is tapped again.

### Consistent Page Titles

Games, BIOS, and Settings use page-owned large titles on supported phone layouts. Their top origin, horizontal inset, font, and empty/populated behavior are shared.

During a tab change:

- The title participates in one matched-geometry namespace.
- Games and BIOS toolbar items retain stable identifiers.
- The library toolbar fades when entering Settings.
- Compact-height layouts use a principal title without squeezing it beside **Boot BIOS**.

### iOS 26 Navigation Tab Bar

iOS 26 continues using the native `UITabBar` presentation so its Liquid Glass selection, tint, press feedback, and system behavior remain available. The bar is installed as a foreground safe-area sibling instead of inside the scrolling page glass hierarchy.

### iOS 17/18 Navigation Tab Bar

Earlier systems receive a dedicated compatible presentation:

- One compact ultra-thin-material outer capsule.
- A wider translucent selected-tab capsule.
- Monochrome blue selected icon and label.
- Spring movement between selections.
- Press scaling and opacity feedback.
- Centered portrait/landscape geometry.
- Home-indicator clearance in compact landscape.
- Transparent system bar background rather than the previous rectangle.

The iPad path retains its intended platform placement and does not reuse the phone's compact geometry.

### Swipe Navigation

A UIKit pan recognizer enables horizontal swipes between Games, BIOS, and Settings.

The recognizer:

- Requires a predominantly horizontal gesture.
- Uses distance plus projected velocity.
- Respects left-to-right and right-to-left tab order.
- Does not cancel the touched view.
- Avoids controls and the native tab bar.
- Protects system navigation edges.
- Yields to horizontally scrollable content such as landscape cover flow.
- Recognizes simultaneously where safe so normal vertical library scrolling remains available.

## BIOS and Settings Presentation

### BIOS

The BIOS page:

- Uses the same page-owned large-title origin as the other retained menu pages.
- Keeps empty and populated states scrollable.
- Aligns its compact-height empty state with Games.
- Avoids rescanning BIOS files while its retained tab is hidden.
- Coalesces bootstrap/import refresh notifications.
- Avoids replacing the BIOS array when its contents are unchanged.
- Keeps the Import BIOS plus symbol white inside its pill.

### Settings

The Settings root:

- Uses a page-owned large title in the retained phone menu.
- Avoids querying JIT status while the hidden tab has never been activated.
- Caches the build-version string.
- Caches DEV9 network adapters for the lifetime of the screen.
- Coalesces host-file writes while the user types and flushes them when leaving or backgrounding.

### iPad

The menu avoids applying the phone-specific page-owned large-title and compact tab-bar assumptions to iPad. This restores the intended iPad navigation-tab placement and lets the platform use the appropriate larger-screen navigation presentation.

## Emulation-Only Mode

Emulation-Only Mode still waits for the emulator's normal startup readiness barriers, including patch and replacement-texture initialization.

The teardown handoff is now two-phase:

1. Swift records the presentation that must remain.
2. Native code releases the selected optional resources.
3. Native code posts a completion notification on the main queue.
4. Swift removes the corresponding overlay/UI only after native teardown has completed.

This avoids showing a stripped UI before the native release has actually finished.

Returning temporarily to the menu and resuming the same stripped VM no longer recreates services already released by Emulation-Only Mode.

BIOS-only boot has no game ELF or replacement-texture map, so native initialization now explicitly satisfies those two readiness barriers after the VM subsystems finish initializing. This prevents automatic Emulation-Only Mode from waiting indefinitely after **Boot BIOS**.

## Gameplay Resource Impact

When gameplay replaces the menu, the existing release path now works with the optimized owners above:

- The Game Library list and metadata entries are released from the active SwiftUI hierarchy.
- Pending cover tasks are cancelled.
- The thumbnail cache stops accepting late results and releases decoded thumbnails.
- The shared menu background host releases its live renderer and inactive snapshot.
- Video player state, display links, animated-image frames, Dynamic Background renderers, and the XMB session shader cache become eligible for teardown.
- The gameplay transition retains only one selected, display-sized cover and lightweight strings until its animation completes.

Emulation-Only Mode can then release its configured optional gameplay services after patches and texture startup are ready. Core VM execution, rendering, audio, disc access, memory cards, and the preserved external-controller input path are not intentionally removed by these menu changes.

## Expected Impact

Expected improvements include:

- Less Game Library main-thread work.
- Fewer duplicate cover-directory scans.
- Fewer simultaneous and duplicate image decodes.
- Faster visible-cover reuse and reliable cover presentation in transitions.
- Lower transient memory for oversized static and animated backgrounds.
- No normal tab-change video restart.
- Less Dynamic Background recreation across retained menu tabs.
- No black background during normal app suspension/resume when a frame can be captured.
- More deterministic cleanup before gameplay and Emulation-Only Mode.
- Smoother game-card context-menu and launch animations.

No numerical CPU, GPU, memory, battery, or thermal claims are included because this archive was not accompanied by an Instruments capture.

## Validation

The following validation completed successfully:

- `git diff --check` for the final Liquid Glass context-preview changes.
- Fetched and compared against `origin/master` at `7b89374919d0`.
- Confirmed 19 modified tracked files, with no tracked additions or deletions.
- Full unsigned iOS device build using `platforms/ios/scripts/build-ios-ipa.sh`.
- Xcode 26.6 / iPhoneOS 26.5 SDK.
- Deployment target: iOS 17.0.
- Architecture: arm64.
- Result: `** BUILD SUCCEEDED **`.
- Unsigned IPA generated at `platforms/ios/build-ios-xcode/ARMSX2-iOS-unsigned.ipa`.

The build reports existing deprecation/unused-value warnings unrelated to this change set. Physical-device interaction and Instruments profiling remain recommended before merge.

## File-by-File Master Comparison

| File | Changes relative to master |
|---|---|
| `pcsx2/VMManager.cpp` | Completes patch and replacement-texture readiness barriers for BIOS-only boots so automatic Emulation-Only teardown can proceed. |
| `platforms/ios/app/src/main/cpp/ARMSX2Bridge.h` | Exposes the native Emulation-Only active-state query to Swift. |
| `platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm` | Posts native optional-resource release completion and reports whether the VM remains in Emulation-Only Mode. |
| `platforms/ios/app/src/main/swift/Models/AppState.swift` | Adds live launch-card metadata, BIOS/JIT boot gates, pending JIT requests, restart continuity, menu/game handoff state, and persistent Emulation-Only presentation behavior. |
| `platforms/ios/app/src/main/swift/Models/CoverStore.swift` | Adds one-pass cover-directory indexing and indexed resolution for complete library refreshes. |
| `platforms/ios/app/src/main/swift/Views/AnimatedLibraryBackgroundView.swift` | Adds asynchronous first-frame loading, Reduce Motion behavior, decoded-memory bounds, and capped display-link scheduling. |
| `platforms/ios/app/src/main/swift/Views/BIOSListView.swift` | Unifies title/layout behavior, retains scrolling, defers hidden-tab scans, coalesces refreshes, preserves toolbar ownership, and updates Import BIOS presentation. |
| `platforms/ios/app/src/main/swift/Views/Background/BackgroundContainerView.swift` | Adds off-main static wallpaper downsampling and coordinates inactive renderer release with snapshot capture. |
| `platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicBackgrounds.swift` | Enables asynchronous Canvas rendering for eligible Dynamic Background styles. |
| `platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicEffects.swift` | Moves the reusable particle-overlay Canvas to asynchronous rendering. |
| `platforms/ios/app/src/main/swift/Views/Background/Dynamic/PlayStation3XMBByMartShaderLibrary.swift` | Retains the XMB shader library across short renderer handoffs and releases it at a real menu-session boundary. |
| `platforms/ios/app/src/main/swift/Views/Background/MenuBackgroundSupport.swift` | Adds persistent renderer ownership, app-switcher snapshots, warm-up fade/release, page-owned title morphing, stable/isolated glass containers, and shared background-aware menu helpers. |
| `platforms/ios/app/src/main/swift/Views/Background/VideoBackgroundView.swift` | Preserves local-video playhead state and generates a capturable current frame for inactive background snapshots. |
| `platforms/ios/app/src/main/swift/Views/CoverThumbnailView.swift` | Adds coordinated bounded decoding, duplicate-request sharing, selected-card fallback decoding, cache lifecycle guards, and gameplay release behavior. |
| `platforms/ios/app/src/main/swift/Views/GameListView.swift` | Implements the optimized library model, centered layouts, stable rotation identities, direct card/context interactions, Fluid Zoom metadata, clear preview, Now Running transitions, neon running glow, and deferred refresh behavior. |
| `platforms/ios/app/src/main/swift/Views/GameScreenView.swift` | Waits for native Emulation-Only release completion and restores an already-stripped VM without recreating released optional services. |
| `platforms/ios/app/src/main/swift/Views/RootView.swift` | Adds boot warnings, live launch overlay, retained tabs, shared toolbar/title transitions, iOS 26/native and iOS 17/18 tab-bar paths, swipe navigation, foreground z-order, safe-area handling, and root menu resource release. |
| `platforms/ios/app/src/main/swift/Views/Settings/AppearanceSettingsView.swift` | Uses the final **Game-Card Zoom Animation** label. |
| `platforms/ios/app/src/main/swift/Views/Settings/SettingsRootView.swift` | Adds consistent Settings title behavior, lazy JIT refresh, cached static values/adapters, and coalesced DEV9 host persistence. |


### Did you use AI to help find, test, or implement this issue or feature?
Yes, to generate this PR.