### PR TITLE
iOS: fix the defects an audit of the Dynamic backgrounds subsystem turned up

### DIFF
--- a/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicColours.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicColours.swift
@@ -1746,7 +1746,13 @@ struct ThemePaletteEditor: View {
     applyEditorSnapshot(snapshot)
   }
 
-  private func applyEditorSnapshot(_ snapshot: ThemePaletteEditorSnapshot) {
+  // restoringSavedColors is false only for Cancel. Undo and redo do want the swatch list
+  // to move with everything else; Cancel does not, because saving a swatch is its own
+  // deliberate act and rolling it back reads as losing work.
+  private func applyEditorSnapshot(
+    _ snapshot: ThemePaletteEditorSnapshot,
+    restoringSavedColors: Bool = true
+  ) {
     pendingUndoSnapshot = nil
     sharedPalette = snapshot.sharedPalette
     sharedCustomColor = snapshot.sharedCustomColor
@@ -1756,7 +1762,9 @@ struct ThemePaletteEditor: View {
     ribbonMultiColor = snapshot.ribbonMultiColor
     particleSettings = snapshot.particleSettings
     isPlayStation3XMBPresetExplicit = snapshot.isPlayStation3XMBPresetExplicit
-    savedColorsJSON = snapshot.savedColorsJSON
+    if restoringSavedColors {
+      savedColorsJSON = snapshot.savedColorsJSON
+    }
     lastEditorSnapshot = snapshot
   }
 
@@ -1776,7 +1784,11 @@ struct ThemePaletteEditor: View {
     isClosingEditor = true
     endBackgroundPreview()
     if let initialEditorSnapshot {
-      applyEditorSnapshot(initialEditorSnapshot)
+      applyEditorSnapshot(initialEditorSnapshot, restoringSavedColors: false)
+      // Restoring the bindings is not enough. Saving a swatch mid session calls
+      // onSaveAppearance, which persists the whole preferences struct, so everything
+      // edited before that point is already committed and would outlive Cancel.
+      onSaveAppearance()
     }
     dismiss()
   }

--- a/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicColours.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicColours.swift
@@ -1643,37 +1643,12 @@ struct ThemePaletteEditor: View {
     recordEditorChange()
     guard oldSnapshot.visualState != newSnapshot.visualState else { return }
 
-    if isOnlyPortraitWideningChange(from: oldSnapshot, to: newSnapshot)
-      || isOnlyBackgroundPreviewTimingChange(from: oldSnapshot, to: newSnapshot)
-    {
+    if isOnlyBackgroundPreviewTimingChange(from: oldSnapshot, to: newSnapshot) {
       lastThemeSnapshot = currentTheme
       return
     }
 
     scheduleBackgroundPreview()
-  }
-
-  private func isOnlyPortraitWideningChange(
-    from oldSnapshot: ThemePaletteEditorSnapshot,
-    to newSnapshot: ThemePaletteEditorSnapshot
-  ) -> Bool {
-    guard
-      oldSnapshot.sharedPalette == newSnapshot.sharedPalette,
-      oldSnapshot.sharedCustomColor == newSnapshot.sharedCustomColor,
-      oldSnapshot.sharedMultiColor == newSnapshot.sharedMultiColor,
-      oldSnapshot.ribbonPalette == newSnapshot.ribbonPalette,
-      oldSnapshot.ribbonCustomColor == newSnapshot.ribbonCustomColor,
-      oldSnapshot.ribbonMultiColor == newSnapshot.ribbonMultiColor,
-      oldSnapshot.particleSettings.widensPortraitBackground
-        != newSnapshot.particleSettings.widensPortraitBackground
-    else {
-      return false
-    }
-
-    var normalizedSettings = oldSnapshot.particleSettings
-    normalizedSettings.widensPortraitBackground =
-      newSnapshot.particleSettings.widensPortraitBackground
-    return normalizedSettings == newSnapshot.particleSettings
   }
 
   private func isOnlyBackgroundPreviewTimingChange(

--- a/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicColours.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicColours.swift
@@ -590,6 +590,24 @@ struct ThemePaletteControls: View {
     }
   }
 
+  // Two separate things force the dark gradient to zero in DynamicBackgroundTheme, and the
+  // slider only ever greyed out for the first. The second is the eye button on a saved
+  // palette, which lives in another section and says nothing about this one, so the slider
+  // sat at full strength doing nothing with no way to work out why.
+  private var darkGradientIsInert: Bool {
+    particleSettings.disablesDarkPaletteEffects || sharedCustomColor?.usesDarkEffect == false
+  }
+
+  private var darkGradientInertReason: String? {
+    if particleSettings.disablesDarkPaletteEffects {
+      return "Dark effects on palettes are switched off above."
+    }
+    if sharedCustomColor?.usesDarkEffect == false {
+      return "This saved palette has its dark effect turned off, so the strength is ignored."
+    }
+    return nil
+  }
+
   private var paletteEffectsSection: some View {
     VStack(alignment: .leading, spacing: 12) {
       Toggle(
@@ -605,8 +623,13 @@ struct ThemePaletteControls: View {
         formattedValue: "\(Int(particleSettings.paletteDarkEffectIntensity * 100))%",
         resetValue: 1
       )
-      .disabled(particleSettings.disablesDarkPaletteEffects)
-      .opacity(particleSettings.disablesDarkPaletteEffects ? 0.45 : 1)
+      .disabled(darkGradientIsInert)
+      .opacity(darkGradientIsInert ? 0.45 : 1)
+      if let reason = darkGradientInertReason {
+        Text(reason)
+          .font(.caption)
+          .foregroundStyle(.orange)
+      }
 
       if target == .shared {
         particleSlider(

--- a/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicPalettes.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicPalettes.swift
@@ -622,18 +622,32 @@ struct SavedPaletteColor: Codable, Hashable, Identifiable {
 
   private static func hexValue(for color: Color) -> String? {
     let uiColor = UIColor(color)
+
+    // The system picker hands back Display P3 on any recent device, and getRed reports
+    // those in extended sRGB, where anything outside the smaller gamut comes back
+    // outside 0...1. P3's pure red is 1.358, -0.074, -0.012. Scaled by 255 that is 346
+    // and -18, which %02X writes as three digits and as a 16 digit negative, and the
+    // reader below parses the result with UInt64(radix: 16) ?? 0 and lands on black.
+    // Converting first is what makes the saved swatch match what was picked; the clamp
+    // is belt and braces, since hex cannot express anything outside the gamut anyway.
     var red: CGFloat = 0
     var green: CGFloat = 0
     var blue: CGFloat = 0
     var alpha: CGFloat = 0
-    guard uiColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
+
+    if let srgbSpace = CGColorSpace(name: CGColorSpace.sRGB),
+      let converted = uiColor.cgColor.converted(
+        to: srgbSpace, intent: .defaultIntent, options: nil),
+      let components = converted.components, components.count >= 3
+    {
+      red = components[0]
+      green = components[1]
+      blue = components[2]
+    } else if !uiColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha) {
       return nil
     }
-    return String(
-      format: "#%02X%02X%02X",
-      Int(red * 255),
-      Int(green * 255),
-      Int(blue * 255)
-    )
+
+    let channel: (CGFloat) -> Int = { Int((min(1, max(0, $0)) * 255).rounded()) }
+    return String(format: "#%02X%02X%02X", channel(red), channel(green), channel(blue))
   }
 }

--- a/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicSettings.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/Dynamic/DynamicSettings.swift
@@ -77,7 +77,6 @@ struct DynamicParticleSettings: Equatable, Codable {
   var twinkle = 0.65
   var drift = 0.55
   var verticalLevel = 0.5
-  var widensPortraitBackground = true
   var backgroundPreviewBeforeApplyingDuration = 0.3
   var backgroundPreviewAfterApplyingDuration = 0.7
   var disablesDarkPaletteEffects = false
@@ -1099,16 +1098,6 @@ struct DynamicParticleSettingsControls: View {
         faceButtonSettings
       }
 
-      HStack {
-        Toggle("Widen theme in portrait", isOn: $particleSettings.widensPortraitBackground)
-        settingResetButton("Widen theme in portrait") {
-          particleSettings.widensPortraitBackground =
-            defaults.widensPortraitBackground
-        }
-      }
-      .font(.subheadline.weight(.semibold))
-      .foregroundStyle(.white)
-      .dynamicSettingsCard()
 
       particleSlider(
         "See background preview before applying",

--- a/platforms/ios/app/src/main/swift/Views/Background/VideoBackgroundView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Background/VideoBackgroundView.swift
@@ -123,7 +123,7 @@ private final class LoopingVideoView: UIView {
                 }
             }
         } else {
-            adaptToPowerState()
+            applyPowerState()
         }
     }
 
@@ -214,7 +214,21 @@ private final class LoopingVideoView: UIView {
         }
     }
 
-    @objc private func adaptToPowerState() {
+    // Every other notification here is a UIKit lifecycle one and arrives on the main
+    // thread. This one does not: Foundation posts the power-state change from whatever
+    // queue it likes, and the body below touches UIKit and the player. The class is a
+    // UIView so it is main-actor isolated, which under Swift 6 means the @objc entry
+    // point checks the executor and traps before the body even runs. So take the hit
+    // off the main thread and hop, the way the seek handler above already does.
+    @objc private nonisolated func adaptToPowerState() {
+        Task { @MainActor [weak self] in
+            self?.applyPowerState()
+        }
+    }
+
+    // Weakly, because a strong capture could leave the last release on that Task's
+    // thread, and deinit assumes it is on main.
+    private func applyPowerState() {
         if ProcessInfo.processInfo.isLowPowerModeEnabled {
             pause()
         } else {


### PR DESCRIPTION
The Dynamic backgrounds subsystem landed since 2.4.1, roughly 13,400 lines, and had never been reviewed by anyone. This is what an audit of it turned up and survived checking. Most of what the audit first flagged did not survive, so what is left is small.

### What changed

* Toggling Low Power Mode with a video wallpaper on screen no longer kills the app.
* A saturated colour picked from the system picker saves as the colour you picked instead of turning black.
* Cancel in the colours editor now means cancel. It was throwing away the swatch you had just saved and keeping the colour edits you had just cancelled, which is both halves of the wrong way round.
* The Dark gradient strength slider greys out when something is holding it at zero, and says which thing.
* Widen theme in portrait is gone. It was persisted, had a reset button, and no renderer has ever read it.

### The crash

Foundation posts the power state notification from whatever queue it likes. The handler is @objc on a UIView subclass, so it is main actor isolated, and this target builds in Swift 6 language mode. That combination does not race, it traps: the thunk checks the executor and aborts before the body runs at all. The other five observers in that file are UIKit lifecycle notifications and genuinely do arrive on main, which is why only this one goes bang.

It needs a video wallpaper set, so it is not every install, but the automatic prompt at 20 percent battery fires it without the user doing anything.

### The colour

The picker hands back Display P3 on any recent device, and getRed reports those in extended sRGB, where anything outside the smaller gamut lands outside 0 to 1. P3 pure red comes back as 1.358, then minus 0.074, then minus 0.012. Scaled by 255 those are 346, minus 18 and minus 3, which the format writes as three digits and as sixteen digit negatives. The reader parses with UInt64 radix 16 and a zero fallback, gives up on that string, and lands on black.

Only affects colours saved from now on. Anything already stored as black was corrupted at write time and there is nothing left to recover from it.

### Notes for reviewers

The power observer stays selector based rather than moving to the block form. The block form returns a token that removeObserver(self) does not unregister, and teardown here relies on that one call clearing all six. The capture is weak because a strong one could leave the final release on the Task's thread, and deinit assumes it is on main, which would swap one trap for another. MainActor.assumeIsolated is not the tool for this: it crashes when the assumption is false, which is precisely the case being fixed.

The colour fix converts through CGColor as well as clamping. The clamp alone stops the corruption; converting is what makes the saved swatch match the colour that was picked rather than a truncated guess at it.

Cancel leaves the swatch list out of its restore, but undo and redo still move it, because moving it is what you want from undo.

Removing a property from a Codable struct is safe in this direction, since synthesised decoding ignores keys it does not know and older settings still load. Adding one back would not be, which is worth remembering if portrait widening is ever built for real.

The dark gradient row already greyed out for one of its two conditions. The one it missed is an unlabelled eye button on a saved palette, in a different section, with nothing tying it to this slider.

Built for device. The crash is the one item a clean build proves nothing about, since the current code traps at runtime rather than at compile time: it wants a real device with a video wallpaper and the Low Power toggle. The colour is best checked on a P3 device, because a device without one will not reproduce the original bug either.
