### PR TITLE
iOS: fix the sprite hacks getting stuck, and the light mode bar over a running game

### DIFF
--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -519,6 +519,28 @@ enum class GSNativeScaling : u8
 	MaxCount
 };
 
+// A hack the player set on purpose. Normally the GameDB gets the last word on these
+// unless manual hacks are on, which is all or nothing: switching one hack off throws
+// away every automatic fix the game had. Pinning one keeps the rest.
+enum class GSUserHackOverride : u8
+{
+	AlignSprite,
+	MergeSprite,
+	RoundSprite,
+	HalfPixelOffset,
+	ForceEvenSpritePosition,
+	NativeScaling,
+	NativePaletteDraw,
+	BilinearHack,
+	TextureOffsetX,
+	AutoFlush,
+	TextureInsideRt,
+	// Appended rather than slotted in next to X, so a mask already written to an INI keeps
+	// meaning what it meant.
+	TextureOffsetY,
+	MaxCount
+};
+
 enum class GSDepthFeedbackMode : u8
 {
 	None      = 0,
@@ -1033,12 +1055,30 @@ struct Pcsx2Config
 		std::string HWDumpDirectory;
 		std::string SWDumpDirectory;
 
+		/// Hacks the player set deliberately, one bit per GSUserHackOverride. Kept out of
+		/// the bitfield union above on purpose: that packing is what OptionsAreEqual
+		/// compares wholesale, and this is not a hack value, it is who owns one.
+		u32 UserHackOverrides = 0;
+
 		GSOptions();
 
 		void LoadSave(SettingsWrapper& wrap);
 
-		/// Sets user hack values to defaults when user hacks are not enabled.
-		void MaskUserHacks();
+		bool IsUserHackPinned(GSUserHackOverride hack) const
+		{
+			return (UserHackOverrides & (1u << static_cast<u32>(hack))) != 0;
+		}
+
+		void SetUserHackPinned(GSUserHackOverride hack, bool pinned)
+		{
+			const u32 bit = 1u << static_cast<u32>(hack);
+			UserHackOverrides = pinned ? (UserHackOverrides | bit) : (UserHackOverrides & ~bit);
+		}
+
+		/// Sets user hack values to defaults when user hacks are not enabled. Hacks the
+		/// player claimed survive, unless the caller is stripping for safety rather than
+		/// preference, in which case pass false.
+		void MaskUserHacks(bool respect_claims = true);
 
 		/// Sets user hack values to defaults when upscaling is not enabled.
 		void MaskUpscalingHacks();

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -1067,10 +1067,21 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 		GSConfig.UserHacks_CPUSpriteRenderBW != old_config.UserHacks_CPUSpriteRenderBW ||
 		GSConfig.UserHacks_CPUCLUTRender != old_config.UserHacks_CPUCLUTRender ||
 		GSConfig.UserHacks_GPUTargetCLUTMode != old_config.UserHacks_GPUTargetCLUTMode ||
-		// Native scaling is the one geometry hack that outlives the draw: it swaps a
-		// target's texture for a downscaled one and pins m_scale to 1. Those targets
-		// stay downscaled after it's switched off, so they have to go.
-		GSConfig.UserHacks_NativeScaling != old_config.UserHacks_NativeScaling)
+		// The geometry hacks below all outlive the draw, because what they move ends up
+		// baked into a cached target: native scaling swaps a target's texture for a
+		// downscaled one and pins m_scale to 1, the rest shift vertices or texture
+		// coordinates on the way in. Switch one off and a target the game doesn't redraw
+		// keeps the old pixels — that's the ghosting people report as a stuck setting.
+		GSConfig.UserHacks_NativeScaling != old_config.UserHacks_NativeScaling ||
+		GSConfig.UserHacks_AlignSpriteX != old_config.UserHacks_AlignSpriteX ||
+		GSConfig.UserHacks_MergePPSprite != old_config.UserHacks_MergePPSprite ||
+		GSConfig.UserHacks_RoundSprite != old_config.UserHacks_RoundSprite ||
+		GSConfig.UserHacks_HalfPixelOffset != old_config.UserHacks_HalfPixelOffset ||
+		GSConfig.UserHacks_ForceEvenSpritePosition != old_config.UserHacks_ForceEvenSpritePosition ||
+		GSConfig.UserHacks_NativePaletteDraw != old_config.UserHacks_NativePaletteDraw ||
+		GSConfig.UserHacks_BilinearHack != old_config.UserHacks_BilinearHack ||
+		GSConfig.UserHacks_TCOffsetX != old_config.UserHacks_TCOffsetX ||
+		GSConfig.UserHacks_TCOffsetY != old_config.UserHacks_TCOffsetY)
 	{
 		if (GSConfig.UserHacks_ReadTCOnClose)
 			g_gs_renderer->ReadbackTextureCache();

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -484,6 +484,37 @@ bool GameDatabaseSchema::isUserHackHWFix(GSHWFixId id)
 	}
 }
 
