### PR TITLE
iOS: stop writing the GS thread's config from the CPU and UI threads

### DIFF
--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
@@ -3419,10 +3419,13 @@ extern "C" void ARMSX2_CaptureGraphicsHackState(void)
     // GSConfig belongs to the GS thread and EmuConfig to the CPU thread; this is
     // called from the UI. Both live in a bitfield, so an off-thread write can drop
     // a neighbouring flag -- including the ones that decide whether GSUpdateConfig
-    // tears the device down.
+    // tears the device down. So write only the one this thread owns and let the
+    // normal push carry it over. The position is not among the flags ImGuiOverlays
+    // re-copies every frame, so without the push it would not arrive at all.
     Host::RunOnCPUThread([pos]() {
         EmuConfig.GS.OsdPerformancePos = pos;
-        GSConfig.OsdPerformancePos = pos;
+        if (MTGS::IsOpen())
+            MTGS::ApplySettings();
     });
 }
 
@@ -3523,23 +3526,26 @@ extern "C" void ARMSX2_CaptureGraphicsHackState(void)
     const bool inputs = full;
 
     // Same ownership problem as setPerformanceOverlayVisible: these are bitfield
-    // members of the CPU and GS threads' configs, written here from the UI.
+    // members of the CPU and GS threads' configs, written here from the UI. Only the
+    // CPU thread's copy gets written now. No push either, deliberately: ImGuiOverlays
+    // re-copies every one of these out of EmuConfig.GS on the GS thread each frame, so
+    // pushing would only add a queue drain per tap of the preset picker.
     Host::RunOnCPUThread([=]() {
-        EmuConfig.GS.OsdShowFPS = GSConfig.OsdShowFPS = fps;
-        EmuConfig.GS.OsdShowVPS = GSConfig.OsdShowVPS = vps;
-        EmuConfig.GS.OsdShowSpeed = GSConfig.OsdShowSpeed = speed;
-        EmuConfig.GS.OsdShowCPU = GSConfig.OsdShowCPU = cpu;
-        EmuConfig.GS.OsdShowGPU = GSConfig.OsdShowGPU = gpu;
-        EmuConfig.GS.OsdShowResolution = GSConfig.OsdShowResolution = resolution;
-        EmuConfig.GS.OsdShowGSStats = GSConfig.OsdShowGSStats = gsStats;
-        EmuConfig.GS.OsdShowFrameTimes = GSConfig.OsdShowFrameTimes = frameTimes;
-        EmuConfig.GS.OsdShowVersion = GSConfig.OsdShowVersion = version;
-        EmuConfig.GS.OsdShowHardwareInfo = GSConfig.OsdShowHardwareInfo = hardwareInfo;
-        EmuConfig.GS.OsdShowIndicators = GSConfig.OsdShowIndicators = indicators;
-        EmuConfig.GS.OsdShowSettings = GSConfig.OsdShowSettings = settings;
-        EmuConfig.GS.OsdShowInputs = GSConfig.OsdShowInputs = inputs;
-        GSConfig.OsdShowVideoCapture = false;
-        GSConfig.OsdShowInputRec = false;
+        EmuConfig.GS.OsdShowFPS = fps;
+        EmuConfig.GS.OsdShowVPS = vps;
+        EmuConfig.GS.OsdShowSpeed = speed;
+        EmuConfig.GS.OsdShowCPU = cpu;
+        EmuConfig.GS.OsdShowGPU = gpu;
+        EmuConfig.GS.OsdShowResolution = resolution;
+        EmuConfig.GS.OsdShowGSStats = gsStats;
+        EmuConfig.GS.OsdShowFrameTimes = frameTimes;
+        EmuConfig.GS.OsdShowVersion = version;
+        EmuConfig.GS.OsdShowHardwareInfo = hardwareInfo;
+        EmuConfig.GS.OsdShowIndicators = indicators;
+        EmuConfig.GS.OsdShowSettings = settings;
+        EmuConfig.GS.OsdShowInputs = inputs;
+        EmuConfig.GS.OsdShowVideoCapture = false;
+        EmuConfig.GS.OsdShowInputRec = false;
     });
 }
 

