### PR TITLE
iOS: offer fractional internal resolutions above 1x

### DIFF
--- a/platforms/ios/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
@@ -155,16 +155,9 @@ struct GraphicsSettingsView: View {
 
             Section(settings.localized("Upscaling")) {
                 Picker(settings.localized("Internal Resolution"), selection: $settings.upscaleMultiplier) {
-                    Text(settings.localized("0.25x (Fastest)")).tag(Float(0.25))
-                    Text("0.5x").tag(Float(0.5))
-                    Text("0.75x").tag(Float(0.75))
-                    Text(settings.localized("1x Native (512x448)")).tag(Float(1.0))
-                    Text("2x (1024x896)").tag(Float(2.0))
-                    Text("3x (1536x1344)").tag(Float(3.0))
-                    Text("4x (2048x1792)").tag(Float(4.0))
-                    Text("5x (2560x2240)").tag(Float(5.0))
-                    Text("6x (3072x2688)").tag(Float(6.0))
-                    Text("8x (4096x3584)").tag(Float(8.0))
+                    ForEach(UpscaleOptions.all, id: \.id) { option in
+                        Text(settings.localized(option.title)).tag(option.id)
+                    }
                 }
                 Text(settings.localized("Lower values can help performance on heavy games. Higher values improve visual quality but reduce performance significantly. Applies immediately; the renderer may briefly stutter while it reinits."))
                     .font(.caption)

--- a/platforms/ios/app/src/main/swift/Views/Settings/PerGame/GraphicsTab.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/PerGame/GraphicsTab.swift
@@ -111,15 +111,6 @@ struct GraphicsTab: View {
         PickerOption(id: 2, title: "Full")
     ]
 
-    private static let upscaleOptions: [(id: Float, title: String)] = [
-        (0.25, "0.25x (Fastest)"),
-        (0.5, "0.5x"),
-        (0.75, "0.75x"),
-        (1.0, "1x Native"),
-        (2.0, "2x"),
-        (3.0, "3x"),
-        (4.0, "4x")
-    ]
     private static let aspectRatioOptions: [(id: String, title: String)] = [
         ("Auto 4:3/3:2", "Auto 4:3 / 3:2"),
         ("4:3", "4:3"),
@@ -151,7 +142,7 @@ struct GraphicsTab: View {
     @ViewBuilder
     private var graphicsContent: some View {
         Section(settings.localized("Graphics")) {
-            EnumPicker(Self.upscaleOptions, selection: $upscaleMultiplier) {
+            EnumPicker(UpscaleOptions.all, selection: $upscaleMultiplier) {
                 Text(settings.localized("Internal Resolution"))
             }
             .disabled(!enabled)

--- a/platforms/ios/app/src/main/swift/Views/Settings/UpscaleOptions.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/UpscaleOptions.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+// One list for both the global Graphics screen and the per game Graphics tab.
+// They used to keep separate copies and had already drifted: the per game one
+// stopped at 4x while the global one went to 8x.
+//
+// The core has always stored this as a float, so the fractional steps below are
+// a UI change only. They matter on a phone, where 2x often runs and 3x often
+// does not, and the useful setting is somewhere in between.
+enum UpscaleOptions {
+    // Sizes are the 512x448 base times the multiplier. Every step lands on
+    // whole pixels, which is why the list steps by a quarter and not a third.
+    static let all: [(id: Float, title: String)] = [
+        (0.25, "0.25x (Fastest)"),
+        (0.5, "0.5x"),
+        (0.75, "0.75x"),
+        (1.0, "1x Native (512x448)"),
+        (1.25, "1.25x (640x560)"),
+        (1.5, "1.5x (768x672)"),
+        (1.75, "1.75x (896x784)"),
+        (2.0, "2x (1024x896)"),
+        (2.25, "2.25x (1152x1008)"),
+        (2.5, "2.5x (1280x1120)"),
+        (2.75, "2.75x (1408x1232)"),
+        (3.0, "3x (1536x1344)"),
+        (3.5, "3.5x (1792x1568)"),
+        (4.0, "4x (2048x1792)"),
+        (5.0, "5x (2560x2240)"),
+        (6.0, "6x (3072x2688)"),
+        (8.0, "8x (4096x3584)")
+    ]
+}


### PR DESCRIPTION
Internal Resolution jumped from 1x straight to 2x to 3x, which is the wrong shape for a phone. This adds the steps in between.

### What changed

* Internal Resolution offers quarter steps above native: 1.25x, 1.5x, 1.75x, 2x, 2.25x, 2.5x, 2.75x, 3x, then 3.5x.
* The per game Graphics tab offers the same values as the global screen. It used to stop at 4x while the global one went to 8x.
* Both pickers read one list now instead of keeping a copy each.

### Why there is no core change

The core has stored this as a float since long before any of this. GetUpscaleMultiplier returns one, the hardware renderer and the texture cache consume it as one, and nothing on the iOS path rounds it. The only ceiling is GSGetMaxUpscaleMultiplier, which is the max texture size over 1280, so 12x on an A16.

Both pickers already listed 0.25x, 0.5x and 0.75x, so the fractional path has been running in production all along. It was simply never offered above native. Nothing was missing except the entries.

### Notes for reviewers

Quarter steps because the 512x448 base times a quarter lands on whole pixels. Thirds do not: 512 over 3 is 170.67.

The shared list is more of the point than the new values are. Two copies is why the per game picker fell behind at 4x while the global one reached 8x, which is not something anybody would have chosen on purpose. One file now, so the next person to add a step cannot repeat it.

The new list is a superset of both old ones, so every value anyone already has saved is still selectable and there is nothing to migrate.

Built for device, no diagnostics in any touched file. The new Swift file is picked up by the existing glob, so there is no project file change to review.

Branched off master, so this carries neither the 2.5.1 bump nor the GS fixes in the other PR. None of the files overlap either of those.
