### PR TITLE
iOS: Virtual Pad Extensions, Native Sub-Settings Swipe, and Quick Menu Refinements

### DIFF
--- a/platforms/ios/app/src/main/swift/Models/DynamicThumbstickSettings.swift
+++ b/platforms/ios/app/src/main/swift/Models/DynamicThumbstickSettings.swift
@@ -228,7 +228,39 @@ final class DynamicThumbstickSettings {
     var invertGyroVertical: Bool { didSet { setBool("InvertGyroVertical", invertGyroVertical) } }
 
     var thumbstickRadius: Double { didSet { setDouble("ThumbstickRadius", thumbstickRadius) } }
+    var leftThumbstickAreaScale: Double {
+        didSet { setDouble("LeftThumbstickAreaScale", leftThumbstickAreaScale) }
+    }
+    var rightThumbstickAreaScale: Double {
+        didSet { setDouble("RightThumbstickAreaScale", rightThumbstickAreaScale) }
+    }
     var deadZone: Double { didSet { setDouble("DeadZone", deadZone) } }
+    var leftInstantDeadzoneEnabled: Bool {
+        didSet { setBool("LeftInstantDeadzoneEnabled", leftInstantDeadzoneEnabled) }
+    }
+    var leftNegativeDeadzone: Double {
+        didSet { setDouble("LeftNegativeDeadzone", leftNegativeDeadzone) }
+    }
+    var rightInstantDeadzoneEnabled: Bool {
+        didSet { setBool("RightInstantDeadzoneEnabled", rightInstantDeadzoneEnabled) }
+    }
+    var rightNegativeDeadzone: Double {
+        didSet { setDouble("RightNegativeDeadzone", rightNegativeDeadzone) }
+    }
+    var convertSwipeToDynamicJoystick: Bool {
+        didSet { setBool("ConvertSwipeToDynamicJoystick", convertSwipeToDynamicJoystick) }
+    }
+    var convertIntoDynamicThumbstickThreshold: Double {
+        didSet {
+            setDouble(
+                "ConvertIntoDynamicThumbstickThreshold",
+                convertIntoDynamicThumbstickThreshold
+            )
+        }
+    }
+    var pullingBackDistance: Double {
+        didSet { setDouble("PullingBackDistance", pullingBackDistance) }
+    }
     var thumbstickOpacity: Double { didSet { setDouble("ThumbstickOpacity", thumbstickOpacity) } }
     var baseOpacity: Double { didSet { setDouble("BaseOpacity", baseOpacity) } }
     var trailOpacity: Double { didSet { setDouble("TrailOpacity", trailOpacity) } }
@@ -255,6 +287,15 @@ final class DynamicThumbstickSettings {
     var fireReleaseDelay: Double { didSet { setDouble("FireReleaseDelay", fireReleaseDelay) } }
     var automaticFireInterval: Double { didSet { setDouble("AutomaticFireInterval", automaticFireInterval) } }
     var dynamicCrosshairEnabled: Bool { didSet { setBool("DynamicCrosshairEnabled", dynamicCrosshairEnabled) } }
+    var showCrosshairWhileHoldingSwipe: Bool {
+        didSet { setBool("ShowCrosshairWhileHoldingSwipe", showCrosshairWhileHoldingSwipe) }
+    }
+    var swipeCrosshairHideDelay: Double {
+        didSet { setDouble("SwipeCrosshairHideDelay", swipeCrosshairHideDelay) }
+    }
+    var triggerButtonWhenUnholdingSwipe: Int {
+        didSet { setInt("TriggerButtonWhenUnholdingSwipe", triggerButtonWhenUnholdingSwipe) }
+    }
     var dynamicCrosshairSize: Double { didSet { setDouble("DynamicCrosshairSize", dynamicCrosshairSize) } }
     var dynamicCrosshairOpacity: Double {
         didSet { setDouble("DynamicCrosshairOpacity", dynamicCrosshairOpacity) }
@@ -299,7 +340,22 @@ final class DynamicThumbstickSettings {
         invertGyroHorizontal = Self.bool("InvertGyroHorizontal", default: false)
         invertGyroVertical = Self.bool("InvertGyroVertical", default: false)
         thumbstickRadius = Self.double("ThumbstickRadius", default: 52)
+        leftThumbstickAreaScale = Self.double("LeftThumbstickAreaScale", default: 3)
+        rightThumbstickAreaScale = Self.double("RightThumbstickAreaScale", default: 3)
         deadZone = Self.double("DeadZone", default: 0.08)
+        leftInstantDeadzoneEnabled = Self.bool("LeftInstantDeadzoneEnabled", default: false)
+        leftNegativeDeadzone = Self.double("LeftNegativeDeadzone", default: -0.08)
+        rightInstantDeadzoneEnabled = Self.bool("RightInstantDeadzoneEnabled", default: false)
+        rightNegativeDeadzone = Self.double("RightNegativeDeadzone", default: -0.08)
+        convertSwipeToDynamicJoystick = Self.bool("ConvertSwipeToDynamicJoystick", default: false)
+        convertIntoDynamicThumbstickThreshold = Self.double(
+            "ConvertIntoDynamicThumbstickThreshold",
+            default: 1
+        )
+        pullingBackDistance = Self.double(
+            "PullingBackDistance",
+            default: 0.05
+        )
         thumbstickOpacity = Self.double("ThumbstickOpacity", default: 0.72)
         baseOpacity = Self.double("BaseOpacity", default: 0.20)
         trailOpacity = Self.double("TrailOpacity", default: 0.10)
@@ -323,6 +379,9 @@ final class DynamicThumbstickSettings {
         fireReleaseDelay = Self.double("FireReleaseDelay", default: 0)
         automaticFireInterval = Self.double("AutomaticFireInterval", default: 0.12)
         dynamicCrosshairEnabled = Self.bool("DynamicCrosshairEnabled", default: false)
+        showCrosshairWhileHoldingSwipe = Self.bool("ShowCrosshairWhileHoldingSwipe", default: false)
+        swipeCrosshairHideDelay = Self.double("SwipeCrosshairHideDelay", default: 0.5)
+        triggerButtonWhenUnholdingSwipe = Self.int("TriggerButtonWhenUnholdingSwipe", default: -1)
         dynamicCrosshairSize = Self.double("DynamicCrosshairSize", default: 32)
         dynamicCrosshairOpacity = Self.double("DynamicCrosshairOpacity", default: 0.70)
         dynamicCrosshairType = DynamicCrosshairType(
@@ -397,6 +456,21 @@ final class DynamicThumbstickSettings {
         !doubleTapToHoldAim || singleTapActionOnNonAimMode || actionsOnNonAimMode
     }
 
+    func setConvertIntoDynamicThumbstickThreshold(_ value: Double) {
+        convertIntoDynamicThumbstickThreshold = min(max(value, 0.01), 3)
+    }
+
+    func setPullingBackDistance(_ value: Double) {
+        pullingBackDistance = min(max(value, 0.01), 1)
+    }
+
+    var effectiveSwipeConversionSettings: (dynamicThumbstick: Double, pullingBack: Double) {
+        (
+            min(max(convertIntoDynamicThumbstickThreshold, 0.01), 3),
+            min(max(pullingBackDistance, 0.01), 1)
+        )
+    }
+
     static func automaticFireBlockedByHardcore() -> Bool {
         let state = ARMSX2Bridge.retroAchievementsState()
         let active = (state["hardcoreActive"] as? NSNumber)?.boolValue ?? false
@@ -438,7 +512,16 @@ final class DynamicThumbstickSettings {
         invertGyroHorizontal = false
         invertGyroVertical = false
         thumbstickRadius = 52
+        leftThumbstickAreaScale = 3
+        rightThumbstickAreaScale = 3
         deadZone = 0.08
+        leftInstantDeadzoneEnabled = false
+        leftNegativeDeadzone = -0.08
+        rightInstantDeadzoneEnabled = false
+        rightNegativeDeadzone = -0.08
+        convertSwipeToDynamicJoystick = false
+        convertIntoDynamicThumbstickThreshold = 1
+        pullingBackDistance = 0.05
         thumbstickOpacity = 0.72
         baseOpacity = 0.20
         trailOpacity = 0.10
@@ -462,6 +545,9 @@ final class DynamicThumbstickSettings {
         fireReleaseDelay = 0
         automaticFireInterval = 0.12
         dynamicCrosshairEnabled = false
+        showCrosshairWhileHoldingSwipe = false
+        swipeCrosshairHideDelay = 0.5
+        triggerButtonWhenUnholdingSwipe = -1
         dynamicCrosshairSize = 32
         dynamicCrosshairOpacity = 0.70
         dynamicCrosshairType = .fourBoxes
@@ -484,6 +570,10 @@ final class DynamicThumbstickSettings {
 
     func holdFireButton(for side: VirtualPadThumbstickSide) -> VirtualPadActionButton {
         side == .left ? leftHoldFireButton : rightHoldFireButton
+    }
+
+    var swipeReleaseActionButton: VirtualPadActionButton? {
+        VirtualPadActionButton(rawValue: triggerButtonWhenUnholdingSwipe)
     }
 
     func effectiveSwipeSensitivity(isAiming: Bool) -> (horizontal: Double, vertical: Double) {

--- a/platforms/ios/app/src/main/swift/Models/EmulatorBridge.swift
+++ b/platforms/ios/app/src/main/swift/Models/EmulatorBridge.swift
@@ -114,8 +114,14 @@ final class EmulatorBridge: @unchecked Sendable {
 
     @MainActor
     func setLeftStick(x: Float, y: Float) {
-        let sensitivity = Float(DynamicThumbstickSettings.shared.movementSensitivity)
-        let output = Self.radiallyClamped(x: x * sensitivity, y: y * sensitivity)
+        let dynamicSettings = DynamicThumbstickSettings.shared
+        let sensitivity = Float(dynamicSettings.movementSensitivity)
+        let clamped = Self.radiallyClamped(x: x * sensitivity, y: y * sensitivity)
+        let output = Self.applyingNegativeDeadzone(
+            to: clamped,
+            enabled: dynamicSettings.leftInstantDeadzoneEnabled,
+            configuredDeadzone: dynamicSettings.leftNegativeDeadzone
+        )
         let inv = SettingsStore.shared.stickInversion(for: .left)
         ARMSX2Bridge.setLeftStickX(inv.x ? -output.x : output.x, y: inv.y ? -output.y : output.y)
     }
@@ -147,9 +153,15 @@ final class EmulatorBridge: @unchecked Sendable {
 
     @MainActor
     private func applyVirtualRightStick() {
-        let output = Self.radiallyClamped(
+        let dynamicSettings = DynamicThumbstickSettings.shared
+        let clamped = Self.radiallyClamped(
             x: virtualRightTouchX + virtualRightMotionX,
             y: virtualRightTouchY + virtualRightMotionY
+        )
+        let output = Self.applyingNegativeDeadzone(
+            to: clamped,
+            enabled: dynamicSettings.rightInstantDeadzoneEnabled,
+            configuredDeadzone: dynamicSettings.rightNegativeDeadzone
         )
         let inv = SettingsStore.shared.stickInversion(for: .right)
         ARMSX2Bridge.setRightStickX(inv.x ? -output.x : output.x, y: inv.y ? -output.y : output.y)
@@ -159,6 +171,23 @@ final class EmulatorBridge: @unchecked Sendable {
         let magnitude = hypotf(x, y)
         guard magnitude > 1 else { return (x, y) }
         return (x / magnitude, y / magnitude)
+    }
+
+    /// Applies a radial minimum-output floor without rescaling larger values.
+    /// This preserves the Dynamic Thumbstick's progressive deadzone curve.
+    private static func applyingNegativeDeadzone(
+        to input: (x: Float, y: Float),
+        enabled: Bool,
+        configuredDeadzone: Double
+    ) -> (x: Float, y: Float) {
+        guard enabled else { return input }
+        let magnitude = hypotf(input.x, input.y)
+        guard magnitude > 0 else { return input }
+
+        let floor = min(max(Float(-configuredDeadzone), 0), 0.95)
+        guard floor > 0, magnitude < floor else { return input }
+        let scale = floor / magnitude
+        return (input.x * scale, input.y * scale)
     }
 
     var isOsdVisible: Bool {

--- a/platforms/ios/app/src/main/swift/Models/SettingsPresetCatalog.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsPresetCatalog.swift
@@ -181,6 +181,7 @@ enum BuiltInSettingsPreset: String, CaseIterable, Identifiable {
 enum BuiltInDynamicControlPreset: String, CaseIterable, Identifiable {
     case defaultPreset = "Default"
     case mgs3 = "MGS 3"
+    case classicFirstPersonShooter = "Classic First Person Shooter"
 
     var id: String { rawValue }
 
@@ -190,11 +191,17 @@ enum BuiltInDynamicControlPreset: String, CaseIterable, Identifiable {
             return "Restores the Dynamic Control switches managed by presets while preserving sensitivities and button assignments."
         case .mgs3:
             return "Enables Dynamic Thumbsticks, Swipe Camera, right-thumbstick actions, the aiming crosshair, and Double Tap to Hold Aim."
+        case .classicFirstPersonShooter:
+            return "Configures responsive swipe aiming, adaptive swipe-to-stick conversion, right-thumbstick actions, automatic fire, and the reactive aiming crosshair for classic first-person shooters."
         }
     }
 
     @MainActor
     func isActive(settings: DynamicThumbstickSettings = .shared) -> Bool {
+        func matches(_ lhs: Double, _ rhs: Double) -> Bool {
+            abs(lhs - rhs) < 0.0001
+        }
+
         switch self {
         case .defaultPreset:
             return settings.legacyThumbsticks &&
@@ -209,6 +216,68 @@ enum BuiltInDynamicControlPreset: String, CaseIterable, Identifiable {
                 settings.rightThumbstickActionsEnabled &&
                 settings.dynamicCrosshairEnabled &&
                 settings.doubleTapToHoldAim
+        case .classicFirstPersonShooter:
+            return !settings.legacyThumbsticks &&
+                settings.dynamicThumbsticks &&
+                settings.swipeCamera &&
+                !settings.gyroscopeCamera &&
+                settings.leftInstantDeadzoneEnabled &&
+                matches(settings.leftNegativeDeadzone, -0.08) &&
+                settings.rightInstantDeadzoneEnabled &&
+                matches(settings.rightNegativeDeadzone, -0.14) &&
+                matches(settings.leftThumbstickAreaScale, 1) &&
+                matches(settings.rightThumbstickAreaScale, 1.75) &&
+                settings.convertSwipeToDynamicJoystick &&
+                matches(settings.convertIntoDynamicThumbstickThreshold, 1) &&
+                matches(settings.pullingBackDistance, 0.05) &&
+                matches(settings.movementSensitivity, 1) &&
+                matches(settings.lookSensitivity, 1) &&
+                matches(settings.swipeSensitivity, 0.28) &&
+                matches(settings.swipeHorizontalSensitivity, 1) &&
+                matches(settings.swipeVerticalSensitivity, 1) &&
+                !settings.swipeSensitivityWhileAimingEnabled &&
+                matches(settings.swipeSensitivityWhileAiming, 0.28) &&
+                matches(settings.swipeHorizontalSensitivityWhileAiming, 1) &&
+                matches(settings.swipeVerticalSensitivityWhileAiming, 1) &&
+                settings.swipeSensitivityWhileNotAimingEnabled &&
+                matches(settings.swipeSensitivityWhileNotAiming, 0.75) &&
+                matches(settings.swipeHorizontalSensitivityWhileNotAiming, 1) &&
+                matches(settings.swipeVerticalSensitivityWhileNotAiming, 1) &&
+                !settings.leftThumbstickActionsEnabled &&
+                settings.rightThumbstickActionsEnabled &&
+                settings.rightAimButton == .leftShoulder &&
+                settings.rightFireButton == .rightShoulder &&
+                settings.rightHoldFireButton == .rightShoulder &&
+                settings.dynamicCrosshairEnabled &&
+                settings.showCrosshairWhileHoldingSwipe &&
+                matches(settings.swipeCrosshairHideDelay, 0.5) &&
+                settings.triggerButtonWhenUnholdingSwipe == -1 &&
+                matches(settings.dynamicCrosshairSize, 32) &&
+                matches(settings.dynamicCrosshairOpacity, 0.70) &&
+                settings.dynamicCrosshairType == .fourBoxes &&
+                settings.dynamicCrosshairAnimation == .reactive &&
+                matches(settings.thumbstickRadius, 52) &&
+                matches(settings.deadZone, 0.08) &&
+                matches(settings.thumbstickOpacity, 0.72) &&
+                matches(settings.baseOpacity, 0.20) &&
+                matches(settings.trailOpacity, 0.10) &&
+                settings.activationHaptics &&
+                !settings.holdAimWhileSwipe &&
+                !settings.doubleTapToHoldAim &&
+                settings.singleTapActionOnNonAimMode &&
+                settings.actionsOnNonAimMode &&
+                matches(settings.aimReleaseDelay, 1.25) &&
+                matches(settings.doubleTapWindow, 0.28) &&
+                settings.tapToFire &&
+                matches(settings.tapMaximumDuration, 0.18) &&
+                matches(settings.tapTravelTolerance, 12) &&
+                settings.rapidTapFireEnabled &&
+                matches(settings.rapidTapWindow, 0.28) &&
+                settings.rapidTapActivationCount == 2 &&
+                matches(settings.automaticFireInterval, 0.12) &&
+                settings.extendFireWhileDragging &&
+                settings.releaseFireWhenTouchEnds &&
+                matches(settings.fireReleaseDelay, 0)
         }
     }
 
@@ -227,6 +296,73 @@ enum BuiltInDynamicControlPreset: String, CaseIterable, Identifiable {
             settings.rightThumbstickActionsEnabled = true
             settings.dynamicCrosshairEnabled = true
             settings.setDoubleTapToHoldAim(true)
+        case .classicFirstPersonShooter:
+            settings.setDynamicThumbsticks(true)
+            settings.swipeCamera = true
+            settings.gyroscopeCamera = false
+
+            settings.leftInstantDeadzoneEnabled = true
+            settings.leftNegativeDeadzone = -0.08
+            settings.rightInstantDeadzoneEnabled = true
+            settings.rightNegativeDeadzone = -0.14
+            settings.leftThumbstickAreaScale = 1
+            settings.rightThumbstickAreaScale = 1.75
+            settings.convertSwipeToDynamicJoystick = true
+            settings.setConvertIntoDynamicThumbstickThreshold(1)
+            settings.setPullingBackDistance(0.05)
+
+            settings.movementSensitivity = 1
+            settings.lookSensitivity = 1
+            settings.swipeSensitivity = 0.28
+            settings.swipeHorizontalSensitivity = 1
+            settings.swipeVerticalSensitivity = 1
+            settings.swipeSensitivityWhileAimingEnabled = false
+            settings.swipeSensitivityWhileAiming = 0.28
+            settings.swipeHorizontalSensitivityWhileAiming = 1
+            settings.swipeVerticalSensitivityWhileAiming = 1
+            settings.swipeSensitivityWhileNotAimingEnabled = true
+            settings.swipeSensitivityWhileNotAiming = 0.75
+            settings.swipeHorizontalSensitivityWhileNotAiming = 1
+            settings.swipeVerticalSensitivityWhileNotAiming = 1
+
+            settings.leftThumbstickActionsEnabled = false
+            settings.rightThumbstickActionsEnabled = true
+            settings.rightAimButton = .leftShoulder
+            settings.rightFireButton = .rightShoulder
+            settings.rightHoldFireButton = .rightShoulder
+
+            settings.dynamicCrosshairEnabled = true
+            settings.showCrosshairWhileHoldingSwipe = true
+            settings.swipeCrosshairHideDelay = 0.5
+            settings.triggerButtonWhenUnholdingSwipe = -1
+            settings.dynamicCrosshairSize = 32
+            settings.dynamicCrosshairOpacity = 0.70
+            settings.dynamicCrosshairType = .fourBoxes
+            settings.dynamicCrosshairAnimation = .reactive
+
+            settings.thumbstickRadius = 52
+            settings.deadZone = 0.08
+            settings.thumbstickOpacity = 0.72
+            settings.baseOpacity = 0.20
+            settings.trailOpacity = 0.10
+            settings.activationHaptics = true
+
+            settings.setHoldAimWhileSwipe(false)
+            settings.setDoubleTapToHoldAim(false)
+            settings.singleTapActionOnNonAimMode = true
+            settings.setActionsOnNonAimMode(true)
+            settings.aimReleaseDelay = 1.25
+            settings.doubleTapWindow = 0.28
+            settings.tapToFire = true
+            settings.tapMaximumDuration = 0.18
+            settings.tapTravelTolerance = 12
+            settings.rapidTapFireEnabled = true
+            settings.rapidTapWindow = 0.28
+            settings.rapidTapActivationCount = 2
+            settings.automaticFireInterval = 0.12
+            settings.extendFireWhileDragging = true
+            settings.releaseFireWhenTouchEnds = true
+            settings.fireReleaseDelay = 0
         }
     }
 }

--- a/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
@@ -1795,6 +1795,14 @@ final class SettingsStore {
             UserDefaults.standard.set(clearLiquidGlassUI, forKey: "ARMSX2iOSClearLiquidGlassUI")
         }
     }
+    var clearLiquidGlassUIQuickMenu: Bool = false {
+        didSet {
+            UserDefaults.standard.set(
+                clearLiquidGlassUIQuickMenu,
+                forKey: "ARMSX2iOSClearLiquidGlassUIQuickMenu"
+            )
+        }
+    }
     var gameCardZoomAnimationEnabled: Bool = true {
         didSet {
             UserDefaults.standard.set(
@@ -2088,6 +2096,9 @@ final class SettingsStore {
         clearLiquidGlassUI = UserDefaults.standard.object(
             forKey: "ARMSX2iOSClearLiquidGlassUI"
         ) as? Bool ?? true
+        clearLiquidGlassUIQuickMenu = UserDefaults.standard.object(
+            forKey: "ARMSX2iOSClearLiquidGlassUIQuickMenu"
+        ) as? Bool ?? false
         gameCardZoomAnimationEnabled = UserDefaults.standard.object(
             forKey: "ARMSX2iOSGameCardZoomAnimationEnabled"
         ) as? Bool ?? true
@@ -2321,6 +2332,9 @@ final class SettingsStore {
         clearLiquidGlassUI = UserDefaults.standard.object(
             forKey: "ARMSX2iOSClearLiquidGlassUI"
         ) as? Bool ?? true
+        clearLiquidGlassUIQuickMenu = UserDefaults.standard.object(
+            forKey: "ARMSX2iOSClearLiquidGlassUIQuickMenu"
+        ) as? Bool ?? false
         gameCardZoomAnimationEnabled = UserDefaults.standard.object(
             forKey: "ARMSX2iOSGameCardZoomAnimationEnabled"
         ) as? Bool ?? true

--- a/platforms/ios/app/src/main/swift/Views/Controller/DynamicThumbstickControls.swift
+++ b/platforms/ios/app/src/main/swift/Views/Controller/DynamicThumbstickControls.swift
@@ -36,7 +36,12 @@ struct DynamicThumbstickSample {
 }
 
 enum DynamicThumbstickMath {
-    static func sample(translation: CGSize, maximumRadius: CGFloat, deadZone: CGFloat) -> DynamicThumbstickSample {
+    static func sample(
+        translation: CGSize,
+        maximumRadius: CGFloat,
+        deadZone: CGFloat,
+        deadZoneProgressRadius: CGFloat? = nil
+    ) -> DynamicThumbstickSample {
         guard maximumRadius > 0 else {
             return DynamicThumbstickSample(input: .zero, rawDistance: 0)
         }
@@ -49,11 +54,16 @@ enum DynamicThumbstickMath {
         let safeDeadZone = min(max(deadZone, 0), 0.95)
         let cappedDistance = min(rawDistance, maximumRadius)
         let normalizedDistance = cappedDistance / maximumRadius
-        // Begin at a true 0% deadzone so even a tiny drag produces input. The
-        // configured deadzone grows with travel and reaches its selected value
-        // at the outer radius, while the remap still preserves full-scale output.
-        let adaptiveDeadZone = safeDeadZone * normalizedDistance
-        let magnitude = (normalizedDistance - adaptiveDeadZone) / (1 - adaptiveDeadZone)
+        // Input saturation and deadzone progression can use different radii.
+        // This preserves the larger movement area while letting the left stick
+        // reach its configured deadzone at the visible Maximum Radius.
+        let progressRadius = max(deadZoneProgressRadius ?? maximumRadius, 1)
+        let deadZoneProgress = min(rawDistance / progressRadius, 1)
+        let progressRadiusScale = min(progressRadius / maximumRadius, 1)
+        let adaptiveDeadZone =
+            safeDeadZone * deadZoneProgress * progressRadiusScale
+        let magnitude = max(normalizedDistance - adaptiveDeadZone, 0) /
+            (1 - adaptiveDeadZone)
 
         return DynamicThumbstickSample(
             input: DynamicThumbstickVector(
@@ -76,11 +86,25 @@ enum DynamicThumbstickMath {
         guard scale > 0 else { return 0 }
         return CGFloat(index + 1) / CGFloat(maximumDots + 1) * scale
     }
+
+    /// Keeps the maximum-pull feedback stable near the boundary so tiny finger
+    /// jitter cannot repeatedly retrigger its haptic.
+    static func overextensionState(
+        distance: CGFloat,
+        maximumRadius: CGFloat,
+        currentlyOverextended: Bool
+    ) -> Bool {
+        currentlyOverextended
+            ? distance > maximumRadius * 0.95
+            : distance > maximumRadius
+    }
 }
 
 struct DynamicThumbstickView: View {
     let isLeft: Bool
     let radius: CGFloat
+    let maximumRadius: CGFloat
+    var deadZoneProgressRadius: CGFloat? = nil
     let deadZone: CGFloat
     let hapticsEnabled: Bool
     let thumbstickOpacity: Double
@@ -99,6 +123,7 @@ struct DynamicThumbstickView: View {
     @State private var dragOffset = CGSize.zero
     @State private var dragDistance: CGFloat = 0
     @State private var isActive = false
+    @State private var isOverextended = false
     @State private var gestureStartedAt: Date?
     @State private var maximumTravel: CGFloat = 0
 
@@ -111,8 +136,10 @@ struct DynamicThumbstickView: View {
                 if isActive {
                     DynamicThumbstickVisual(
                         radius: radius,
+                        maximumRadius: maximumRadius,
                         dragOffset: dragOffset,
                         dragDistance: dragDistance,
+                        isOverextended: isOverextended,
                         thumbstickOpacity: thumbstickOpacity,
                         baseOpacity: baseOpacity,
                         trailOpacity: trailOpacity
@@ -145,6 +172,7 @@ struct DynamicThumbstickView: View {
                     }
                     if hapticsEnabled && SettingsStore.shared.hapticFeedback {
                         HapticManager.light.impactOccurred(intensity: 0.72)
+                        HapticManager.medium.prepare()
                     }
                 }
 
@@ -152,11 +180,13 @@ struct DynamicThumbstickView: View {
                 if tapActionsEnabled { onInteractionActivity() }
                 let sample = DynamicThumbstickMath.sample(
                     translation: value.translation,
-                    maximumRadius: radius,
-                    deadZone: deadZone
+                    maximumRadius: maximumRadius,
+                    deadZone: deadZone,
+                    deadZoneProgressRadius: deadZoneProgressRadius
                 )
                 dragOffset = value.translation
                 dragDistance = sample.rawDistance
+                updateOverextension(sample.rawDistance)
                 onVector(sample.input)
             }
             .onEnded { value in
@@ -181,6 +211,22 @@ struct DynamicThumbstickView: View {
         }
     }
 
+    private func updateOverextension(_ distance: CGFloat) {
+        let overextended = DynamicThumbstickMath.overextensionState(
+            distance: distance,
+            maximumRadius: maximumRadius,
+            currentlyOverextended: isOverextended
+        )
+        guard overextended != isOverextended else { return }
+        isOverextended = overextended
+        if overextended {
+            if hapticsEnabled && SettingsStore.shared.hapticFeedback {
+                HapticManager.medium.impactOccurred(intensity: 1)
+                HapticManager.medium.prepare()
+            }
+        }
+    }
+
     private func reset() {
         guard isActive || gestureStartedAt != nil else {
             onVector(.zero)
@@ -190,6 +236,7 @@ struct DynamicThumbstickView: View {
         if tapActionsEnabled && gestureStartedAt != nil { onInteractionEnded() }
         gestureStartedAt = nil
         maximumTravel = 0
+        isOverextended = false
         withAnimation(.easeOut(duration: 0.14)) {
             isActive = false
         }
@@ -198,8 +245,10 @@ struct DynamicThumbstickView: View {
 
 private struct DynamicThumbstickVisual: View {
     let radius: CGFloat
+    let maximumRadius: CGFloat
     let dragOffset: CGSize
     let dragDistance: CGFloat
+    let isOverextended: Bool
     let thumbstickOpacity: Double
     let baseOpacity: Double
     let trailOpacity: Double
@@ -207,8 +256,8 @@ private struct DynamicThumbstickVisual: View {
     var body: some View {
         ZStack {
             ForEach(0..<7, id: \.self) { index in
-                let scale = DynamicThumbstickMath.trailDotScale(index: index, rawDistance: dragDistance, maximumRadius: radius)
-                let progress = DynamicThumbstickMath.trailDotPositionProgress(index: index, rawDistance: dragDistance, maximumRadius: radius)
+                let scale = DynamicThumbstickMath.trailDotScale(index: index, rawDistance: dragDistance, maximumRadius: maximumRadius)
+                let progress = DynamicThumbstickMath.trailDotPositionProgress(index: index, rawDistance: dragDistance, maximumRadius: maximumRadius)
                 if scale > 0 {
                     Circle()
                         .fill(Color(white: 0.82).opacity(trailOpacity * Double(scale)))
@@ -222,6 +271,15 @@ private struct DynamicThumbstickVisual: View {
             Circle()
                 .fill(Color(white: 0.72).opacity(baseOpacity))
                 .frame(width: radius * 0.42, height: radius * 0.42)
+                .overlay {
+                    Circle()
+                        .stroke(
+                            Color.white.opacity(isOverextended ? 0.55 : 0),
+                            lineWidth: 1.5
+                        )
+                        .scaleEffect(isOverextended ? 1.45 : 1)
+                }
+                .scaleEffect(isOverextended ? 1.28 : 1)
 
             Circle()
                 .fill(Color(white: 0.88).opacity(thumbstickOpacity))
@@ -229,27 +287,71 @@ private struct DynamicThumbstickVisual: View {
                 .offset(dragOffset)
         }
         .frame(width: radius * 2, height: radius * 2)
+        .animation(
+            isOverextended
+                ? .easeInOut(duration: 0.42).repeatForever(autoreverses: true)
+                : .easeOut(duration: 0.16),
+            value: isOverextended
+        )
     }
 }
 
 struct VirtualPadCameraSwipeView: View {
     let maximumTapDuration: TimeInterval
     let tapTravelTolerance: CGFloat
+    let convertsToDynamicJoystick: Bool
+    let thumbstickRadius: CGFloat
+    let maximumThumbstickRadius: CGFloat
+    let thumbstickDeadZone: CGFloat
+    let convertIntoDynamicThumbstickThreshold: CGFloat
+    let pullingBackDistance: CGFloat
+    let thumbstickOpacity: Double
+    let baseOpacity: Double
+    let trailOpacity: Double
+    let hapticsEnabled: Bool
     let onDelta: (CGSize) -> Void
+    let onDynamicJoystick: (DynamicThumbstickVector?) -> Void
     let onBegan: () -> Void
     let onActivity: () -> Void
     let onTap: () -> Void
+    let onReleased: () -> Void
     let onEnded: () -> Void
 
     @State private var lastLocation: CGPoint?
     @State private var gestureStartedAt: Date?
     @State private var maximumTravel: CGFloat = 0
+    @State private var origin = CGPoint.zero
+    @State private var dragOffset = CGSize.zero
+    @State private var dragDistance: CGFloat = 0
+    @State private var isDynamicJoystickMode = false
+    @State private var isOverextended = false
+    @State private var activeDynamicThumbstickDistance: CGFloat?
+    @State private var dynamicJoystickPeakTravel: CGFloat = 0
+    @State private var previousRadialTravel: CGFloat = 0
 
     var body: some View {
         GeometryReader { _ in
-            Color.clear
-                .contentShape(Rectangle())
-                .gesture(swipeGesture)
+            ZStack(alignment: .topLeading) {
+                Color.clear
+                    .contentShape(Rectangle())
+
+                if isDynamicJoystickMode {
+                    DynamicThumbstickVisual(
+                        radius: thumbstickRadius,
+                        maximumRadius: maximumThumbstickRadius,
+                        dragOffset: dragOffset,
+                        dragDistance: dragDistance,
+                        isOverextended: isOverextended,
+                        thumbstickOpacity: thumbstickOpacity,
+                        baseOpacity: baseOpacity,
+                        trailOpacity: trailOpacity
+                    )
+                    .position(origin)
+                    .transition(.opacity.combined(with: .scale(scale: 0.9)))
+                    .allowsHitTesting(false)
+                }
+            }
+            .gesture(swipeGesture)
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Camera swipe area")
@@ -263,11 +365,75 @@ struct VirtualPadCameraSwipeView: View {
                 if gestureStartedAt == nil {
                     gestureStartedAt = value.time
                     maximumTravel = 0
+                    origin = value.startLocation
+                    dragOffset = .zero
+                    dragDistance = 0
+                    activeDynamicThumbstickDistance = thumbstickRadius * min(
+                        max(convertIntoDynamicThumbstickThreshold, 0.01),
+                        3
+                    )
+                    dynamicJoystickPeakTravel = 0
+                    previousRadialTravel = 0
                     onBegan()
+                    if convertsToDynamicJoystick &&
+                        hapticsEnabled &&
+                        SettingsStore.shared.hapticFeedback {
+                        HapticManager.medium.prepare()
+                    }
                 }
-                maximumTravel = max(maximumTravel, hypot(value.translation.width, value.translation.height))
+                let rawTravel = hypot(value.translation.width, value.translation.height)
+                maximumTravel = max(maximumTravel, rawTravel)
+                dragOffset = value.translation
+                dragDistance = rawTravel
                 onActivity()
-                defer { lastLocation = value.location }
+                defer {
+                    lastLocation = value.location
+                    previousRadialTravel = rawTravel
+                }
+
+                if convertsToDynamicJoystick {
+                    updateOverextension(rawTravel)
+                    let entryDistance = activeDynamicThumbstickDistance ??
+                        thumbstickRadius * min(max(convertIntoDynamicThumbstickThreshold, 0.01), 3)
+                    let pullbackDistance = thumbstickRadius *
+                        min(max(pullingBackDistance, 0.01), 1)
+
+                    if isDynamicJoystickMode {
+                        dynamicJoystickPeakTravel = max(dynamicJoystickPeakTravel, rawTravel)
+                        if dynamicJoystickPeakTravel - rawTravel >= pullbackDistance {
+                            onDynamicJoystick(nil)
+                            activeDynamicThumbstickDistance = rawTravel
+                            dynamicJoystickPeakTravel = 0
+                            withAnimation(.spring(response: 0.20, dampingFraction: 0.82)) {
+                                isDynamicJoystickMode = false
+                            }
+                        } else {
+                            let sample = DynamicThumbstickMath.sample(
+                                translation: value.translation,
+                                maximumRadius: maximumThumbstickRadius,
+                                deadZone: thumbstickDeadZone
+                            )
+                            onDynamicJoystick(sample.input)
+                        }
+                        return
+                    }
+
+                    let movingOutward = rawTravel > previousRadialTravel + 0.5
+                    if movingOutward && rawTravel >= entryDistance {
+                        let sample = DynamicThumbstickMath.sample(
+                            translation: value.translation,
+                            maximumRadius: maximumThumbstickRadius,
+                            deadZone: thumbstickDeadZone
+                        )
+                        withAnimation(.spring(response: 0.20, dampingFraction: 0.82)) {
+                            isDynamicJoystickMode = true
+                        }
+                        dynamicJoystickPeakTravel = rawTravel
+                        onDynamicJoystick(sample.input)
+                        return
+                    }
+                }
+
                 guard let lastLocation else { return }
                 let delta = CGSize(
                     width: value.location.x - lastLocation.x,
@@ -281,6 +447,7 @@ struct VirtualPadCameraSwipeView: View {
                 let duration = value.time.timeIntervalSince(gestureStartedAt ?? value.time)
                 let travel = max(maximumTravel, hypot(value.translation.width, value.translation.height))
                 if duration <= maximumTapDuration && travel <= tapTravelTolerance { onTap() }
+                onReleased()
                 onEnded()
                 reset()
             }
@@ -291,10 +458,38 @@ struct VirtualPadCameraSwipeView: View {
         reset()
     }
 
+    private func updateOverextension(_ distance: CGFloat) {
+        let overextended = DynamicThumbstickMath.overextensionState(
+            distance: distance,
+            maximumRadius: maximumThumbstickRadius,
+            currentlyOverextended: isOverextended
+        )
+        guard overextended != isOverextended else { return }
+        isOverextended = overextended
+        if overextended {
+            if hapticsEnabled && SettingsStore.shared.hapticFeedback {
+                HapticManager.medium.impactOccurred(intensity: 1)
+                HapticManager.medium.prepare()
+            }
+        }
+    }
+
     private func reset() {
+        if isDynamicJoystickMode {
+            onDynamicJoystick(nil)
+        }
         lastLocation = nil
         gestureStartedAt = nil
         maximumTravel = 0
+        dragOffset = .zero
+        dragDistance = 0
+        isOverextended = false
+        activeDynamicThumbstickDistance = nil
+        dynamicJoystickPeakTravel = 0
+        previousRadialTravel = 0
+        withAnimation(.easeOut(duration: 0.14)) {
+            isDynamicJoystickMode = false
+        }
     }
 }
 
@@ -303,6 +498,7 @@ final class SwipeCameraInputDriver: NSObject {
     private var displayLink: CADisplayLink?
     private var pendingDelta = CGSize.zero
     private var pendingDeltaIsAiming = false
+    private var heldJoystickVector: DynamicThumbstickVector?
     private var lastTimestamp: CFTimeInterval?
     private var outputWasActive = false
     var onCameraMotion: ((DynamicThumbstickVector) -> Void)?
@@ -316,9 +512,24 @@ final class SwipeCameraInputDriver: NSObject {
     }
 
     func add(delta: CGSize, isAiming: Bool) {
+        guard heldJoystickVector == nil else { return }
         pendingDelta.width += delta.width
         pendingDelta.height += delta.height
         pendingDeltaIsAiming = isAiming
+    }
+
+    func setDynamicJoystick(_ vector: DynamicThumbstickVector?) {
+        pendingDelta = .zero
+        pendingDeltaIsAiming = false
+
+        if let vector {
+            let limitedVector = vector.limited(to: 1)
+            heldJoystickVector = limitedVector
+            publish(limitedVector)
+        } else if heldJoystickVector != nil {
+            heldJoystickVector = nil
+            publish(.zero)
+        }
     }
 
     func stop() {
@@ -326,10 +537,9 @@ final class SwipeCameraInputDriver: NSObject {
         displayLink = nil
         pendingDelta = .zero
         pendingDeltaIsAiming = false
+        heldJoystickVector = nil
         lastTimestamp = nil
-        outputWasActive = false
-        onCameraMotion?(.zero)
-        EmulatorBridge.shared.setRightStick(x: 0, y: 0)
+        publish(.zero)
     }
 
     @objc private func update(_ link: CADisplayLink) {
@@ -337,14 +547,14 @@ final class SwipeCameraInputDriver: NSObject {
         let deltaTime = min(max(link.timestamp - previous, 1.0 / 240.0), 1.0 / 20.0)
         lastTimestamp = link.timestamp
 
+        guard heldJoystickVector == nil else { return }
+
         let delta = pendingDelta
         let isAiming = pendingDeltaIsAiming
         pendingDelta = .zero
         guard delta != .zero else {
             if outputWasActive {
-                outputWasActive = false
-                onCameraMotion?(.zero)
-                EmulatorBridge.shared.setRightStick(x: 0, y: 0)
+                publish(.zero)
             }
             return
         }
@@ -358,7 +568,11 @@ final class SwipeCameraInputDriver: NSObject {
             x: CGFloat(degreesPerSecondX / referenceDegreesPerSecond),
             y: CGFloat(degreesPerSecondY / referenceDegreesPerSecond)
         ).limited(to: 1)
-        outputWasActive = true
+        publish(motion)
+    }
+
+    private func publish(_ motion: DynamicThumbstickVector) {
+        outputWasActive = motion != .zero
         onCameraMotion?(motion)
         EmulatorBridge.shared.setRightStick(
             x: Float(motion.x),
@@ -478,6 +692,8 @@ private final class VirtualPadActionPressCoordinator {
     static let shared = VirtualPadActionPressCoordinator()
 
     private var pressedSources: [VirtualPadActionButton: Set<String>] = [:]
+    private var pulseTasks: [String: Task<Void, Never>] = [:]
+    private var pulseButtons: [String: VirtualPadActionButton] = [:]
 
     func set(_ button: VirtualPadActionButton, source: String, pressed: Bool) {
         var sources = pressedSources[button, default: []]
@@ -499,12 +715,47 @@ private final class VirtualPadActionPressCoordinator {
             EmulatorBridge.shared.setPadButton(button.padButton, pressed: isPressed)
         }
     }
+
+    func pulse(
+        _ button: VirtualPadActionButton,
+        source: String,
+        duration: TimeInterval = 0.075
+    ) {
+        pulseTasks[source]?.cancel()
+        if let previous = pulseButtons[source], previous != button {
+            set(previous, source: source, pressed: false)
+        }
+
+        pulseButtons[source] = button
+        set(button, source: source, pressed: true)
+        pulseTasks[source] = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(max(duration, 0)))
+            guard !Task.isCancelled, let self else { return }
+            self.set(button, source: source, pressed: false)
+            self.pulseTasks.removeValue(forKey: source)
+            self.pulseButtons.removeValue(forKey: source)
+        }
+    }
+}
+
+@MainActor
+func pulseVirtualPadActionButton(
+    _ button: VirtualPadActionButton,
+    source: String,
+    duration: TimeInterval = 0.075
+) {
+    VirtualPadActionPressCoordinator.shared.pulse(
+        button,
+        source: source,
+        duration: duration
+    )
 }
 
 @MainActor
 @Observable
 final class DynamicCrosshairRuntimeState {
     private(set) var isAiming = false
+    private(set) var isSwipeCrosshairVisible = false
     private(set) var isCameraMoving = false
     private(set) var isCameraSettling = false
     private(set) var isShooting = false
@@ -520,16 +771,17 @@ final class DynamicCrosshairRuntimeState {
     @ObservationIgnored private var sourceMotion: [DynamicCrosshairMotionSource: DynamicThumbstickVector] = [:]
     @ObservationIgnored private var settlingTask: Task<Void, Never>?
     @ObservationIgnored private var shotTask: Task<Void, Never>?
+    @ObservationIgnored private var swipeHideTask: Task<Void, Never>?
 
     func setAiming(_ aiming: Bool) {
         isAiming = aiming
-        if !aiming {
+        if !aiming && !isSwipeCrosshairVisible {
             clearTransientActivity()
         }
     }
 
     func updateCameraMotion(_ motion: DynamicThumbstickVector, source: DynamicCrosshairMotionSource) {
-        guard isAiming else { return }
+        guard isAiming || isSwipeCrosshairVisible else { return }
 
         let limitedMotion = motion.limited(to: 1.35)
         if limitedMotion.magnitude > 0.003 {
@@ -601,8 +853,31 @@ final class DynamicCrosshairRuntimeState {
     }
 
     func reset() {
+        swipeHideTask?.cancel()
+        swipeHideTask = nil
         isAiming = false
+        isSwipeCrosshairVisible = false
         clearTransientActivity()
+    }
+
+    func swipeInteractionBegan() {
+        swipeHideTask?.cancel()
+        swipeHideTask = nil
+        isSwipeCrosshairVisible = true
+    }
+
+    func swipeInteractionEnded(hideDelay: TimeInterval) {
+        swipeHideTask?.cancel()
+        let delay = max(hideDelay, 0)
+        swipeHideTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(delay))
+            guard !Task.isCancelled, let self else { return }
+            self.isSwipeCrosshairVisible = false
+            self.swipeHideTask = nil
+            if !self.isAiming {
+                self.clearTransientActivity()
+            }
+        }
     }
 
     private func clearTransientActivity() {
@@ -988,6 +1263,10 @@ struct DynamicAimCrosshairOverlay: View {
     private var activeRuntime: DynamicCrosshairRuntimeState? {
         if rightRuntime.isAiming { return rightRuntime }
         if leftRuntime.isAiming { return leftRuntime }
+        if settings.showCrosshairWhileHoldingSwipe,
+           rightRuntime.isSwipeCrosshairVisible {
+            return rightRuntime
+        }
         return nil
     }
 

--- a/platforms/ios/app/src/main/swift/Views/GameOverlayContainer.swift
+++ b/platforms/ios/app/src/main/swift/Views/GameOverlayContainer.swift
@@ -12,8 +12,9 @@ enum PauseLayoutVariant {
     /// iPad, any orientation: two side-by-side columns inside one unified scroll
     /// surface.
     case ipadTwoColumn
-    /// iPhone landscape: one wide single column. Covers every iPhone in landscape,
-    /// including Pro Max / Plus models that report a regular width size class.
+    /// iPhone landscape: one or two columns according to the panel's measured size.
+    /// Covers every iPhone in landscape, including Pro Max / Plus models that report
+    /// a regular width size class.
     case phoneLandscape
     /// iPhone portrait: one single column.
     case phonePortrait
@@ -36,7 +37,7 @@ struct OverlayMetrics {
     /// Deterministic dim behind the card. A plain opacity scrim is used instead of a
     /// SwiftUI Material, which collapses to a flat grey over a paused Metal frame
     /// (worst on iPad and under Reduce Transparency). Bumped for Reduce Transparency
-    /// users. Kept on the lighter side because the cards themselves are opaque.
+    /// users while remaining light enough for the paused game to show through glass.
     let scrimOpacity: Double
 
     init(size: CGSize, isIPad: Bool, safeArea: EdgeInsets, reduceTransparency: Bool) {
@@ -52,8 +53,8 @@ struct OverlayMetrics {
             let heightMargin: CGFloat = isLandscape ? 88 : 72
             let widthCap: CGFloat = isLandscape ? 980 : 620
             let heightCap: CGFloat = isLandscape ? 760 : 640
-            cardMaxWidth = min(widthCap, size.width - horizontalInset - widthMargin)
-            cardMaxHeight = min(heightCap, size.height - verticalInset - heightMargin)
+            cardMaxWidth = max(0, min(widthCap, size.width - horizontalInset - widthMargin))
+            cardMaxHeight = max(0, min(heightCap, size.height - verticalInset - heightMargin))
             scrimOpacity = reduceTransparency ? OverlayTheme.scrimPadReduceTransparency : OverlayTheme.scrimPad
         } else if isLandscape {
             // iPhone landscape: a tall floating command panel. Bounds leave a real margin
@@ -61,14 +62,14 @@ struct OverlayMetrics {
             // the virtual pad instead of reading as an edge-to-edge slab. Caps keep wide
             // phones from stretching past a comfortable reading width/height.
             variant = .phoneLandscape
-            cardMaxWidth = min(760, size.width - horizontalInset - 40)
-            cardMaxHeight = min(468, size.height - verticalInset - 36)
+            cardMaxWidth = max(0, min(760, size.width - horizontalInset - 40))
+            cardMaxHeight = max(0, min(468, size.height - verticalInset - 36))
             scrimOpacity = reduceTransparency ? OverlayTheme.scrimPhoneLandscapeReduceTransparency : OverlayTheme.scrimPhoneLandscape
         } else {
             // iPhone portrait: the liked compact card, slightly roomier.
             variant = .phonePortrait
-            cardMaxWidth = min(480, size.width - horizontalInset - 32)
-            cardMaxHeight = min(620, size.height - verticalInset - 32)
+            cardMaxWidth = max(0, min(480, size.width - horizontalInset - 32))
+            cardMaxHeight = max(0, min(620, size.height - verticalInset - 32))
             scrimOpacity = reduceTransparency ? OverlayTheme.scrimPhonePortraitReduceTransparency : OverlayTheme.scrimPhonePortrait
         }
     }
@@ -96,7 +97,6 @@ enum OverlayFrameMode {
 }
 
 struct GameOverlayContainer<Content: View>: View {
-    let safeAreaInsets: EdgeInsets
     var onTapOutside: (() -> Void)? = nil
     var frameMode: OverlayFrameMode = .bounded
     @ViewBuilder let content: (OverlayMetrics) -> Content
@@ -112,7 +112,16 @@ struct GameOverlayContainer<Content: View>: View {
 
     var body: some View {
         GeometryReader { geo in
-            let metrics = OverlayMetrics(size: geo.size, isIPad: isIPad, safeArea: safeAreaInsets, reduceTransparency: reduceTransparency)
+            // This geometry belongs to the active gameplay scene, so its insets update
+            // with rotation, Stage Manager, and system chrome. Using it here avoids a
+            // competing UIApplication/window lookup and preserves asymmetric notch space.
+            let safeAreaInsets = geo.safeAreaInsets
+            let metrics = OverlayMetrics(
+                size: geo.size,
+                isIPad: isIPad,
+                safeArea: safeAreaInsets,
+                reduceTransparency: reduceTransparency
+            )
 
             ZStack {
                 backdrop(metrics: metrics)
@@ -127,25 +136,21 @@ struct GameOverlayContainer<Content: View>: View {
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .transition(reduceMotion ? .opacity : .scale(scale: 0.97).combined(with: .opacity))
                 } else if frameMode == .landscapePanel && metrics.variant == .phoneLandscape {
-                    // Polished landscape panel: as tall as the deck, but a floating rounded
-                    // card with bounded width, corner radius, and shadow instead of a
-                    // full-bleed slab. Vertical clearance uses deck-style explicit safe-area
-                    // gutters (applied before the frame so they create outside clearance, not
-                    // internal content padding), which recovers the height the earlier
-                    // centered cardMaxHeight bound was losing on large iPhones.
-                    let panelGutter: CGFloat = 8
+                    // Keep the landscape panel floating and bounded. Safe-area padding is
+                    // outside the clipped card, so an asymmetric notch shifts the panel
+                    // into the usable region instead of becoming empty space inside it.
                     content(metrics)
-                        .padding(.top, max(safeAreaInsets.top, panelGutter))
-                        .padding(.bottom, max(safeAreaInsets.bottom, panelGutter))
-                        .frame(maxWidth: metrics.cardMaxWidth, maxHeight: .infinity)
+                        .frame(maxWidth: metrics.cardMaxWidth, maxHeight: metrics.cardMaxHeight)
                         .clipShape(RoundedRectangle(cornerRadius: 26, style: .continuous))
                         .shadow(color: .black.opacity(0.28), radius: 22, x: 0, y: 12)
+                        .padding(safeAreaInsets)
                         .transition(reduceMotion ? .opacity : .scale(scale: 0.97).combined(with: .opacity))
                 } else {
                     content(metrics)
                         .frame(maxWidth: metrics.cardMaxWidth, maxHeight: metrics.cardMaxHeight)
                         .clipShape(RoundedRectangle(cornerRadius: 26, style: .continuous))
                         .shadow(color: .black.opacity(0.28), radius: 22, x: 0, y: 12)
+                        .padding(safeAreaInsets)
                         .transition(reduceMotion ? .opacity : .scale(scale: 0.96).combined(with: .opacity))
                 }
             }

--- a/platforms/ios/app/src/main/swift/Views/GameScreenView.swift
+++ b/platforms/ios/app/src/main/swift/Views/GameScreenView.swift
@@ -277,14 +277,6 @@ struct GameScreenView: View {
             .first?.safeAreaInsets ?? .zero
     }
 
-    /// SwiftUI `EdgeInsets` view of `displaySafeAreaInsets`, for the shared overlay
-    /// container which bounds its card from the host window's safe-area insets so the
-    /// card clears the notch / Dynamic Island / home indicator.
-    private var displaySafeAreaEdgeInsets: EdgeInsets {
-        let insets = displaySafeAreaInsets
-        return EdgeInsets(top: insets.top, leading: insets.left, bottom: insets.bottom, trailing: insets.right)
-    }
-
     @ViewBuilder
     private var pauseMenuOverlay: some View {
         if case .paused = overlayRoute {
@@ -292,7 +284,6 @@ struct GameScreenView: View {
             // (`.pausedPresenting`) the card is omitted so it cannot z-order over the
             // child overlay; the child covers the screen and the card reappears on dismiss.
             GameOverlayContainer(
-                safeAreaInsets: displaySafeAreaEdgeInsets,
                 onTapOutside: { overlayRoute = .hidden },
                 frameMode: .landscapePanel
             ) { metrics in
@@ -474,7 +465,7 @@ struct GameScreenView: View {
                 // integrated with gameplay (no system sheet chrome / status bar / Dynamic
                 // Island leak). The panel dismisses via Save/Cancel, so the backdrop does
                 // not tap-to-dismiss.
-                GameOverlayContainer(safeAreaInsets: displaySafeAreaEdgeInsets, frameMode: .landscapePanel) { _ in
+                GameOverlayContainer(frameMode: .landscapePanel) { _ in
                     runtimePerGameSettingsContent
                 }
                 .id(screenIsLandscape)

--- a/platforms/ios/app/src/main/swift/Views/OverlayDesignSystem.swift
+++ b/platforms/ios/app/src/main/swift/Views/OverlayDesignSystem.swift
@@ -8,12 +8,9 @@ import SwiftUI
 /// In-game overlay design tokens. Scoped to overlays presented over gameplay (the pause menu and
 /// Per-Game Settings) — this is NOT a global app theme.
 ///
-/// The surfaces are a graphite/charcoal ladder (shell -> card -> elevated) so an overlay reads as a
-/// premium "console command deck" with clear grouping and depth, without going darker overall and
-/// without a pure-black-hole background. Chrome uses a controlled glass stack (SwiftUI Material
-/// under a graphite tint that wins the hue) so it reads as frosted glass without picking up muddy
-/// game colors; the gameplay scrim stays a plain tinted color and never uses Material. Blue is the
-/// accent only (never row titles); red is destructive only.
+/// The clear glass shell uses lightly tinted section cards for grouping while allowing paused
+/// gameplay to remain visible. The gameplay scrim stays a plain tinted color and never uses
+/// Material. Blue is the accent only (never row titles); red is destructive only.
 enum OverlayTheme {
     // MARK: Surfaces — opaque graphite ladder (darkest -> lightest)
 
@@ -68,7 +65,7 @@ enum OverlayTheme {
     // MARK: Glass — controlled frosted chrome (panel shell + cards; never the gameplay scrim)
 
     static let shellGlassTint: Double = 0.72
-    static let cardGlassTint: Double = 0.78
+    static let cardGlassTint: Double = 0.28
     static let glassTopHighlight = Color.white.opacity(0.10)
     static let cardTopHighlight = Color.white.opacity(0.07)
     static let cardShadow = Color.black.opacity(0.18)
@@ -117,11 +114,10 @@ extension EnvironmentValues {
     }
 }
 
-/// Opaque overlay shell content. Host this INSIDE `GameOverlayContainer` (which supplies the scrim,
-/// bounded card, corner clipping and shadow); the scaffold is the panel's CONTENT, not the card
-/// frame. It applies the graphite shell background, clamps Dynamic Type so oversized type cannot
-/// break the bounded card, and scopes the accent tint LOCALLY so children inherit the overlay
-/// accent without touching the global app tint. Header/footer are composed by the caller.
+/// Clear glass overlay shell content. Host this INSIDE `GameOverlayContainer` (which supplies the
+/// scrim, bounded card, corner clipping, and shadow); the scaffold is the panel's CONTENT, not the
+/// card frame. One shared glass surface avoids stacking a separate material renderer under every
+/// section. It also clamps Dynamic Type and scopes the accent tint locally.
 struct OverlayPanelScaffold<Content: View>: View {
     private let content: Content
 
@@ -133,7 +129,7 @@ struct OverlayPanelScaffold<Content: View>: View {
         content
             .dynamicTypeSize(...DynamicTypeSize.accessibility3)
             .tint(OverlayTheme.accent)
-            .background(OverlayFrostBackground())
+            .glassSurface(clear: true, cornerRadius: 26)
     }
 }
 
@@ -185,9 +181,9 @@ struct OverlaySectionCard<Content: View>: View {
 }
 
 /// Pinned overlay footer: a full-width primary action (Resume / Save) as a `borderedProminent`
-/// button tinted with the overlay accent, plus an optional secondary action, on the shell surface
-/// with a top hairline. Apply via `.safeAreaInset(edge: .bottom)`. Pass `compact: true` for the
-/// iPad / iPhone-landscape sizing; the default `.large` is the liked iPhone-portrait size.
+/// button tinted with the overlay accent, plus an optional secondary action. It inherits the
+/// scaffold's single glass surface and adds only a top hairline. Apply via
+/// `.safeAreaInset(edge: .bottom)`.
 struct OverlayFooter: View {
     private let primaryLabel: String
     private let primarySystemImage: String
@@ -233,7 +229,6 @@ struct OverlayFooter: View {
             .padding(.top, 8)
             .padding(.bottom, compact ? 10 : 14)
         }
-        .background(OverlayFrostBackground())
         .tint(OverlayTheme.accent)
     }
 }
@@ -292,7 +287,6 @@ struct OverlayHeader: View {
 /// truncation, so on a narrow width the trailing value elides first while the label stays intact.
 /// The label is never blue (`textPrimary`); red is used only when `isDestructive`.
 struct OverlayActionRow: View {
-    @Environment(\.overlayCompact) private var compact
     private let label: String
     private let systemImage: String?
     private let trailingValue: String?
@@ -335,7 +329,7 @@ struct OverlayActionRow: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .frame(minHeight: compact ? 38 : 44)
+            .frame(minHeight: 44)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -345,7 +339,6 @@ struct OverlayActionRow: View {
 /// A toggle row on the graphite card: graphite label + accent switch (accent comes from the
 /// scaffold's local `.tint`). Matches `OverlayActionRow` height so toggles and actions align.
 struct OverlayToggleRow: View {
-    @Environment(\.overlayCompact) private var compact
     private let label: String
     private let systemImage: String
     @Binding private var isOn: Bool
@@ -369,6 +362,6 @@ struct OverlayToggleRow: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .frame(minHeight: compact ? 38 : 44)
+        .frame(minHeight: 44)
     }
 }

--- a/platforms/ios/app/src/main/swift/Views/QuickMenuView.swift
+++ b/platforms/ios/app/src/main/swift/Views/QuickMenuView.swift
@@ -15,11 +15,10 @@ enum QuickMenuDestination: Equatable {
     case resetROM
 }
 
-/// Native in-game pause menu: a premium opaque graphite "command deck" presented by the host as a
-/// bounded card over a lighter, controlled dim of the paused gameplay. The host pauses the VM
-/// while this card is shown. Toggles are bound directly; everything else is routed back to the
-/// host through closures (unchanged from before) so the existing panels, child-screen routing and
-/// confirmation flows stay exactly as in Phase A.
+/// Native in-game pause menu: a clear Liquid Glass "command deck" presented by the host as a
+/// bounded card over a controlled dim of the paused gameplay. The host pauses the VM while this
+/// card is shown. Toggles are bound directly; everything else is routed back to the host through
+/// closures so existing panels, child-screen routing, and confirmation flows remain unchanged.
 ///
 /// Layout adapts to the card's geometry (read via a GeometryReader, since the host frames this
 /// view to the bounded card size): two columns when the card is comfortably wide, one column
@@ -55,6 +54,10 @@ struct QuickMenuView: View {
         GeometryReader { geo in
             overlayBody(width: geo.size.width, height: geo.size.height)
         }
+        .environment(
+            \.clearLiquidGlassUIEnabled,
+            settings.clearLiquidGlassUIQuickMenu
+        )
     }
 
     @ViewBuilder
@@ -93,7 +96,7 @@ struct QuickMenuView: View {
                     iconOnly: width < 380
                 )
                 ScrollView {
-                    cardsContent(twoColumns: width > 700)
+                    cardsContent(twoColumns: supportsTwoColumns(width: width, height: height))
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -101,11 +104,9 @@ struct QuickMenuView: View {
         .environment(\.overlayCompact, true)
     }
 
-    /// Two columns only when the card is wide enough to keep both columns comfortable.
-    /// iPad portrait and short/small phone-landscape devices fall back to one column.
-    /// iPhone portrait always uses a single-column scroll layout — the screen is
-    /// too narrow for two comfortable columns, even on Plus/Max devices. Landscape
-    /// and iPad still get two columns when wide enough.
+    /// Two columns only when the measured card can keep both columns comfortable.
+    /// iPhone portrait always uses one column, while compact landscape and iPad
+    /// layouts fall back to one column below their respective usable-size threshold.
     private func supportsTwoColumns(width: CGFloat, height: CGFloat) -> Bool {
         switch variant {
         case .phonePortrait:
@@ -113,7 +114,9 @@ struct QuickMenuView: View {
         case .ipadTwoColumn:
             return width >= 500 && height >= 320
         case .phoneLandscape:
-            return width >= 570 && height >= 300
+            // Notched 19.5:9 iPhones retain at least 640 points after safe-area
+            // clearance; smaller 16:9 phones continue using the compact column.
+            return width >= 640 && height >= 300
         }
     }
 
@@ -257,13 +260,13 @@ struct QuickMenuView: View {
     }
 
     /// Hosts an injected SwiftUI `Menu` (controller skin / change disc) as a row that matches the
-    /// graphite action rows as closely as an opaque AnyView allows. The menu's own action
+    /// action rows as closely as an opaque AnyView allows. The menu's own action
     /// semantics are untouched.
     @ViewBuilder
     private func injectedMenuRow(_ menu: AnyView) -> some View {
         menu
             .foregroundStyle(OverlayTheme.textPrimary)
-            .frame(maxWidth: .infinity, minHeight: variant == .phoneLandscape ? 38 : 44, alignment: .leading)
+            .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
     }
 }
 
@@ -300,7 +303,7 @@ private struct LandscapeCommandBar: View {
                     }
                 }
                 .buttonStyle(.borderedProminent)
-                .controlSize(.small)
+                .controlSize(.regular)
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 6)

--- a/platforms/ios/app/src/main/swift/Views/RootView.swift
+++ b/platforms/ios/app/src/main/swift/Views/RootView.swift
@@ -410,6 +410,7 @@ struct MenuTabView: View {
     @State private var selectedTab = 0
     @State private var activeLibraryTab = 0
     @State private var settingsRootResetRequest = 0
+    @State private var settingsNavigationHasDestination = false
     @State private var menuLargeTitleMorphActive = false
     @State private var menuLargeTitleMorphResetTask: Task<Void, Never>?
     let backgroundHost: PersistentMenuBackgroundHost
@@ -494,7 +495,10 @@ struct MenuTabView: View {
                             BIOSListView()
                         default:
                             SettingsRootView(
-                                resetToRootRequest: settingsRootResetRequest
+                                resetToRootRequest: settingsRootResetRequest,
+                                onNavigationPathActivityChanged: {
+                                    settingsNavigationHasDestination = $0
+                                }
                             )
                         }
                     }
@@ -568,13 +572,17 @@ struct MenuTabView: View {
                         appliesLegacyLandscapeInsets: !settingsBackgroundActive
                     ) {
                         SettingsRootView(
-                            resetToRootRequest: settingsRootResetRequest
+                            resetToRootRequest: settingsRootResetRequest,
+                            onNavigationPathActivityChanged: {
+                                settingsNavigationHasDestination = $0
+                            }
                         )
                     }
                     .environment(\.menuTabIsActive, selectedTab == 2)
                     .retainedMenuTabPage(2, selection: selectedTab)
 
                     NativeMenuTabSwipeRecognizer(
+                        isEnabled: selectedTab != 2 || !settingsNavigationHasDestination,
                         onSwipe: navigateFromHorizontalSwipe
                     )
                     .frame(width: 0, height: 0)
@@ -1217,16 +1225,19 @@ private struct NativeMenuTabBar: UIViewRepresentable {
 /// ownership of their own drags.
 @MainActor
 private struct NativeMenuTabSwipeRecognizer: UIViewRepresentable {
+    let isEnabled: Bool
     let onSwipe: (CGFloat) -> Void
 
     func makeUIView(context: Context) -> InstallerView {
         let view = InstallerView()
         view.onSwipe = onSwipe
+        view.setEnabled(isEnabled)
         return view
     }
 
     func updateUIView(_ uiView: InstallerView, context: Context) {
         uiView.onSwipe = onSwipe
+        uiView.setEnabled(isEnabled)
     }
 
     static func dismantleUIView(_ uiView: InstallerView, coordinator: ()) {
@@ -1235,6 +1246,7 @@ private struct NativeMenuTabSwipeRecognizer: UIViewRepresentable {
 
     final class InstallerView: UIView, UIGestureRecognizerDelegate {
         var onSwipe: (CGFloat) -> Void = { _ in }
+        private var recognizesTabSwipes = true
         private weak var gestureHost: UIView?
         private lazy var panGesture: UIPanGestureRecognizer = {
             let gesture = UIPanGestureRecognizer(
@@ -1256,6 +1268,12 @@ private struct NativeMenuTabSwipeRecognizer: UIViewRepresentable {
         func uninstall() {
             gestureHost?.removeGestureRecognizer(panGesture)
             gestureHost = nil
+        }
+
+        func setEnabled(_ enabled: Bool) {
+            guard recognizesTabSwipes != enabled else { return }
+            recognizesTabSwipes = enabled
+            panGesture.isEnabled = enabled
         }
 
         private func install(on host: UIView?) {
@@ -1281,7 +1299,8 @@ private struct NativeMenuTabSwipeRecognizer: UIViewRepresentable {
         override func gestureRecognizerShouldBegin(
             _ gestureRecognizer: UIGestureRecognizer
         ) -> Bool {
-            guard let pan = gestureRecognizer as? UIPanGestureRecognizer,
+            guard recognizesTabSwipes,
+                  let pan = gestureRecognizer as? UIPanGestureRecognizer,
                   let gestureHost else {
                 return false
             }

--- a/platforms/ios/app/src/main/swift/Views/Settings/AppearanceSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/AppearanceSettingsView.swift
@@ -122,13 +122,16 @@ struct AppearanceSettingsView: View {
                 Toggle(isOn: $settings.clearLiquidGlassUI) {
                     Label(settings.localized("Clear Liquid Glass UI"), systemImage: "rectangle.on.rectangle")
                 }
+                Toggle(isOn: $settings.clearLiquidGlassUIQuickMenu) {
+                    Label(settings.localized("Clear Liquid Glass UI Quick Menu"), systemImage: "pause.rectangle")
+                }
                 Toggle(isOn: $settings.gameCardZoomAnimationEnabled) {
                     Label(settings.localized("Game-Card Zoom Animation"), systemImage: "rectangle.inset.filled.and.person.filled")
                 }
             } header: {
                 Text(settings.localized("Interface"))
             } footer: {
-                Text(settings.localized("Uses the clear Liquid Glass style for menu cards and controls. Turn this off to use the more opaque regular Liquid Glass style."))
+                Text(settings.localized("Choose the clear Liquid Glass style independently for the main interface and Quick Menu. Disabled options use the more opaque regular Liquid Glass style."))
             }
         }
         .navigationTitle(settings.localized("Appearance"))

--- a/platforms/ios/app/src/main/swift/Views/Settings/SettingsRootView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/SettingsRootView.swift
@@ -117,6 +117,7 @@ private enum SettingsPane: String, CaseIterable, Identifiable {
 
 struct SettingsRootView: View {
     let resetToRootRequest: Int
+    let onNavigationPathActivityChanged: (Bool) -> Void
     @State private var settings = SettingsStore.shared
     @State private var jitAvailable = false
     @State private var noJITFallbackActive = false
@@ -130,8 +131,12 @@ struct SettingsRootView: View {
     @State private var selectedPane: SettingsPane? = .emulator
 #endif
 
-    init(resetToRootRequest: Int = 0) {
+    init(
+        resetToRootRequest: Int = 0,
+        onNavigationPathActivityChanged: @escaping (Bool) -> Void = { _ in }
+    ) {
         self.resetToRootRequest = resetToRootRequest
+        self.onNavigationPathActivityChanged = onNavigationPathActivityChanged
     }
 
     private var backgroundConfigured: Bool {
@@ -352,6 +357,12 @@ struct SettingsRootView: View {
             withTransaction(transaction) {
                 navigationPath.removeAll()
             }
+        }
+        .onChange(of: navigationPath.isEmpty) { _, isEmpty in
+            onNavigationPathActivityChanged(!isEmpty)
+        }
+        .onAppear {
+            onNavigationPathActivityChanged(!navigationPath.isEmpty)
         }
 #endif
     }

--- a/platforms/ios/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift
@@ -280,7 +280,7 @@ struct VirtualPadSettingsView: View {
             } header: {
                 Text(settings.localized("Dynamic Control Presets"))
             } footer: {
-                Text(settings.localized("Selecting a preset changes only the listed Dynamic Control options. All sensitivity, button assignments, and other Virtual Pad settings are preserved."))
+                Text(settings.localized("Each preset applies its listed Dynamic Control configuration. Unrelated Virtual Pad appearance and controller-layout settings are preserved."))
                     .lineLimit(nil)
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -306,6 +306,82 @@ struct VirtualPadSettingsView: View {
                 Text(settings.localized("Dynamic Controls"))
             } footer: {
                 Text(settings.localized("Legacy and Dynamic Thumbsticks are mutually exclusive. Dynamic sticks appear where each touch begins. Swipe Camera replaces the right touch stick, while Gyroscope Camera augments the active right-side control."))
+            }
+
+            Section {
+                Toggle(
+                    settings.localized("Left Thumbstick Instant Deadzone"),
+                    isOn: $dynamicSettings.leftInstantDeadzoneEnabled
+                )
+                if dynamicSettings.leftInstantDeadzoneEnabled {
+                    DynamicControlSlider(
+                        title: settings.localized("Left Negative Deadzone"),
+                        value: $dynamicSettings.leftNegativeDeadzone,
+                        range: -0.25...0,
+                        step: 0.01,
+                        valueLabel: negativeDeadzoneLabel
+                    )
+                }
+
+                Toggle(
+                    settings.localized("Right Thumbstick Instant Deadzone"),
+                    isOn: $dynamicSettings.rightInstantDeadzoneEnabled
+                )
+                if dynamicSettings.rightInstantDeadzoneEnabled {
+                    DynamicControlSlider(
+                        title: settings.localized("Right Negative Deadzone"),
+                        value: $dynamicSettings.rightNegativeDeadzone,
+                        range: -0.25...0,
+                        step: 0.01,
+                        valueLabel: negativeDeadzoneLabel
+                    )
+                }
+
+                DynamicControlSlider(
+                    title: settings.localized("Left Thumbstick Movement Area"),
+                    value: $dynamicSettings.leftThumbstickAreaScale,
+                    range: 1...5,
+                    step: 0.25,
+                    valueLabel: thumbstickAreaScaleLabel
+                )
+                DynamicControlSlider(
+                    title: settings.localized("Right Thumbstick Movement Area"),
+                    value: $dynamicSettings.rightThumbstickAreaScale,
+                    range: 1...5,
+                    step: 0.25,
+                    valueLabel: thumbstickAreaScaleLabel
+                )
+
+                Toggle(
+                    settings.localized("Convert Swipe to Dynamic Joystick"),
+                    isOn: $dynamicSettings.convertSwipeToDynamicJoystick
+                )
+                if dynamicSettings.convertSwipeToDynamicJoystick {
+                    DynamicControlSlider(
+                        title: settings.localized("Convert Into Dynamic Thumbstick"),
+                        value: Binding(
+                            get: { dynamicSettings.convertIntoDynamicThumbstickThreshold },
+                            set: { dynamicSettings.setConvertIntoDynamicThumbstickThreshold($0) }
+                        ),
+                        range: 0.01...3,
+                        step: 0.01,
+                        valueLabel: percentageLabel
+                    )
+                    DynamicControlSlider(
+                        title: settings.localized("Pulling Back Distance"),
+                        value: Binding(
+                            get: { dynamicSettings.pullingBackDistance },
+                            set: { dynamicSettings.setPullingBackDistance($0) }
+                        ),
+                        range: 0.01...1,
+                        step: 0.01,
+                        valueLabel: percentageLabel
+                    )
+                }
+            } header: {
+                Text(settings.localized("Instant Movement & Aiming"))
+            } footer: {
+                Text(settings.localized("Instant deadzones add the selected minimum output only after real movement, while preserving the progressive Dynamic Thumbstick deadzone. Movement areas default to 3× without enlarging the visible controls. Swipe conversion enters Dynamic Thumbstick mode at the selected outward distance. Pulling back by the selected distance returns to Swipe Camera and temporarily rebases the next outward conversion point until the screen is released."))
             }
 
             controlSensitivitySection
@@ -338,6 +414,23 @@ struct VirtualPadSettingsView: View {
                     isOn: $dynamicSettings.dynamicCrosshairEnabled
                 )
                 if dynamicSettings.dynamicCrosshairEnabled {
+                    Toggle(
+                        settings.localized("Show Crosshair While Holding Swipe"),
+                        isOn: $dynamicSettings.showCrosshairWhileHoldingSwipe
+                    )
+                    .disabled(!dynamicSettings.swipeCamera)
+
+                    if dynamicSettings.showCrosshairWhileHoldingSwipe {
+                        DynamicControlSlider(
+                            title: settings.localized("Crosshair Hide Delay"),
+                            value: $dynamicSettings.swipeCrosshairHideDelay,
+                            range: 0...3,
+                            step: 0.1,
+                            valueLabel: durationLabel
+                        )
+                        .disabled(!dynamicSettings.swipeCamera)
+                    }
+
                     DynamicControlSlider(
                         title: settings.localized("Crosshair Size"),
                         value: $dynamicSettings.dynamicCrosshairSize,
@@ -372,7 +465,7 @@ struct VirtualPadSettingsView: View {
             } header: {
                 Text(settings.localized("Dynamic Crosshair"))
             } footer: {
-                Text(settings.localized("The crosshair appears only while Aim Mode is active. Every animation follows live swipe, thumbstick, and gyroscope direction and speed, then reacts separately to single shots and automatic fire."))
+                Text(settings.localized("The crosshair appears while Aim Mode is active and can remain visible while holding Swipe Camera. The hide delay controls how long it stays after the swipe ends. Every animation follows live swipe, thumbstick, and gyroscope direction and speed, then reacts separately to single shots and automatic fire."))
             }
 
             if dynamicSettings.dynamicThumbsticks {
@@ -470,6 +563,18 @@ struct VirtualPadSettingsView: View {
                 (dynamicSettings.dynamicThumbsticks &&
                     (dynamicSettings.leftThumbstickActionsEnabled || dynamicSettings.rightThumbstickActionsEnabled)) {
                 Section {
+                    if dynamicSettings.swipeCamera {
+                        Picker(
+                            settings.localized("Trigger Button When Un-holding Swipe"),
+                            selection: $dynamicSettings.triggerButtonWhenUnholdingSwipe
+                        ) {
+                            Text(settings.localized("Off")).tag(-1)
+                            ForEach(VirtualPadActionButton.allCases) { button in
+                                Text(settings.localized(button.title)).tag(button.rawValue)
+                            }
+                        }
+                    }
+
                     Toggle(
                         dynamicActionTitle("Hold Aim While Touching Camera", role: .aim),
                         isOn: Binding(
@@ -1066,6 +1171,14 @@ struct VirtualPadSettingsView: View {
 
     private func percentageLabel(_ value: Double) -> String {
         "\(Int((value * 100).rounded()))%"
+    }
+
+    private func negativeDeadzoneLabel(_ value: Double) -> String {
+        "\(Int((value * 100).rounded()))% \(settings.localized("Deadzone"))"
+    }
+
+    private func thumbstickAreaScaleLabel(_ value: Double) -> String {
+        String(format: "%.2fx", value)
     }
 
     private func durationLabel(_ value: Double) -> String {

--- a/platforms/ios/app/src/main/swift/Views/VirtualControllerView.swift
+++ b/platforms/ios/app/src/main/swift/Views/VirtualControllerView.swift
@@ -322,6 +322,9 @@ struct VirtualControllerView: View {
         .onChange(of: dynamicSettings.dynamicThumbsticks) { _, _ in
             resetDynamicInputs()
         }
+        .onChange(of: dynamicSettings.convertSwipeToDynamicJoystick) { _, _ in
+            resetDynamicInputs()
+        }
         .onChange(of: dynamicSettings.leftThumbstickActionsEnabled) { _, _ in
             resetDynamicInputs()
         }
@@ -514,6 +517,11 @@ struct VirtualControllerView: View {
 
     @ViewBuilder
     private func dynamicInputZones(w: CGFloat, h: CGFloat) -> some View {
+        let conversionSettings = dynamicSettings.effectiveSwipeConversionSettings
+        let visualRadius = CGFloat(dynamicSettings.thumbstickRadius)
+        let rightAreaScale = CGFloat(
+            min(max(dynamicSettings.rightThumbstickAreaScale, 1), 5)
+        )
         Group {
             if dynamicSettings.dynamicThumbsticks && isVisible("lstick") {
                 dynamicThumbstickZone(isLeft: true)
@@ -525,10 +533,30 @@ struct VirtualControllerView: View {
                 VirtualPadCameraSwipeView(
                     maximumTapDuration: dynamicSettings.tapMaximumDuration,
                     tapTravelTolerance: CGFloat(dynamicSettings.tapTravelTolerance),
+                    convertsToDynamicJoystick: dynamicSettings.convertSwipeToDynamicJoystick,
+                    thumbstickRadius: visualRadius,
+                    maximumThumbstickRadius: visualRadius * rightAreaScale,
+                    thumbstickDeadZone: CGFloat(dynamicSettings.deadZone),
+                    convertIntoDynamicThumbstickThreshold: CGFloat(
+                        conversionSettings.dynamicThumbstick
+                    ),
+                    pullingBackDistance: CGFloat(conversionSettings.pullingBack),
+                    thumbstickOpacity: dynamicSettings.thumbstickOpacity,
+                    baseOpacity: dynamicSettings.baseOpacity,
+                    trailOpacity: dynamicSettings.trailOpacity,
+                    hapticsEnabled: dynamicSettings.activationHaptics,
                     onDelta: {
                         swipeInput.add(delta: $0, isAiming: activeTouchActionSession.right.isAiming)
                     },
+                    onDynamicJoystick: {
+                        swipeInput.setDynamicJoystick($0)
+                    },
                     onBegan: {
+                        if dynamicSettings.dynamicCrosshairEnabled &&
+                            dynamicSettings.showCrosshairWhileHoldingSwipe {
+                            activeTouchActionSession.right.crosshairState
+                                .swipeInteractionBegan()
+                        }
                         if dynamicSettings.rightThumbstickActionsEnabled {
                             activeTouchActionSession.right.interactionBegan()
                         }
@@ -543,7 +571,19 @@ struct VirtualControllerView: View {
                             activeTouchActionSession.right.interactionTapped()
                         }
                     },
+                    onReleased: {
+                        if let button = dynamicSettings.swipeReleaseActionButton {
+                            pulseVirtualPadActionButton(
+                                button,
+                                source: "cameraSwipe.release"
+                            )
+                        }
+                    },
                     onEnded: {
+                        activeTouchActionSession.right.crosshairState
+                            .swipeInteractionEnded(
+                                hideDelay: dynamicSettings.swipeCrosshairHideDelay
+                            )
                         if dynamicSettings.rightThumbstickActionsEnabled {
                             activeTouchActionSession.right.interactionEnded()
                         }
@@ -567,9 +607,23 @@ struct VirtualControllerView: View {
         let actionController = isLeft
             ? activeTouchActionSession.left
             : activeTouchActionSession.right
+        let visualRadius = CGFloat(dynamicSettings.thumbstickRadius)
+        let areaScale = CGFloat(
+            min(
+                max(
+                    isLeft
+                        ? dynamicSettings.leftThumbstickAreaScale
+                        : dynamicSettings.rightThumbstickAreaScale,
+                    1
+                ),
+                5
+            )
+        )
         return DynamicThumbstickView(
             isLeft: isLeft,
-            radius: CGFloat(dynamicSettings.thumbstickRadius),
+            radius: visualRadius,
+            maximumRadius: visualRadius * areaScale,
+            deadZoneProgressRadius: isLeft ? visualRadius : nil,
             deadZone: CGFloat(dynamicSettings.deadZone),
             hapticsEnabled: dynamicSettings.activationHaptics,
             thumbstickOpacity: dynamicSettings.thumbstickOpacity,


### PR DESCRIPTION
# iOS: Virtual Pad Extensions, Native Sub-Settings Swipe, and Quick Menu Refinements

## Master Base and Package Scope

The changes are limited to three feature groups:

1. Virtual Pad and Dynamic Controls.
2. Native back-swipe behavior inside Settings sub-screens.
3. Quick Menu layout and optional clear Liquid Glass.

Overall source diff:

- 14 modified Swift files.
- 842 inserted lines.
- 102 removed lines.
- No native emulator-core, CMake, Metal renderer, or Objective-C++ changes.

## Summary

This PR expands touch-first gameplay controls while keeping the existing
controller and emulator input paths intact. It adds instant movement/aiming
options, configurable Dynamic Thumbstick travel areas, adaptive conversion
between Swipe Camera and joystick control, swipe crosshair and release actions,
and a complete Classic First Person Shooter preset.

It also resolves a gesture conflict in Settings: a rightward swipe inside a
sub-setting now belongs to the native `NavigationStack` back gesture instead of
switching the root tab to BIOS.

Finally, it refines the in-game Quick Menu with active-scene safe-area geometry,
responsive two-column landscape presentation, consistent touch targets, and an
independent clear Liquid Glass preference.

## Virtual Pad and Dynamic Controls

### Instant Movement and Aiming

A new `Instant Movement & Aiming` section is available under:

`Settings → Virtual Pad → Dynamic Controls`

It provides:

- `Left Thumbstick Instant Deadzone`
- `Left Negative Deadzone`
- `Right Thumbstick Instant Deadzone`
- `Right Negative Deadzone`
- `Left Thumbstick Movement Area`
- `Right Thumbstick Movement Area`
- `Convert Swipe to Dynamic Joystick`
- `Convert Into Dynamic Thumbstick`
- `Pulling Back Distance`

The instant-deadzone options add a radial minimum output only after real finger
or motion input exists. A stationary touch still produces zero input, preventing
drift. Output direction is preserved, and input above the selected floor is not
rescaled.

The minimum-output floor is applied at the shared emulator bridge:

- Left output covers the Dynamic Left Thumbstick path.
- Right output covers Dynamic Right Thumbstick, Swipe Camera, converted joystick,
  and gyroscope-combined right-stick output.
- Existing stick inversion remains applied after the radial correction.

This does not replace the progressive Dynamic Thumbstick deadzone. The stick
still begins at a true 0% deadzone and progressively reaches the configured
deadzone as travel increases.

### Larger Configurable Thumbstick Movement Areas

The visible thumbstick size remains controlled by `Maximum Radius`, while the
distance needed to reach 100% input can now be enlarged independently:

- Left and right movement-area scales support `1.00×` through `5.00×`.
- New installations default both areas to `3.00×`.
- The on-screen thumbstick artwork does not become three times larger.
- Input, trail progress, overextension detection, and converted Swipe Camera
  joystick output use the expanded input radius.

The left stick uses a separate deadzone-progression radius. This allows its
expanded travel area to coexist with the existing rule that the configured
deadzone progressively reaches its selected value at the visible Maximum Radius.

### Maximum-Pull Pulse and Haptic Feedback

Crossing beyond the configured maximum movement radius:

- Pulses the Dynamic Thumbstick origin indicator.
- Produces medium haptic feedback when activation haptics and global haptics are
  enabled.
- Uses a 95% re-entry boundary to prevent small finger jitter from repeatedly
  retriggering haptics at the edge.
- Resets when the touch ends.

The same feedback applies when Swipe Camera has converted into Dynamic Joystick
mode.

### Swipe Camera to Dynamic Joystick Conversion

`Convert Swipe to Dynamic Joystick` allows one continuous right-side gesture to
move between relative camera swiping and held analog-stick input.

Behavior:

1. A touch begins as normal Swipe Camera input.
2. Outward travel crossing `Convert Into Dynamic Thumbstick` changes the gesture
   to an analog right-stick hold.
3. The conversion threshold supports `1%` through `300%` and defaults to `100%`.
4. Pulling back by the configured `Pulling Back Distance`, rather than returning
   to a fixed absolute radius, changes the gesture back to Swipe Camera.
5. The return point becomes the next temporary outward conversion point for the
   same touch.
6. Releasing the screen resets the temporary threshold to the saved setting.

For example, at 150% outward travel with a 5% pullback distance, returning to
145% changes back to Swipe Camera. The user does not have to return all the way
to an old fixed 90% threshold.

The Swipe Camera driver has one authoritative output mode at a time:

- Relative swipe deltas are ignored while a converted joystick vector is held.
- Entering joystick mode clears queued swipe deltas.
- Leaving joystick mode publishes a zero vector before normal swipe updates
  resume.
- Disabling conversion or changing relevant Dynamic Control modes resets active
  input, preventing a stuck right stick.

### Crosshair While Holding Swipe

The Dynamic Crosshair section adds:

- `Show Crosshair While Holding Swipe`
- `Crosshair Hide Delay`

When enabled, the selected Dynamic Crosshair can appear during Swipe Camera even
when Aim Mode is not active. It continues receiving live camera motion and
reactive animation data.

After the swipe ends, an asynchronous hide task retains the crosshair for the
configured delay, which defaults to `0.5 s`. A new swipe cancels the pending hide
task. Reset and gameplay teardown cancel it as well.

### Trigger Button When Releasing Swipe

Dynamic Actions adds:

`Trigger Button When Un-holding Swipe`

The picker supports Off and every existing PlayStation virtual-pad action. When
the camera-zone touch ends, the selected action is asserted as a short `75 ms`
pulse.

The pulse coordinator:

- Shares button-source ownership with existing Dynamic Actions.
- Prevents one source from incorrectly releasing a button still held by another
  source.
- Cancels or replaces an earlier release pulse from the same source.
- Releases the button automatically without blocking the main thread.

### Classic First Person Shooter Preset

Dynamic Control Presets adds:

`Classic First Person Shooter`

The preset configures the full control profile represented by the new settings,
including:

- Dynamic Thumbsticks and Swipe Camera enabled.
- Gyroscope Camera disabled.
- Left instant deadzone at `-8%`.
- Right instant deadzone at `-14%`.
- Left movement area at `1.00×`.
- Right movement area at `1.75×`.
- Swipe conversion at `100%` with `5%` pullback.
- Base swipe sensitivity at `0.28°/pt`.
- Non-aiming swipe sensitivity at `0.75°/pt`.
- Right-thumbstick Dynamic Actions using L1 for Aim and R1 for Fire/Hold Fire.
- Four-Box Reactive crosshair at 32 pt and 70% opacity.
- Crosshair while holding Swipe Camera enabled with a `0.5 s` hide delay.
- Non-aim single- and multi-tap actions enabled.
- Automatic-fire timing, release behavior, and action travel tolerances.
- Existing activation haptics and thumbstick appearance values shown by the
  preset.

Preset detection compares every managed value, so the preset remains selected
only while its complete configuration is active. Applying it preserves unrelated
Virtual Pad appearance, imported skin, and controller-layout settings.

### Persistence and Defaults

Every new Dynamic Control option is stored with the existing
`DynamicThumbstickSettings` UserDefaults namespace and restored on launch.
`resetToDefaults()` also resets every new value.

## Native Back Swipe in Settings Sub-Screens

### Problem

ARMSX2 has an app-wide horizontal pan recognizer for moving between Games, BIOS,
and Settings. The Settings screen also uses the native `NavigationStack`
interactive-pop gesture.

When a child setting was open, both recognizers could accept the same rightward
swipe. The app-wide recognizer could win and navigate to BIOS instead of returning
to the parent Settings screen.

### Resolution

`SettingsRootView` now reports whether its navigation path is empty.
`MenuTabView` uses that state to control the root tab-swipe recognizer.

- Games and BIOS retain horizontal tab swiping.
- Settings retains horizontal tab swiping at its root screen.
- While any Settings child is pushed, the app-wide tab recognizer is disabled.
- The native interactive back gesture exclusively owns the swipe.
- Completing or cancelling the native back gesture keeps the correct navigation
  state.
- Returning or resetting Settings to its root automatically re-enables tab
  swiping.
- Bottom-tab selection remains available while a Settings child is open.

This preserves native `NavigationStack` behavior; it does not implement a custom
pop animation or manually mutate the Settings path during a gesture.

## Quick Menu

### Active-Scene Safe-Area Geometry

`GameOverlayContainer` now uses `GeometryProxy.safeAreaInsets` from the active
gameplay overlay instead of converting insets from the first application window.

This:

- Tracks the actual scene and current orientation.
- Handles asymmetric landscape notch and Dynamic Island clearance.
- Behaves correctly with multi-window and Stage Manager geometry.
- Applies safe-area space outside the clipped panel.
- Enforces both calculated maximum width and maximum height.
- Clamps calculated dimensions to zero or greater in unusually small windows.

The obsolete Quick Menu safe-area argument and conversion were removed from
`GameScreenView`. The existing UIKit safe-area value remains available for other
gameplay chrome that still uses it.

### Responsive Landscape Columns

The rendered Quick Menu now consistently uses
`supportsTwoColumns(width:height:)`.

- iPhone portrait remains one column.
- Smaller 16:9 iPhones remain one column in landscape.
- Notched 19.5:9 iPhones use two columns with at least 640 pt usable width and
  300 pt height.
- iPad uses two columns when its measured card has sufficient space.

This removes the previous disagreement between a shared `570 pt` helper and a
separate `>700 pt` rendering condition.

### Clear-Capable Liquid Glass Shell

The Quick Menu uses one shared glass shell instead of stacking an opaque shell,
strongly tinted section cards, and a second footer material.

- Native iOS 26 Liquid Glass supports regular and clear variants.
- Earlier iOS versions use the shared ultra-thin material fallback.
- Section-card graphite opacity changes from `78%` to `28%`.
- The footer inherits the shell rather than rendering another frosted layer.
- The paused-game scrim remains a deterministic color instead of a full-screen
  Material.

### Independent Appearance Toggle

Appearance adds:

`Settings → Appearance → Interface → Clear Liquid Glass UI Quick Menu`

- Default: Off.
- Persisted independently from the main `Clear Liquid Glass UI` option.
- Loaded during normal settings initialization and explicit settings reload.
- Applied only through the Quick Menu's local environment.
- Does not create another menu-background or game renderer.

### Touch Targets

Quick Menu action rows, toggle rows, injected menu rows, and the landscape Resume
button use regular sizing with a minimum 44-point target.

## Performance and Resource Impact

### Virtual Pad

- Uses the existing display link for Swipe Camera; no second display link is
  created for converted joystick mode.
- Only one right-stick source is published at a time.
- Movement calculations are constant-time vector math.
- Crosshair delay and button-pulse work use cancellable tasks rather than polling
  timers.
- Input reset paths clear held vectors, transient tasks, and gesture state.

### Settings Navigation

- Tracks only the Boolean empty/non-empty state of the Settings navigation path.
- Does not observe or copy complete child-view state.
- Disables the existing recognizer instead of installing another competing
  gesture.

### Quick Menu

- Uses one glass effect for the complete shell.
- Removes the duplicate footer material.
- Does not add per-row glass renderers.
- Uses local SwiftUI geometry rather than querying global UIKit windows.
- Adds no polling, display links, network requests, or emulator-side work.

## Compatibility and Behavioral Boundaries

This PR does not change:

- External controller input.
- Legacy Thumbsticks.
- Emulator CPU, JIT, GS/Metal, SPU2, CDVD, memory cards, or patch loading.
- VM pause/resume and Quick Menu route actions.
- Save-state, disc, speed, RetroAchievements, cheats, or per-game settings
  behavior.
- Main menu background ownership.
- Existing game-library files or cover handling.

## Review Notes

- The new movement-area keys default to `3.00×`, including for existing users
  who do not yet have those keys. This intentionally provides the larger control
  area, but should be reviewed on small screens and near display edges.
- Right instant deadzone is applied after touch and gyroscope values are
  combined. A large minimum floor can therefore make very small gyro motion more
  visible.
- A `5%` pullback is approximately `2.6 pt` at the default 52 pt visual radius.
  Device testing should confirm the 95% overextension hysteresis and outward-only
  re-entry logic prevent unwanted mode flapping.
- The camera gesture uses a zero-distance drag, so the configured release action
  also runs after a stationary camera-zone tap. This matches the current source
  behavior and should be confirmed as the desired interaction.
- Automatic-fire fields in the Classic First Person Shooter preset continue to
  rely on the existing runtime RetroAchievements Hardcore restriction.
- New setting labels use the existing English-key fallback. Translation-table
  entries are not included in this source diff, so untranslated locales will
  display the new labels in English.
- While a Settings child is open, both directions of app-wide tab swiping are
  intentionally disabled. Native back swipe owns the gesture; bottom-tab
  selection remains available.

## Files Changed

### Virtual Pad

- `platforms/ios/app/src/main/swift/Models/DynamicThumbstickSettings.swift`
- `platforms/ios/app/src/main/swift/Models/EmulatorBridge.swift`
- `platforms/ios/app/src/main/swift/Models/SettingsPresetCatalog.swift`
- `platforms/ios/app/src/main/swift/Views/Controller/DynamicThumbstickControls.swift`
- `platforms/ios/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift`
- `platforms/ios/app/src/main/swift/Views/VirtualControllerView.swift`

### Sub-Settings Swipe

- `platforms/ios/app/src/main/swift/Views/RootView.swift`
- `platforms/ios/app/src/main/swift/Views/Settings/SettingsRootView.swift`

### Quick Menu

- `platforms/ios/app/src/main/swift/Models/SettingsStore.swift`
- `platforms/ios/app/src/main/swift/Views/GameOverlayContainer.swift`
- `platforms/ios/app/src/main/swift/Views/GameScreenView.swift`
- `platforms/ios/app/src/main/swift/Views/OverlayDesignSystem.swift`
- `platforms/ios/app/src/main/swift/Views/QuickMenuView.swift`
- `platforms/ios/app/src/main/swift/Views/Settings/AppearanceSettingsView.swift`

## Suggested Manual Review

- Exercise both Dynamic Thumbsticks with instant deadzones enabled and disabled.
- Confirm zero movement while stationary and immediate movement after a small
  real drag.
- Check all movement-area scales and verify the visible stick size remains
  unchanged.
- Cross and recross the maximum radius, confirming pulse and haptic hysteresis.
- Convert Swipe Camera to joystick at several thresholds, pull back at several
  distances, and release in both modes.
- Confirm crosshair appearance, live motion, delayed hiding, and cancellation by
  a new swipe.
- Test every release-action button and overlapping held-button ownership.
- Apply and detect the Classic First Person Shooter preset.
- Complete and cancel native back swipes from multiple Settings children.
- Confirm root tab swipes return after popping to Settings root.
- Verify Quick Menu portrait, small 16:9 landscape, notched 19.5:9 landscape, and
  iPad layouts.
- Compare regular and clear Quick Menu Liquid Glass on iOS 26 and the fallback on
  earlier iOS versions.


### Did you use AI to help find, test, or implement this issue or feature?
Yes, to generate this PR.md.