+// Which fixes a player can claim for themselves. Anything not listed keeps the old
+// behaviour, so the database still wins on the ones no UI exposes.
+static std::optional<GSUserHackOverride> UserHackOverrideForHWFix(GameDatabaseSchema::GSHWFixId id)
+{
+	switch (id)
+	{
+		case GameDatabaseSchema::GSHWFixId::AlignSprite:
+			return GSUserHackOverride::AlignSprite;
+		case GameDatabaseSchema::GSHWFixId::MergeSprite:
+			return GSUserHackOverride::MergeSprite;
+		case GameDatabaseSchema::GSHWFixId::RoundSprite:
+			return GSUserHackOverride::RoundSprite;
+		case GameDatabaseSchema::GSHWFixId::HalfPixelOffset:
+			return GSUserHackOverride::HalfPixelOffset;
+		case GameDatabaseSchema::GSHWFixId::ForceEvenSpritePosition:
+			return GSUserHackOverride::ForceEvenSpritePosition;
+		case GameDatabaseSchema::GSHWFixId::NativeScaling:
+			return GSUserHackOverride::NativeScaling;
+		case GameDatabaseSchema::GSHWFixId::NativePaletteDraw:
+			return GSUserHackOverride::NativePaletteDraw;
+		case GameDatabaseSchema::GSHWFixId::BilinearUpscale:
+			return GSUserHackOverride::BilinearHack;
+		case GameDatabaseSchema::GSHWFixId::AutoFlush:
+			return GSUserHackOverride::AutoFlush;
+		case GameDatabaseSchema::GSHWFixId::TextureInsideRT:
+			return GSUserHackOverride::TextureInsideRt;
+		default:
+			return std::nullopt;
+	}
+}
+
 void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool applyAuto) const
 {
 	// Only apply core game fixes if the user has enabled them.
@@ -760,7 +791,12 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 
 	for (const auto& [id, value] : gsHWFixes)
 	{
-		if (isUserHackHWFix(id) && !apply_auto_fixes)
+		// A pin is manual mode for one fix instead of all of them, so it takes the same
+		// road out: the player's value stays and this one gets named in the warning.
+		const std::optional<GSUserHackOverride> pin = UserHackOverrideForHWFix(id);
+		const bool pinned = pin.has_value() && config.IsUserHackPinned(pin.value());
+
+		if (isUserHackHWFix(id) && (!apply_auto_fixes || pinned))
 		{
 			if (configMatchesHWFix(config, id, value))
 				continue;
@@ -1077,10 +1113,12 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 
 	if (!is_sw_renderer && !disabled_fixes.empty())
 	{
+		// Pinning a single hack lands here too, and then blaming manual mode would be a lie.
+		const std::string_view reason = apply_auto_fixes ?
+			TRANSLATE_SV("GameDatabase", "Your own choice was kept for these graphics fixes, so the automatic ones were not applied:") :
+			TRANSLATE_SV("GameDatabase", "Manual GS hardware renderer fixes are enabled, automatic fixes were not applied:");
 		Host::AddKeyedOSDMessage("HWFixesWarning",
-			fmt::format(ICON_FA_WAND_MAGIC_SPARKLES " {}\n{}",
-				TRANSLATE_SV("GameDatabase", "Manual GS hardware renderer fixes are enabled, automatic fixes were not applied:"),
-				disabled_fixes),
+			fmt::format(ICON_FA_WAND_MAGIC_SPARKLES " {}\n{}", reason, disabled_fixes),
 			Host::OSD_ERROR_DURATION);
 	}
 	else

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -832,6 +832,9 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 	return (
 		OpEqu(bitsets[0]) &&
 		OpEqu(bitsets[1]) &&
+		// Pinning or unpinning changes what the GameDB is allowed to write, so it has to
+		// count as a settings change even when no hack value moved with it.
+		OpEqu(UserHackOverrides) &&
 
 		OpEqu(InterlaceMode) &&
 		OpEqu(LinearPresent) &&
@@ -1068,6 +1071,9 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBoolEx(PreloadFrameWithGSData, "preload_frame_with_gs_data");
 	SettingsWrapBitBoolEx(Mipmap, "mipmap");
 	SettingsWrapBitBoolEx(ManualUserHacks, "UserHacks");
+	// Bit per GSUserHackOverride. Written by the frontend when someone changes one hack
+	// on purpose, not something to hand-edit.
+	SettingsWrapEntryEx(UserHackOverrides, "UserHackOverrides");
 	SettingsWrapBitBoolEx(UserHacks_AlignSpriteX, "UserHacks_align_sprite_X");
 	SettingsWrapIntEnumEx(UserHacks_AutoFlush, "UserHacks_AutoFlushLevel");
 	SettingsWrapBitBoolEx(UserHacks_CPUFBConversion, "UserHacks_CPU_FB_Conversion");
@@ -1213,38 +1219,57 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	}
 }
 
-void Pcsx2Config::GSOptions::MaskUserHacks()
+void Pcsx2Config::GSOptions::MaskUserHacks(bool respect_claims)
 {
 	if (ManualUserHacks)
 		return;
 
-	UserHacks_AlignSpriteX = false;
-	UserHacks_MergePPSprite = false;
-	UserHacks_ForceEvenSpritePosition = false;
-	UserHacks_NativePaletteDraw = false;
+	// A pinned hack is the player's answer for this one setting, so it survives here and
+	// past the GameDB. Everything they didn't touch still goes back to automatic.
+	const auto keep = [this, respect_claims](GSUserHackOverride hack) {
+		return respect_claims && IsUserHackPinned(hack);
+	};
+
+	if (!keep(GSUserHackOverride::AlignSprite))
+		UserHacks_AlignSpriteX = false;
+	if (!keep(GSUserHackOverride::MergeSprite))
+		UserHacks_MergePPSprite = false;
+	if (!keep(GSUserHackOverride::ForceEvenSpritePosition))
+		UserHacks_ForceEvenSpritePosition = false;
+	if (!keep(GSUserHackOverride::NativePaletteDraw))
+		UserHacks_NativePaletteDraw = false;
+	if (!keep(GSUserHackOverride::HalfPixelOffset))
+		UserHacks_HalfPixelOffset = GSHalfPixelOffset::Off;
+	if (!keep(GSUserHackOverride::RoundSprite))
+		UserHacks_RoundSprite = 0;
+	if (!keep(GSUserHackOverride::NativeScaling))
+		UserHacks_NativeScaling = GSNativeScaling::Off;
+	if (!keep(GSUserHackOverride::AutoFlush))
+		UserHacks_AutoFlush = GSHWAutoFlushLevel::Disabled;
+	if (!keep(GSUserHackOverride::TextureInsideRt))
+		UserHacks_TextureInsideRt = GSTextureInRtMode::Disabled;
+	if (!keep(GSUserHackOverride::BilinearHack))
+		UserHacks_BilinearHack = GSBilinearDirtyMode::Automatic;
+	if (!keep(GSUserHackOverride::TextureOffsetX))
+		UserHacks_TCOffsetX = 0;
+	if (!keep(GSUserHackOverride::TextureOffsetY))
+		UserHacks_TCOffsetY = 0;
+
 	UserHacks_DisableSafeFeatures = false;
 	UserHacks_DisableRenderFixes = false;
-	UserHacks_HalfPixelOffset = GSHalfPixelOffset::Off;
-	UserHacks_RoundSprite = 0;
-	UserHacks_NativeScaling = GSNativeScaling::Off;
-	UserHacks_AutoFlush = GSHWAutoFlushLevel::Disabled;
 	GPUPaletteConversion = false;
 	PreloadFrameWithGSData = false;
 	UserHacks_DisablePartialInvalidation = false;
 	UserHacks_DisableDepthSupport = false;
 	UserHacks_CPUFBConversion = false;
 	UserHacks_ReadTCOnClose = false;
-	UserHacks_TextureInsideRt = GSTextureInRtMode::Disabled;
 	UserHacks_Limit24BitDepth = GSLimit24BitDepth::Disabled;
 	UserHacks_EstimateTextureRegion = false;
 	UserHacks_DrawBuffering = false;
-	UserHacks_TCOffsetX = 0;
-	UserHacks_TCOffsetY = 0;
 	UserHacks_CPUSpriteRenderBW = 0;
 	UserHacks_CPUSpriteRenderLevel = 0;
 	UserHacks_CPUCLUTRender = 0;
 	UserHacks_GPUTargetCLUTMode = GSGPUTargetCLUTMode::Disabled;
-	UserHacks_BilinearHack = GSBilinearDirtyMode::Automatic;
 	SkipDrawStart = 0;
 	SkipDrawEnd = 0;
 }
@@ -1253,6 +1278,10 @@ void Pcsx2Config::GSOptions::MaskUpscalingHacks()
 {
 	if (UpscaleMultiplier > 1.0f)
 		return;
+
+	// Pins deliberately don't count here. At native res the renderer skips these anyway
+	// (GSRendererHW::Draw wants rt->GetScale() > 1), so honouring a pin would only leave
+	// GSConfig and the settings overlay claiming something that never runs.
 
 	UserHacks_AlignSpriteX = false;
 	UserHacks_MergePPSprite = false;

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -815,7 +815,13 @@ void VMManager::ApplyGameFixes()
 		EmuConfig.Gamefixes.InstantDMAHack = true;
 
 		// Disable user's manual hardware fixes, it might be problematic.
+		// LoadCoreSettings() already masked with the flag still set, so clearing it here
+		// isn't enough on its own — the hacks it was meant to strip are still in EmuConfig.
+		// Claims don't get a say either: whether a hack is safe on the BIOS has nothing to
+		// do with whether the player asked for it.
 		EmuConfig.GS.ManualUserHacks = false;
+		EmuConfig.GS.MaskUserHacks(false);
+		EmuConfig.GS.MaskUpscalingHacks();
 		return;
 	}
 

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.h
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.h
@@ -250,6 +250,14 @@ typedef void (^ARMSX2RetroAchievementsCompletion)(BOOL success, NSString * _Nonn
 + (void)applyGraphicsSettingsNow;
 + (void)flushINISettings;
 
+// What the running game is actually using for each upscaling hack, keyed by INI key.
+// Each entry has "effective", "reason" (ARMSX2GraphicsHackReason) and "pinned". The
+// masks and the GameDB sit between the INI and the renderer, so this is the only way
+// the settings screen can tell whether a toggle did anything. Refreshed on the
+// ARMSX2GraphicsHackStateChanged notification.
++ (nonnull NSDictionary<NSString *, id> *)graphicsHackState;
++ (void)setGraphicsHackPinned:(nonnull NSString *)iniKey pinned:(BOOL)pinned NS_SWIFT_NAME(setGraphicsHackPinned(_:pinned:));
+
 // Frame-time history (read-only). frameTimeHistory wraps
 // PerformanceMetrics::GetFrameTimeHistory() (a thread-safe read of the
 // 150-sample ring buffer) and frameTimeHistoryPos returns its current write

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
@@ -2187,6 +2187,7 @@ enum class ARMSX2GraphicsHackReason : int
     NeedsUpscaling,
     FromGameDatabase,
     NoGame,
+    PerGame,
 };
 
 struct ARMSX2GraphicsHackDescriptor
@@ -2269,7 +2270,21 @@ extern "C" void ARMSX2_CaptureGraphicsHackState(void)
     const bool has_vm = VMManager::HasValidVM();
     const Pcsx2Config::GSOptions& gs = EmuConfig.GS;
 
-    for (const ARMSX2GraphicsHackDescriptor& hack : s_graphics_hacks) {
+    // Resolved before the lock below, deliberately. It walks the game database, and
+    // anything that reaches back into settings from under that lock would hang.
+    std::array<bool, s_graphics_hacks.size()> database_sets{};
+    for (size_t i = 0; i < s_graphics_hacks.size(); i++)
+        database_sets[i] = has_vm && ARMSX2GameDatabaseSetsHWFix(s_graphics_hacks[i].hw_fix_id);
+
+    // One lock for the whole sweep, reading the two layers by hand. The Host getters
+    // take this same lock per call and it isn't recursive, so nothing in here may call
+    // one -- that would hang rather than misreport.
+    std::unique_lock<std::mutex> settings_lock = Host::GetSettingsLock();
+    const SettingsInterface* base_layer = Host::Internal::GetBaseSettingsLayer();
+    const SettingsInterface* game_layer = Host::Internal::GetGameSettingsLayer();
+
+    for (size_t i = 0; i < s_graphics_hacks.size(); i++) {
+        const ARMSX2GraphicsHackDescriptor& hack = s_graphics_hacks[i];
         ARMSX2GraphicsHackState state;
         state.ini_key = hack.ini_key;
         state.pinned = gs.IsUserHackPinned(hack.override_id);
@@ -2281,22 +2296,30 @@ extern "C" void ARMSX2_CaptureGraphicsHackState(void)
         }
 
         state.effective = hack.read(gs);
-        // The layered value, so a per-game override counts as what was asked for.
-        const int requested = hack.is_bool ?
-            static_cast<int>(Host::GetBoolSettingValue("EmuCore/GS", hack.ini_key, false)) :
-            Host::GetIntSettingValue("EmuCore/GS", hack.ini_key, 0);
+
+        // The graphics screen edits globals, so it shows the base value. The game may be
+        // running the per-game one, which is a different number and worth saying out loud.
+        const bool from_game_layer = game_layer && game_layer->ContainsValue("EmuCore/GS", hack.ini_key);
+        const SettingsInterface* source = from_game_layer ? game_layer : base_layer;
+        int requested = 0;
+        if (source) {
+            requested = hack.is_bool ?
+                static_cast<int>(source->GetBoolValue("EmuCore/GS", hack.ini_key, false)) :
+                source->GetIntValue("EmuCore/GS", hack.ini_key, 0);
+        }
 
         if (state.effective == requested)
-            state.reason = ARMSX2GraphicsHackReason::Applied;
+            state.reason = from_game_layer ? ARMSX2GraphicsHackReason::PerGame : ARMSX2GraphicsHackReason::Applied;
         else if (hack.upscaling_only && gs.UpscaleMultiplier <= 1.0f)
             state.reason = ARMSX2GraphicsHackReason::NeedsUpscaling;
-        else if (ARMSX2GameDatabaseSetsHWFix(hack.hw_fix_id))
+        else if (database_sets[i])
             state.reason = ARMSX2GraphicsHackReason::FromGameDatabase;
         else
             state.reason = ARMSX2GraphicsHackReason::NeedsManualHacks;
 
         snapshot.push_back(state);
     }
+    settings_lock.unlock();
 
     {
         std::lock_guard<std::mutex> lock(s_graphics_hack_mutex);

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
@@ -49,6 +49,7 @@ extern "C" void ARMSX2_iOSCopyDeviceStats(int* outBatteryPercent, int* outTherma
 #include "GS/GSState.h"
 #include "SPU2/spu2.h"
 #include "GameList.h"
+#include "GameDatabase.h"
 #include "ps2/BiosTools.h"
 #include "pcsx2/Host.h"
 #include "pcsx2/INISettingsInterface.h"
@@ -60,12 +61,14 @@ extern "C" void ARMSX2_iOSCopyDeviceStats(int* outBatteryPercent, int* outTherma
 #include "common/MRCHelpers.h"
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
 #include <functional>
 #include <limits>
+#include <mutex>
 #include <optional>
 #include <string_view>
 #include <vector>
@@ -1963,6 +1966,39 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
         else
             si.DeleteValue("EmuCore/GS", "UserHacks_TCOffsetY");
 
+        // Overriding a hack for one game only counts if the GameDB stops writing that
+        // hack for that game, so the claim goes in this file too.
+        u32 perGameClaims = 0;
+        const auto claim = [&perGameClaims](GSUserHackOverride hack) {
+            perGameClaims |= 1u << static_cast<u32>(hack);
+        };
+        if (halfPixelOffset != ARMSX2UseGlobalIntSentinel)
+            claim(GSUserHackOverride::HalfPixelOffset);
+        if (roundSprite != ARMSX2UseGlobalIntSentinel)
+            claim(GSUserHackOverride::RoundSprite);
+        if (alignSpriteOverride)
+            claim(GSUserHackOverride::AlignSprite);
+        if (mergeSpriteOverride)
+            claim(GSUserHackOverride::MergeSprite);
+        if (wildArmsOffsetOverride)
+            claim(GSUserHackOverride::ForceEvenSpritePosition);
+        if (textureOffsetXOverride)
+            claim(GSUserHackOverride::TextureOffsetX);
+        if (textureOffsetYOverride)
+            claim(GSUserHackOverride::TextureOffsetY);
+
+        // The per-game layer replaces this key rather than merging into it, so the global
+        // claims have to be carried across or they vanish for any game with its own file,
+        // and the database takes those hacks straight back.
+        const u32 globalClaims = g_p44_settings_interface ?
+            static_cast<u32>(g_p44_settings_interface->GetIntValue("EmuCore/GS", "UserHackOverrides", 0)) : 0;
+        const u32 combinedClaims = globalClaims | perGameClaims;
+
+        if (combinedClaims != 0)
+            si.SetIntValue("EmuCore/GS", "UserHackOverrides", static_cast<int>(combinedClaims));
+        else
+            si.DeleteValue("EmuCore/GS", "UserHackOverrides");
+
         if (skipDrawStartOverride)
             si.SetIntValue("EmuCore/GS", "UserHacks_SkipDraw_Start", ARMSX2ClampInt(skipDrawStart, 0, 5000));
         else
@@ -2037,6 +2073,7 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
         si.DeleteValue("EmuCore", "EnablePatches");
         si.DeleteValue("EmuCore", "EnableGameFixes");
         si.DeleteValue("EmuCore/GS", "UserHacks");
+        si.DeleteValue("EmuCore/GS", "UserHackOverrides");
         si.DeleteValue("EmuCore/CPU", "CoreType");
         si.DeleteValue("EmuCore/CPU", "UseArm64Dynarec");
         si.DeleteValue("ARMSX2iOS/PerGame", "ManualMTVU");
@@ -2138,6 +2175,137 @@ static std::string ARMSX2PerGameSettingsPath(const std::string& serial, u32 crc)
 {
     FileSystem::CreateDirectoryPath(EmuFolders::GameSettings.c_str(), false);
     return VMManager::GetGameSettingsPath(serial, crc);
+}
+
+#pragma mark - Graphics hack state
+
+// Why a hack isn't doing what the screen says. Mirrored in GraphicsSettingsView.
+enum class ARMSX2GraphicsHackReason : int
+{
+    Applied = 0,
+    NeedsManualHacks,
+    NeedsUpscaling,
+    FromGameDatabase,
+    NoGame,
+};
+
+struct ARMSX2GraphicsHackDescriptor
+{
+    const char* ini_key;
+    GSUserHackOverride override_id;
+    GameDatabaseSchema::GSHWFixId hw_fix_id;
+    // Upscaling masks these at native res whatever else is true.
+    bool upscaling_only;
+    // Bools are written to the INI as true/false, so reading one back as an int just
+    // gives you the default and every row looks overridden.
+    bool is_bool;
+    int (*read)(const Pcsx2Config::GSOptions& gs);
+};
+
+struct ARMSX2GraphicsHackState
+{
+    const char* ini_key = "";
+    int effective = 0;
+    ARMSX2GraphicsHackReason reason = ARMSX2GraphicsHackReason::NoGame;
+    bool pinned = false;
+};
+
+static constexpr std::array<ARMSX2GraphicsHackDescriptor, 9> s_graphics_hacks = {{
+    {"UserHacks_align_sprite_X", GSUserHackOverride::AlignSprite, GameDatabaseSchema::GSHWFixId::AlignSprite, true, true,
+        [](const Pcsx2Config::GSOptions& gs) { return static_cast<int>(gs.UserHacks_AlignSpriteX); }},
+    {"UserHacks_merge_pp_sprite", GSUserHackOverride::MergeSprite, GameDatabaseSchema::GSHWFixId::MergeSprite, true, true,
+        [](const Pcsx2Config::GSOptions& gs) { return static_cast<int>(gs.UserHacks_MergePPSprite); }},
+    {"UserHacks_ForceEvenSpritePosition", GSUserHackOverride::ForceEvenSpritePosition, GameDatabaseSchema::GSHWFixId::ForceEvenSpritePosition, true, true,
+        [](const Pcsx2Config::GSOptions& gs) { return static_cast<int>(gs.UserHacks_ForceEvenSpritePosition); }},
+    {"UserHacks_NativePaletteDraw", GSUserHackOverride::NativePaletteDraw, GameDatabaseSchema::GSHWFixId::NativePaletteDraw, true, true,
+        [](const Pcsx2Config::GSOptions& gs) { return static_cast<int>(gs.UserHacks_NativePaletteDraw); }},
+    {"UserHacks_round_sprite_offset", GSUserHackOverride::RoundSprite, GameDatabaseSchema::GSHWFixId::RoundSprite, true, false,
+        [](const Pcsx2Config::GSOptions& gs) { return static_cast<int>(gs.UserHacks_RoundSprite); }},
+    {"UserHacks_HalfPixelOffset", GSUserHackOverride::HalfPixelOffset, GameDatabaseSchema::GSHWFixId::HalfPixelOffset, true, false,
+        [](const Pcsx2Config::GSOptions& gs) { return static_cast<int>(gs.UserHacks_HalfPixelOffset); }},
+    {"UserHacks_native_scaling", GSUserHackOverride::NativeScaling, GameDatabaseSchema::GSHWFixId::NativeScaling, true, false,
+        [](const Pcsx2Config::GSOptions& gs) { return static_cast<int>(gs.UserHacks_NativeScaling); }},
+    {"UserHacks_TCOffsetX", GSUserHackOverride::TextureOffsetX, GameDatabaseSchema::GSHWFixId::Count, true, false,
+        [](const Pcsx2Config::GSOptions& gs) { return static_cast<int>(gs.UserHacks_TCOffsetX); }},
+    {"UserHacks_TCOffsetY", GSUserHackOverride::TextureOffsetY, GameDatabaseSchema::GSHWFixId::Count, true, false,
+        [](const Pcsx2Config::GSOptions& gs) { return static_cast<int>(gs.UserHacks_TCOffsetY); }},
+}};
+
+static std::mutex s_graphics_hack_mutex;
+static std::vector<ARMSX2GraphicsHackState> s_graphics_hack_state;
+
+static const ARMSX2GraphicsHackDescriptor* ARMSX2FindGraphicsHack(const char* ini_key)
+{
+    for (const ARMSX2GraphicsHackDescriptor& hack : s_graphics_hacks) {
+        if (std::strcmp(hack.ini_key, ini_key) == 0)
+            return &hack;
+    }
+    return nullptr;
+}
+
+static bool ARMSX2GameDatabaseSetsHWFix(GameDatabaseSchema::GSHWFixId id)
+{
+    if (id == GameDatabaseSchema::GSHWFixId::Count)
+        return false;
+
+    const GameDatabaseSchema::GameEntry* game = GameDatabase::findGame(VMManager::GetDiscSerial());
+    if (!game)
+        return false;
+
+    for (const auto& [fix_id, value] : game->gsHWFixes) {
+        if (fix_id == id)
+            return true;
+    }
+    return false;
+}
+
+// CPU thread only: EmuConfig is its and the masks have only settled by the time an
+// apply is finished.
+extern "C" void ARMSX2_CaptureGraphicsHackState(void)
+{
+    std::vector<ARMSX2GraphicsHackState> snapshot;
+    snapshot.reserve(s_graphics_hacks.size());
+
+    const bool has_vm = VMManager::HasValidVM();
+    const Pcsx2Config::GSOptions& gs = EmuConfig.GS;
+
+    for (const ARMSX2GraphicsHackDescriptor& hack : s_graphics_hacks) {
+        ARMSX2GraphicsHackState state;
+        state.ini_key = hack.ini_key;
+        state.pinned = gs.IsUserHackPinned(hack.override_id);
+
+        if (!has_vm) {
+            state.reason = ARMSX2GraphicsHackReason::NoGame;
+            snapshot.push_back(state);
+            continue;
+        }
+
+        state.effective = hack.read(gs);
+        // The layered value, so a per-game override counts as what was asked for.
+        const int requested = hack.is_bool ?
+            static_cast<int>(Host::GetBoolSettingValue("EmuCore/GS", hack.ini_key, false)) :
+            Host::GetIntSettingValue("EmuCore/GS", hack.ini_key, 0);
+
+        if (state.effective == requested)
+            state.reason = ARMSX2GraphicsHackReason::Applied;
+        else if (hack.upscaling_only && gs.UpscaleMultiplier <= 1.0f)
+            state.reason = ARMSX2GraphicsHackReason::NeedsUpscaling;
+        else if (ARMSX2GameDatabaseSetsHWFix(hack.hw_fix_id))
+            state.reason = ARMSX2GraphicsHackReason::FromGameDatabase;
+        else
+            state.reason = ARMSX2GraphicsHackReason::NeedsManualHacks;
+
+        snapshot.push_back(state);
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(s_graphics_hack_mutex);
+        s_graphics_hack_state = std::move(snapshot);
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"ARMSX2GraphicsHackStateChanged" object:nil];
+    });
 }
 
 @implementation ARMSX2Bridge
@@ -3574,7 +3742,52 @@ static std::string ARMSX2PerGameSettingsPath(const std::string& serial, u32 crc)
         VMManager::ApplySettings();
         if (MTGS::IsOpen())
             MTGS::ApplySettings();
+        ARMSX2_CaptureGraphicsHackState();
     });
+}
+
+// The player's value and the value the game is running are two different things, and
+// the settings screen could only ever see the first one. MaskUserHacks,
+// MaskUpscalingHacks and the GameDB all sit in between and all of them settle on the
+// CPU thread, so snapshot there after an apply and let the UI read the copy.
++ (nonnull NSDictionary<NSString *, id> *)graphicsHackState
+{
+    NSMutableDictionary<NSString*, id>* result = [NSMutableDictionary dictionary];
+
+    // The snapshot is only meaningful while a game is up. It is taken again on shutdown,
+    // but whether the VM is already gone by then decides what it catches, and a leftover
+    // "the game database is setting this" back in the menu would be nonsense.
+    if (!VMManager::HasValidVM())
+        return result;
+
+    std::lock_guard<std::mutex> lock(s_graphics_hack_mutex);
+    for (const ARMSX2GraphicsHackState& hack : s_graphics_hack_state) {
+        result[@(hack.ini_key)] = @{
+            @"effective": @(hack.effective),
+            @"reason": @(static_cast<int>(hack.reason)),
+            @"pinned": @(hack.pinned),
+        };
+    }
+    return result;
+}
+
+// Writes the claim only. The caller asks for the apply, so claiming a hack and changing
+// its value in the same gesture coalesce into one instead of applying twice. Bit math
+// stays here rather than in Swift because the enum lives in Config.h.
++ (void)setGraphicsHackPinned:(nonnull NSString *)iniKey pinned:(BOOL)pinned
+{
+    if (!g_p44_settings_interface)
+        return;
+
+    const ARMSX2GraphicsHackDescriptor* descriptor = ARMSX2FindGraphicsHack(iniKey.UTF8String);
+    if (!descriptor)
+        return;
+
+    const u32 bit = 1u << static_cast<u32>(descriptor->override_id);
+    u32 mask = static_cast<u32>(g_p44_settings_interface->GetIntValue("EmuCore/GS", "UserHackOverrides", 0));
+    mask = pinned ? (mask | bit) : (mask & ~bit);
+    g_p44_settings_interface->SetIntValue("EmuCore/GS", "UserHackOverrides", static_cast<int>(mask));
+    ARMSX2ScheduleINISave();
 }
 
 // Force any deferred base-settings INI write to disk immediately.

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
@@ -116,6 +116,19 @@ static void ARMSX2FlushINISave()
 static NSDate* s_lastNVMSaveDate = nil;
 static ARMSX2RetroAchievementsToastInfo* s_pendingRetroAchievementsNotification = nil;
 
