### PR TITLE
iOS: stop the patch manager claiming Hardcore is blocking before it is

### DIFF
--- a/platforms/ios/app/src/main/swift/Models/PatchStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/PatchStore.swift
@@ -157,14 +157,23 @@ final class PatchStore: @unchecked Sendable {
         return !PadLayoutGameIdentity.normalizedCRC(crc).isEmpty
     }
 
-    /// True when RetroAchievements Hardcore Mode is enabled or active. While true, no `.pnach`
-    /// content — cheats *or* patches — may be enabled: the core also refuses to apply them, so
-    /// already-enabled entries take no effect until Hardcore is off.
+    /// True when Hardcore Mode is actually in force, which is the only state the core refuses
+    /// pnach content in. Every gate down there keys on IsHardcoreModeActive, so the preference
+    /// on its own must not count: Hardcore only arms on a reset, and until it does the entries
+    /// carry on applying no matter what this screen says about them.
     static func hardcoreBlocksPnachContent() -> Bool {
         let state = ARMSX2Bridge.retroAchievementsState()
         let active = (state["hardcoreActive"] as? NSNumber)?.boolValue ?? false
-        let preference = (state["hardcorePreference"] as? NSNumber)?.boolValue ?? false
-        return active || preference || ARMSX2Bridge.isRetroAchievementsHardcoreActive()
+        return active || ARMSX2Bridge.isRetroAchievementsHardcoreActive()
+    }
+
+    /// Hardcore is switched on but has not taken hold yet, because it only arms when a game
+    /// boots. Everything below is still live until then, and saying nothing is how people end
+    /// up believing a cheat beat Hardcore.
+    static func hardcorePendingRestart() -> Bool {
+        guard !hardcoreBlocksPnachContent() else { return false }
+        let state = ARMSX2Bridge.retroAchievementsState()
+        return (state["hardcorePreference"] as? NSNumber)?.boolValue ?? false
     }
 
     /// Presentation patches that stay legal under Hardcore: widescreen and 60fps from a

--- a/platforms/ios/app/src/main/swift/Views/CheatsPatchesManagerView.swift
+++ b/platforms/ios/app/src/main/swift/Views/CheatsPatchesManagerView.swift
@@ -56,6 +56,19 @@ struct CheatsPatchesManagerView: View {
                                 .foregroundStyle(.orange)
                         }
                     }
+                } else if PatchStore.hardcorePendingRestart() {
+                    // This screen used to claim everything was blocked the moment Hardcore was
+                    // switched on. It is not: Hardcore arms on a boot, and until then the
+                    // entries below carry on working.
+                    Section {
+                        Label {
+                            Text("Hardcore Mode is switched on but has not taken hold yet. Anything enabled here still works until you boot a game, and will stop then.")
+                                .fixedSize(horizontal: false, vertical: true)
+                        } icon: {
+                            Image(systemName: "clock.badge.exclamationmark")
+                                .foregroundStyle(.orange)
+                        }
+                    }
                 }
                 installedSection
                 availableSection


### PR DESCRIPTION
Flip Hardcore Mode on and the Cheats and Patches screen immediately says cheats and most patches are blocked. They are not. Hardcore only arms when a game boots, and every gate in the core keys on it being active, so until then everything on that screen carries on working under a banner saying it cannot.

This is how the God of War 2 report started: someone watched a cheat keep working while the app insisted it was suppressed.

### What changed

* The screen only claims Hardcore is blocking things when Hardcore is actually in force.
* The in between state gets its own line, saying Hardcore is switched on but has not taken hold, and that anything enabled still works until a game is booted.

### Why it read wrong

hardcoreBlocksPnachContent was ORing the preference in with the active state. Its own doc comment asserted that the core refuses to apply the entries, which is what made the behaviour look settled and correct.

Everything downstream shares that predicate, so enabling entries and the preserve already enabled behaviour are now permissive while Hardcore is merely pending, and unchanged once it is really on.

### Notes for reviewers

Nothing here changes which entries the core applies. That is a separate concern and is handled on its own.

The core also has a message for this case, at Achievements DisplayHardcoreDeferredMessage, and it deliberately returns early on platforms with native notifications. That is correct and stays as it is: the iOS RetroAchievements screen already raises its own warning when the toggle is flipped with a game running, worded better than the core's, so routing the core one through as well would just double up.

Built for device. Not exercised on hardware, so the new banner has not been seen on a screen.
