### PR TITLE
iOS: stop the cheats switch claiming cheats are on under Hardcore

### DIFF
--- a/platforms/ios/app/src/main/swift/Views/Settings/EmulatorSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/EmulatorSettingsView.swift
@@ -7,6 +7,22 @@ struct EmulatorSettingsView: View {
     @State private var settings = SettingsStore.shared
     @State private var stikDebugOpenFailed = false
     @State private var stikDebugOpenInProgress = false
+    // Cached rather than asked per redraw: the lookup takes the achievements lock, and
+    // this sits in a Form that rebuilds on every other row.
+    @State private var hardcoreBlocksCheats = false
+
+    /// Hardcore only clears EnableCheats in the running config, so the INI this row reads
+    /// still says on and the row lies. The write is dropped further down as well, without
+    /// a word, so turning it on looks like it worked until something reloads.
+    private var cheatsBinding: Binding<Bool> {
+        Binding(
+            get: { hardcoreBlocksCheats ? false : settings.enableCheats },
+            set: { newValue in
+                guard !hardcoreBlocksCheats else { return }
+                settings.enableCheats = newValue
+            }
+        )
+    }
 
     var body: some View {
         Form {
@@ -266,7 +282,13 @@ struct EmulatorSettingsView: View {
                 Toggle(settings.localized("GameDB Core Fixes"), isOn: $settings.enableGameFixes)
                 Toggle(settings.localized("GameDB Graphics Fixes"), isOn: $settings.enableGameDBHardwareFixes)
                 Toggle(settings.localized("GameDB PNACH Patches"), isOn: $settings.enablePatches)
-                Toggle(settings.localized("Enable PNACH Cheats"), isOn: $settings.enableCheats)
+                Toggle(settings.localized("Enable PNACH Cheats"), isOn: cheatsBinding)
+                    .disabled(hardcoreBlocksCheats)
+                if hardcoreBlocksCheats {
+                    Text(settings.localized("Hardcore Mode is turning cheats off. Switch it off in RetroAchievements to use them again."))
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
                 Toggle(settings.localized("Widescreen Patches"), isOn: $settings.enableWidescreenPatches)
                 Toggle(settings.localized("No-Interlacing Patches"), isOn: $settings.enableNoInterlacingPatches)
 
@@ -343,6 +365,10 @@ struct EmulatorSettingsView: View {
         .navigationTitle(settings.localized("Emulator"))
         .navigationBarTitleDisplayMode(.inline)
         .dynamicTypeSize(...DynamicTypeSize.accessibility3)
+        .onAppear { hardcoreBlocksCheats = PatchStore.hardcoreBlocksPnachContent() }
+        .onReceive(NotificationCenter.default.publisher(for: Notification.Name("ARMSX2RetroAchievementsStateChanged"))) { _ in
+            hardcoreBlocksCheats = PatchStore.hardcoreBlocksPnachContent()
+        }
     }
 
     private static func formatFPS(_ value: Float) -> String {


### PR DESCRIPTION
Turn Hardcore Mode on, go to Emulator settings, and Enable PNACH Cheats still shows enabled. Tap it and nothing happens. Cheats really are off by then, so the row is simply wrong about it.

### What changed

* The Enable PNACH Cheats row now reports what is actually in force rather than what is stored, greys out while Hardcore Mode is on, and says which setting is holding it.

### Why it read wrong

Hardcore clears EnableCheats in the running config only. The INI keeps saying true, and this row reads the INI, so it kept advertising a setting that stopped being in force the moment Hardcore came on. Turning it back on is refused down in the bridge with no message, which is why tapping it looked broken rather than blocked.

### Notes for reviewers

Nothing about which cheats apply changes here. The core already refuses them three separate ways under Hardcore: the challenge mode enforcement clears EnableCheats, ReloadEnabledLists empties the enabled cheat list, and the pnach walk will not even enumerate cheat files from disk. iOS reloads the patch lists the moment Hardcore toggles, so it does not wait for a reboot either. I went looking for cheats still firing and could not find a path where they do. If anyone has a repro where a cheat keeps working under Hardcore, that is a different bug and worth its own report.

The check reuses PatchStore.hardcoreBlocksPnachContent, which the Cheats and Patches manager already uses, so the two screens cannot end up disagreeing about whether Hardcore is blocking anything.

It is cached in state rather than asked for on every redraw. The lookup takes the achievements lock, and this row sits in a Form that rebuilds whenever anything else on the screen changes. The manager view calls it per row inside a list, which is fine there and wasteful here.

The per game side was checked and needed nothing. Its enableCheats value round trips through the bridge but no per game toggle renders it, so there was nothing to gate.

Built for device. Not run on hardware, so the greyed out row and its caption have not been seen on a screen.