--- a/platforms/ios/app/src/main/cpp/IOS/SceneDelegate.mm
+++ b/platforms/ios/app/src/main/cpp/IOS/SceneDelegate.mm
@@ -31,6 +31,7 @@
 #include "pcsx2/Counters.h"           // g_FrameCount
 #include "pcsx2/GameList.h"
 #include "pcsx2/Host.h"
+#include "pcsx2/MTGS.h"
 #include "pcsx2/PerformanceMetrics.h"
 #include "pcsx2/R5900.h"              // cpuRegs
 #include "pcsx2/VMManager.h"
@@ -1131,6 +1132,12 @@ static void ARMSX2StartJITKeepalive()
                     static_cast<int>(VMManager::GetState()), ::g_FrameCount);
                 std::fflush(stderr);
                 ARMSX2ApplyIOSOsdPresetFromConfig("post-vm-initialize");
+                // The only one of the three OSD apply points that runs with the GS already
+                // open, so the overlay position needs pushing rather than just being left in
+                // EmuConfig. Safe here and nowhere else: this is the VM thread, which is what
+                // MTGS::RunOnGSThread asserts on.
+                if (MTGS::IsOpen())
+                    MTGS::ApplySettings();
                 std::fprintf(stderr, "@@BOOT_POST_INIT@@ stage=after_osd state=%d frame=%u\n",
                     static_cast<int>(VMManager::GetState()), ::g_FrameCount);
                 std::fflush(stderr);

--- a/platforms/ios/app/src/main/cpp/ios_main.mm
+++ b/platforms/ios/app/src/main/cpp/ios_main.mm
@@ -842,36 +842,28 @@ void ARMSX2SetIOSOsdFlags(bool show_fps, bool show_vps, bool show_speed, bool sh
     bool show_settings, bool show_inputs, bool show_frame_times, bool show_version,
     bool show_hardware_info)
 {
+    // EmuConfig only. GSConfig belongs to the GS thread, and this runs on whichever
+    // thread the caller happens to be on -- the UIKit one at scene connect. These are
+    // bitfields sharing a word, so writing one from here is a read-modify-write against
+    // whatever the GS thread is doing to its neighbours.
+    //
+    // Nothing is lost by dropping the second write: ImGuiOverlays copies all of these out
+    // of EmuConfig.GS into GSConfig every frame, on the GS thread, right before it draws.
     EmuConfig.GS.OsdShowFPS = show_fps;
-    GSConfig.OsdShowFPS = show_fps;
     EmuConfig.GS.OsdShowVPS = show_vps;
-    GSConfig.OsdShowVPS = show_vps;
     EmuConfig.GS.OsdShowSpeed = show_speed;
-    GSConfig.OsdShowSpeed = show_speed;
     EmuConfig.GS.OsdShowCPU = show_cpu;
-    GSConfig.OsdShowCPU = show_cpu;
     EmuConfig.GS.OsdShowGPU = show_gpu;
-    GSConfig.OsdShowGPU = show_gpu;
     EmuConfig.GS.OsdShowResolution = show_resolution;
-    GSConfig.OsdShowResolution = show_resolution;
     EmuConfig.GS.OsdShowGSStats = show_gs_stats;
-    GSConfig.OsdShowGSStats = show_gs_stats;
     EmuConfig.GS.OsdShowIndicators = show_indicators;
-    GSConfig.OsdShowIndicators = show_indicators;
     EmuConfig.GS.OsdShowSettings = show_settings;
-    GSConfig.OsdShowSettings = show_settings;
     EmuConfig.GS.OsdShowInputs = show_inputs;
-    GSConfig.OsdShowInputs = show_inputs;
     EmuConfig.GS.OsdShowFrameTimes = show_frame_times;
-    GSConfig.OsdShowFrameTimes = show_frame_times;
     EmuConfig.GS.OsdShowVersion = show_version;
-    GSConfig.OsdShowVersion = show_version;
     EmuConfig.GS.OsdShowHardwareInfo = show_hardware_info;
-    GSConfig.OsdShowHardwareInfo = show_hardware_info;
     EmuConfig.GS.OsdShowVideoCapture = false;
-    GSConfig.OsdShowVideoCapture = false;
     EmuConfig.GS.OsdShowInputRec = false;
-    GSConfig.OsdShowInputRec = false;
 }
 
 void ARMSX2WriteIOSOsdFlagsToSettings()