+// This file has no ARC, so a static holding an object has to own it. Both writers below
+// are handed autoreleased objects, and a raw assignment leaves the static pointing at
+// freed memory once the pool drains.
+static void ARMSX2SetLastNVMSaveDate(NSDate* date)
+{
+#if __has_feature(objc_arc)
+    s_lastNVMSaveDate = date;
+#else
+    [s_lastNVMSaveDate release];
+    s_lastNVMSaveDate = [date retain];
+#endif
+}
+
 @implementation ARMSX2SaveStateSlotInfo
 @end
 
@@ -1302,7 +1315,7 @@ static NSInteger ARMSX2BackupAssignedMemoryCards(const char* reason, s32 stateSl
 static bool ARMSX2FlushNVRAMAndMemoryCards(const char* reason)
 {
     cdvdSaveNVRAM();
-    s_lastNVMSaveDate = [NSDate date];
+    ARMSX2SetLastNVMSaveDate([NSDate date]);
 
     if (!VMManager::HasValidVM()) {
         NSLog(@"[ARMSX2Bridge] Save-state flush skipped memory cards reason=%s validVM=0",
@@ -2344,7 +2357,7 @@ extern "C" void ARMSX2_CaptureGraphicsHackState(void)
 
 + (void)saveNVRAM {
     cdvdSaveNVRAM();
-    s_lastNVMSaveDate = [NSDate date];
+    ARMSX2SetLastNVMSaveDate([NSDate date]);
     NSLog(@"[ARMSX2Bridge] NVM saved at %@", s_lastNVMSaveDate);
 }
 
@@ -4910,6 +4923,10 @@ extern "C" void ARMSX2_CaptureGraphicsHackState(void)
 + (nullable ARMSX2RetroAchievementsToastInfo *)consumePendingRetroAchievementsNotification {
     __block ARMSX2RetroAchievementsToastInfo* pending = nil;
     void (^consume)(void) = ^{
+        // Hands the static's reference to `pending`, which is why this clears the pointer
+        // by hand instead of calling ARMSX2ClearPendingRetroAchievementsNotification().
+        // That one releases, and the autorelease at the end of this function is already
+        // paying for the reference. Using it here would over-release.
         pending = s_pendingRetroAchievementsNotification;
         s_pendingRetroAchievementsNotification = nil;
     };

--- a/platforms/ios/app/src/main/cpp/IOS/HostImpls.mm
+++ b/platforms/ios/app/src/main/cpp/IOS/HostImpls.mm
@@ -182,6 +182,9 @@ namespace Host
     void OnGameChanged(const std::string&, const std::string&, const std::string&, const std::string&, unsigned int, unsigned int)
     {
         ARMSX2_PostRuntimeMenuStateChanged();
+        // The GameDB's hardware fixes only land once the serial is known, so this is the
+        // first point where the effective hack values mean anything.
+        ARMSX2_CaptureGraphicsHackState();
     }
     void OnVMDestroyed() {}
     void SetFullscreen(bool) {}

--- a/platforms/ios/app/src/main/cpp/IOS/IOSRuntime.h
+++ b/platforms/ios/app/src/main/cpp/IOS/IOSRuntime.h
@@ -82,6 +82,9 @@ extern "C" void ARMSX2_PostRetroAchievementsStateChanged(void);
 extern "C" void ARMSX2_PostRetroAchievementsNotification(const char* title, const char* message,
 	const char* badgePath, float duration);
 extern "C" void ARMSX2_PostRuntimeMenuStateChanged(void);
+// Snapshots the upscaling hacks the running game ended up with, after the masks and
+// the GameDB have had their say. CPU thread only, since it reads EmuConfig.
+extern "C" void ARMSX2_CaptureGraphicsHackState(void);
 // Runtime telemetry gate (env-gated, cached).
 bool ARMSX2IOSRuntimeTelemetryEnabled();
 

--- a/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
@@ -1076,6 +1076,52 @@ final class SettingsStore {
         _upscalerConfig.onSet?(upscaler)
     }}
 
+    /// Why an upscaling hack isn't doing what the row says. Mirrors the enum in
+    /// ARMSX2Bridge.mm; the values cross as ints.
+    enum GraphicsHackReason: Int {
+        case applied = 0
+        case needsManualHacks
+        case needsUpscaling
+        case fromGameDatabase
+        case noGame
+    }
+
+    struct GraphicsHackStatus {
+        var effective: Int
+        var reason: GraphicsHackReason
+        var pinned: Bool
+    }
+
+    /// What the running game really has, keyed by INI key. The INI is what the player
+    /// asked for; between the two sit the two mask passes and the GameDB, and only the
+    /// core can see the result. Empty until a game is running.
+    var graphicsHackStatus: [String: GraphicsHackStatus] = [:]
+
+    func graphicsHack(_ key: String) -> GraphicsHackStatus? {
+        graphicsHackStatus[key]
+    }
+
+    func refreshGraphicsHackStatus() {
+        var parsed: [String: GraphicsHackStatus] = [:]
+        for (key, value) in ARMSX2Bridge.graphicsHackState() {
+            guard let entry = value as? [String: Any],
+                  let effective = entry["effective"] as? Int,
+                  let rawReason = entry["reason"] as? Int,
+                  let reason = GraphicsHackReason(rawValue: rawReason),
+                  let pinned = entry["pinned"] as? Bool else { continue }
+            parsed[key] = GraphicsHackStatus(effective: effective, reason: reason, pinned: pinned)
+        }
+        graphicsHackStatus = parsed
+    }
+
+    /// Claims a hack for the player so the GameDB stops overwriting that one. Shares the
+    /// debounced apply with the row's own write, so claiming and changing in one gesture
+    /// costs one apply rather than two.
+    func setGraphicsHackPinned(_ key: String, _ pinned: Bool) {
+        ARMSX2Bridge.setGraphicsHackPinned(key, pinned: pinned)
+        requestGraphicsApplyGuarded()
+    }
+
     /// Homogeneous bool GS hacks — see SettingsStore+Graphics.swift for the option list.
     var gsBoolHacks: [String: Bool] = [:]
 
@@ -2673,6 +2719,9 @@ final class SettingsStore {
 
     /// Reset graphics settings to ARMSX2 iOS defaults
     func resetGraphicsDefaults() {
+        // Hand the hacks back to the game database, otherwise a reset leaves whatever was
+        // claimed still overriding it.
+        ARMSX2Bridge.setINIInt("EmuCore/GS", key: "UserHackOverrides", value: 0)
         renderer = 17           // Metal
         upscaleMultiplier = 1.0 // Native PS2
         vsyncQueueSize = 8

--- a/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
@@ -1084,6 +1084,7 @@ final class SettingsStore {
         case needsUpscaling
         case fromGameDatabase
         case noGame
+        case perGame
     }
 
     struct GraphicsHackStatus {

--- a/platforms/ios/app/src/main/swift/Views/GameScreenView.swift
+++ b/platforms/ios/app/src/main/swift/Views/GameScreenView.swift
@@ -146,6 +146,8 @@ struct EmulationOnlyGameView: View {
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                     }
                     .ignoresSafeArea(.container, edges: .bottom)
+                    // Same top safe-area strip as the full game screen, same reason.
+                    .background(Color.black.ignoresSafeArea())
                 } else {
                     ZStack {
                         accessibleMetalSurface
@@ -406,6 +408,10 @@ struct GameScreenView: View {
                         }
                     }
                     .ignoresSafeArea(.container, edges: .bottom)
+                    // The game stays out of the top safe area on purpose, so something has
+                    // to fill it. Black rather than leaving it to whatever is behind: the
+                    // root controller is only black because a boot notification made it so.
+                    .background(Color.black.ignoresSafeArea())
                 }
             }
             .preference(key: GameScreenSizePreferenceKey.self, value: geo.size)

--- a/platforms/ios/app/src/main/swift/Views/RootView.swift
+++ b/platforms/ios/app/src/main/swift/Views/RootView.swift
@@ -61,8 +61,17 @@ struct RootView: View {
 
     var body: some View {
         ZStack {
+            // Menu backdrop, and only that. It used to live inside the menu branch of a
+            // switch; once this became a ZStack it started painting over gameplay too,
+            // where it is near white in light mode and shows in the strip of top safe
+            // area the portrait game view leaves clear for the Dynamic Island. Same
+            // condition as the layer below so the two cannot drift apart.
             Color(uiColor: .systemGroupedBackground)
                 .ignoresSafeArea()
+                .opacity(
+                    appState.currentScreen == .menu ||
+                    appState.gameplayLaunchBackgroundVisible ? 1 : 0
+                )
 
             PersistentMenuBackgroundLayer(host: backgroundHost)
                 .opacity(

--- a/platforms/ios/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
@@ -21,6 +21,54 @@ struct GraphicsSettingsView: View {
         !settings.enableGameDBHardwareFixes
     }
 
+    /// Touching a hack claims it, which is what stops the game database overwriting that
+    /// one on the next apply. Without this the row writes the INI and the database wins.
+    private func claiming<T: Equatable>(_ key: String, _ value: Binding<T>) -> Binding<T> {
+        Binding(
+            get: { value.wrappedValue },
+            set: { newValue in
+                guard newValue != value.wrappedValue else { return }
+                value.wrappedValue = newValue
+                settings.setGraphicsHackPinned(key, true)
+            }
+        )
+    }
+
+    /// One line under a row when what the game is running isn't what the row says, plus
+    /// the way back to the database value once the player has claimed it.
+    @ViewBuilder
+    private func hackNote(_ key: String, shown: Int) -> some View {
+        if let status = settings.graphicsHack(key), status.reason != .noGame {
+            if status.effective != shown, let explanation = explanation(for: status.reason) {
+                Text(explanation)
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+            if status.pinned {
+                Button(settings.localized("Use the game database value")) {
+                    settings.setGraphicsHackPinned(key, false)
+                }
+                .font(.caption)
+            }
+        }
+    }
+
+    private func explanation(for reason: SettingsStore.GraphicsHackReason) -> String? {
+        switch reason {
+        case .needsUpscaling:
+            return settings.localized("Ignored at 1x Internal Resolution.")
+        case .fromGameDatabase:
+            if let game = appState.runningGameName {
+                return settings.localized("The game database is setting this for") + " \(game)."
+            }
+            return settings.localized("The game database is setting this for this game.")
+        case .needsManualHacks:
+            return settings.localized("The automatic graphics fixes are in charge of this one.")
+        case .applied, .noGame:
+            return nil
+        }
+    }
+
     private var skipDrawStartBinding: Binding<Int> {
         Binding(
             get: { settings.skipDrawStart },
@@ -254,7 +302,7 @@ struct GraphicsSettingsView: View {
                     get: { manualAdvancedHacks },
                     set: { settings.enableGameDBHardwareFixes = !$0 }
                 ))
-                Text(settings.localized("GameDB Graphics Fixes are safest for most games. Manual Advanced Hacks disable those automatic graphics fixes and allow the sprite, texture-offset, and Skipdraw values below. Reset/relaunch may be needed."))
+                Text(settings.localized("GameDB Graphics Fixes are safest for most games, and turning this on drops all of them. You don't need it to change one sprite or texture-offset value below: changing one keeps your answer for that setting and leaves the rest automatic. Skipdraw still needs this on."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 // MaskUpscalingHacks() zeroes these unless the multiplier is above 1, so the
@@ -277,7 +325,10 @@ struct GraphicsSettingsView: View {
                         .foregroundStyle(.orange)
                 }
 
-                Picker(settings.localized("Half-pixel Offset"), selection: $settings.halfPixelOffset) {
+                // These stay usable with the automatic fixes on. Changing one claims it,
+                // so the game database keeps every other fix for the game and loses only
+                // the one that was argued with.
+                Picker(settings.localized("Half-pixel Offset"), selection: claiming("UserHacks_HalfPixelOffset", $settings.halfPixelOffset)) {
                     Text(settings.localized("Off")).tag(0)
                     Text(settings.localized("Normal / Vertex")).tag(1)
                     Text(settings.localized("Special / Texture")).tag(2)
@@ -285,24 +336,24 @@ struct GraphicsSettingsView: View {
                     Text(settings.localized("Align to Native")).tag(4)
                     Text(settings.localized("Align to Native + Texture Offset")).tag(5)
                 }
-                .disabled(!manualAdvancedHacks)
+                hackNote("UserHacks_HalfPixelOffset", shown: settings.halfPixelOffset)
 
-                Picker(settings.localized("Round Sprite"), selection: $settings.roundSprite) {
+                Picker(settings.localized("Round Sprite"), selection: claiming("UserHacks_round_sprite_offset", $settings.roundSprite)) {
                     Text(settings.localized("Off")).tag(0)
                     Text(settings.localized("Half")).tag(1)
                     Text(settings.localized("Full")).tag(2)
                 }
-                .disabled(!manualAdvancedHacks)
+                hackNote("UserHacks_round_sprite_offset", shown: settings.roundSprite)
 
-                Toggle(settings.localized("Align Sprite"), isOn: $settings.alignSprite)
-                    .disabled(!manualAdvancedHacks)
-                Toggle(settings.localized("Merge Sprite"), isOn: $settings.mergeSprite)
-                    .disabled(!manualAdvancedHacks)
-                Toggle(settings.localized("Wild Arms Offset"), isOn: $settings.wildArmsOffset)
-                    .disabled(!manualAdvancedHacks)
+                Toggle(settings.localized("Align Sprite"), isOn: claiming("UserHacks_align_sprite_X", $settings.alignSprite))
+                hackNote("UserHacks_align_sprite_X", shown: settings.alignSprite ? 1 : 0)
+                Toggle(settings.localized("Merge Sprite"), isOn: claiming("UserHacks_merge_pp_sprite", $settings.mergeSprite))
+                hackNote("UserHacks_merge_pp_sprite", shown: settings.mergeSprite ? 1 : 0)
+                Toggle(settings.localized("Wild Arms Offset"), isOn: claiming("UserHacks_ForceEvenSpritePosition", $settings.wildArmsOffset))
+                hackNote("UserHacks_ForceEvenSpritePosition", shown: settings.wildArmsOffset ? 1 : 0)
 
-                ClampedIntField(title: settings.localized("Texture Offset X"), value: $settings.textureOffsetX, range: SettingsStore.textureOffsetRange, isEnabled: manualAdvancedHacks)
-                ClampedIntField(title: settings.localized("Texture Offset Y"), value: $settings.textureOffsetY, range: SettingsStore.textureOffsetRange, isEnabled: manualAdvancedHacks)
+                ClampedIntField(title: settings.localized("Texture Offset X"), value: claiming("UserHacks_TCOffsetX", $settings.textureOffsetX), range: SettingsStore.textureOffsetRange)
+                ClampedIntField(title: settings.localized("Texture Offset Y"), value: claiming("UserHacks_TCOffsetY", $settings.textureOffsetY), range: SettingsStore.textureOffsetRange)
                 Text(settings.localized("Texture offsets are advanced troubleshooting values. Type a value and clamp to range. Default is 0."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -425,6 +476,12 @@ struct GraphicsSettingsView: View {
         }
         .navigationTitle(settings.localized("Graphics"))
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear { settings.refreshGraphicsHackStatus() }
+        // The core re-snapshots after every apply and on a game change, since that is
+        // when the masks and the database have finished arguing.
+        .onReceive(NotificationCenter.default.publisher(for: Notification.Name("ARMSX2GraphicsHackStateChanged"))) { _ in
+            settings.refreshGraphicsHackStatus()
+        }
         .confirmationDialog(
             settings.localized("Clear Shader Cache?"),
             isPresented: $showShaderCacheClearConfirm,

--- a/platforms/ios/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
@@ -64,6 +64,10 @@ struct GraphicsSettingsView: View {
             return settings.localized("The game database is setting this for this game.")
         case .needsManualHacks:
             return settings.localized("The automatic graphics fixes are in charge of this one.")
+        case .perGame:
+            // This screen edits the global value, so the row can honestly disagree with
+            // what the game is running. Change it in the game's own settings.
+            return settings.localized("This game has its own setting for this, and that is what it is using.")
         case .applied, .noGame:
             return nil
         }


### PR DESCRIPTION
Someone reported that Align Sprite gets stuck: turn it on and it stays on, turn it off and the ghosting is still there. We already shipped a fix for this. That fix was real and it did work, it closed a gap where most graphics keys wrote the INI and never told the running game. It just turned out to be the first of seven gates the value has to get through, and the other six are why the report kept coming back.

Two of them explain the whole thing. For the 227 games the game database has an Align Sprite entry for, your value gets wiped and the database writes its own, so the row says off while the game runs it on. And the hack rewrites sprite positions into a render target, so switching it off never repaints a target the game does not redraw. Those pixels sit there until the scene changes.

Two smaller fixes ride along at the end. They are unrelated to the hacks and can be read on their own.

### What changed

* Switching a geometry hack off takes effect on screen straight away. The cached targets holding the old pixels are dropped now, which is the ghosting that would not go away.
* You can change one hack without losing every automatic fix for that game. Before, arguing with a single setting meant turning on Manual Advanced Hacks, which throws the whole set away and usually trades one glitch for a different one. Change one now and the game database keeps everything else it knows.
* When a setting is not doing what the row says, the row says why. Ignored at 1x, the game database choosing it, or the automatic fixes still being in charge.
* If a game has its own setting for one of these, the row tells you that too, instead of quietly showing you the global value while the game runs something else.
* The sprite and texture offset rows are no longer greyed out. Skipdraw still needs the master toggle, since nothing claims that one.
* A setting you claimed can be handed back to the game database, and resetting graphics defaults hands all of them back.
* Manual hacks are now actually switched off on the BIOS screen. The code said it was doing that and was not, because the masking had already run by the time the flag was cleared.
* Light mode no longer paints a white strip across the top of the screen while a game is running. The menu backdrop had been covering the whole window since the root view became a stack, and that strip is the top safe area the portrait game view leaves clear for the Dynamic Island. Dark mode hid it because the same colour is nearly black there.
* One more object in the bridge owns what it points at, matching the toast lifetime fix that just landed.

### Notes for reviewers

The claim mask sits outside the bitfield union in GSOptions on purpose. That packing is what OptionsAreEqual compares wholesale, and this is not a hack value, it is who owns one. It gets its own comparison so that claiming or releasing a setting counts as a change even when no value moved with it.

MaskUpscalingHacks deliberately ignores a claim, and so does the strip that runs before the ELF boots. Below 2x the renderer skips these whatever the config says, so honouring a claim there would only leave GSConfig and the settings overlay claiming something that never runs. The BIOS one is a safety measure rather than a preference: whether a hack is safe on the BIOS screen has nothing to do with whether someone asked for it.

Per game overrides carry the global claims across when they are written. The per game layer replaces that key rather than merging into it, so without that a game with its own settings file would silently lose every claim made globally and the database would take those hacks straight back.

The two texture offset bits are separate, and the new one is appended to the end of the enum rather than slotted in beside its partner, so a mask already written to an INI keeps meaning what it meant.

Qt and Big Picture never set a claim bit, so the mask stays zero and they behave exactly as before.

Reading the effective values takes the settings lock once for the whole sweep and reads the base layer and the game layer by hand. The Host getters take that same lock per call and it is not recursive, so once it is held nothing in there may call one. The game database lookups happen before the lock for the same reason. Worth remembering if that loop grows, because the cost of forgetting is a hung CPU thread rather than a wrong string.

Toggling a hack now costs a texture cache purge, one frame, same as every other entry already in that list.

Built for device. The reasoning is traced end to end and it compiles clean, but none of it has been run on hardware. Three things worth trying first: switching Align Sprite off mid game on a title that shows the ghosting, which fails on the current build, a game with its own override set, since that is the case where two settings layers and the database can all disagree at once, and the top of the screen in light mode with a game running.