@@ -919,8 +911,11 @@ void ARMSX2ApplyIOSOsdPresetFromConfig(const char* reason)
     int position = s_settings_interface->GetIntValue("EmuCore/GS", "OsdPerformancePos", static_cast<int>(OsdOverlayPos::TopRight));
     if (position == static_cast<int>(OsdOverlayPos::TopCenter))
         position = static_cast<int>(OsdOverlayPos::TopRight);
+    // Not mirrored per frame the way the flags above are, so this one really does have to
+    // be pushed. Not from here though: this function has no thread hop and one of its
+    // callers is the UIKit thread, where MTGS::RunOnGSThread asserts. The call site that
+    // needs it is the only one running after the GS opens, and it pushes there.
     EmuConfig.GS.OsdPerformancePos = static_cast<OsdOverlayPos>(position);
-    GSConfig.OsdPerformancePos = static_cast<OsdOverlayPos>(position);
 
     Console.WriteLn("@@OSD@@ preset=%d position=%d reason=%s fps=%d vps=%d speed=%d gpu=%d device_stats=%d frame_times=%d version=%d hardware=%d",
         s_settings_interface->GetIntValue("ARMSX2iOS/UI", "OsdPreset", 0), position, reason ? reason : "unknown",


### PR DESCRIPTION
The iOS OSD paths wrote both EmuConfig.GS and the global GSConfig. GSConfig belongs to the GS thread, which reads those fields while it draws, and the writers run on the CPU thread and, at scene connect, the UIKit one. They are bitfields packed into a shared word, so each write is a read modify write racing whatever the GS thread is doing to the neighbours.

### What changed

* The OSD paths no longer write the GS thread's config from another thread. Nothing about when the OSD updates changes.

### Why the flags did not need a replacement

ImGuiOverlays copies all thirteen OsdShow fields out of EmuConfig.GS into GSConfig on the GS thread, every frame, immediately before drawing. The second write was never what delivered them. Dropping it changes nothing about timing, and no push was added in its place: that would have put a queue drain behind every tap of the preset picker for a value already being delivered.

The overlay position is not in that per frame copy, so that one is pushed, from the two places that are provably on the CPU thread. The bridge already had a hop; the boot path pushes at the one site that runs after the GS is open.

### Notes for reviewers

The push deliberately does not live in ARMSX2SetIOSOsdFlags or ARMSX2ApplyIOSOsdPresetFromConfig. Neither has a thread hop of its own, and one of their three callers is scene willConnectToSession on the UIKit thread. MTGS::RunOnGSThread asserts on the CPU thread, and a second producer on that ring is worse than the race being fixed.

The two earlier boot call sites needed nothing at all. GSopen assigns GSConfig wholesale from EmuConfig, so a write before that point was being overwritten anyway.

Adding the overlay position to the per frame copy would have been tidier and is wrong. ReleaseNonEssentialRuntimeResources hides the overlay in emulation only mode by clearing exactly that field in GSConfig, and a mirror would undo it every frame and put the OSD back.

Two things found while doing this and deliberately left alone, both older than this change:

The GPU timing switch in GSUpdateConfig only fires on a rising edge of OsdShowGPU. The per frame copy has always levelled that field before the comparison runs, so it never fires and the GPU line has never had real timing data. Removing these writes does not change that, and fixing it properly belongs in the copy itself.

SceneDelegate tests SDL_Init with a less than zero comparison. SDL3 returns a bool there, so the check is always false and a failed SDL init is never noticed. Untouched here, unrelated to this change.

Built for device. The behaviour this protects against is a data race, so a clean run proves nothing about it either way. What can be checked by eye is that the OSD still appears, still switches with the preset picker, still moves with the position setting, and still hides in emulation only mode.
