### PR TITLE
Skin browser search placement and filter, and a fastmem reload fix

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -458,18 +458,6 @@ bool VMManager::Internal::CPUThreadInitialize()
 	// This also sorts out input sources.
 	LoadSettings();
 
-	// LoadSettings() re-reads EnableFastmem from the INI, clobbering the runtime
-	// disable that vtlb_Core_Alloc applied when the 4 GB fastmem area failed to
-	// allocate on low-VA devices (e.g. iPhone SE 2). Re-apply the disable from
-	// the sticky flag so the EE recompiler does not emit fastmem load/store
-	// against a null base. The flag is process-lifetime: once the area fails,
-	// it stays failed.
-	if (vtlb_FastmemAreaUnavailable() && EmuConfig.Cpu.Recompiler.EnableFastmem)
-	{
-		EmuConfig.Cpu.Recompiler.EnableFastmem = false;
-		Console.Warning("Fastmem re-disabled after settings reload (area allocation previously failed)");
-	}
-
 	if (EmuConfig.Achievements.Enabled && !Achievements::IsActive())
 		Achievements::Initialize();
 
@@ -746,6 +734,23 @@ void VMManager::LoadCoreSettings(SettingsInterface& si)
 	static const bool s_mvu_diff_env = (std::getenv("MVU_DIFF") != nullptr);
 	if (s_mvu_diff_env)
 		EmuConfig.Speedhacks.vuThread = false;
+
+	// The 4 GB fastmem reservation can fail outright on a low VA device, and the
+	// INI still says fastmem is on, so every reload from here turns it back on
+	// against a base that was never mapped. The flag is sticky for the life of
+	// the process. It belongs here rather than at the call sites: it used to be
+	// re-applied by hand after each load, and the ELF change path was missed.
+	if (vtlb_FastmemAreaUnavailable() && EmuConfig.Cpu.Recompiler.EnableFastmem)
+	{
+		EmuConfig.Cpu.Recompiler.EnableFastmem = false;
+
+		static bool s_warned_fastmem_reload = false;
+		if (!s_warned_fastmem_reload)
+		{
+			s_warned_fastmem_reload = true;
+			Console.Warning("Fastmem re-disabled after settings reload (area allocation previously failed)");
+		}
+	}
 }
 
 void VMManager::LoadInputBindings(SettingsInterface& si, std::unique_lock<std::mutex>& lock)
@@ -868,9 +873,6 @@ void VMManager::ApplySettings()
 	EmuConfig = Pcsx2Config();
 	EmuConfig.CopyRuntimeConfig(old_config);
 	LoadSettings();
-	// Re-apply the sticky fastmem-area-unavailable disable (see CPUThreadInitialize).
-	if (vtlb_FastmemAreaUnavailable() && EmuConfig.Cpu.Recompiler.EnableFastmem)
-		EmuConfig.Cpu.Recompiler.EnableFastmem = false;
 	CheckForConfigChanges(old_config);
 	if (s_emulation_only_mode.load(std::memory_order_acquire))
 		ReleaseNonEssentialRuntimeResources(s_emulation_only_release_flags.load(std::memory_order_acquire));

--- a/platforms/ios/app/src/main/swift/Views/Settings/SkinBrowserView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/SkinBrowserView.swift
@@ -4,12 +4,27 @@
 import SwiftUI
 
 struct SkinBrowserView: View {
+    /// Ready means the skin ships a layout for iOS. The rest still install, they
+    /// just leave you to place the buttons.
+    private enum Filter: Hashable, CaseIterable {
+        case all, installed, ready
+
+        var title: String {
+            switch self {
+            case .all: return "All"
+            case .installed: return "Installed"
+            case .ready: return "Ready"
+            }
+        }
+    }
+
     @StateObject private var catalog = SkinCatalog()
     @StateObject private var installer = SkinInstaller()
     // Held directly so the rows invalidate off the library itself rather than
     // off whatever the installer happens to be publishing.
     @State private var skinLibrary = VPadSkinLibraryStore.shared
     @State private var searchText = ""
+    @State private var filter: Filter = .all
     @State private var detailAlert: String?
     @State private var previewSkin: CatalogSkin?
     @State private var skinPendingRemoval: CatalogSkin?
@@ -45,8 +60,19 @@ struct SkinBrowserView: View {
                     .foregroundStyle(.secondary)
             }
 
+            if !catalog.skins.isEmpty {
+                Picker("Show", selection: $filter) {
+                    ForEach(Filter.allCases, id: \.self) { option in
+                        Text(option.title).tag(option)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .listRowSeparator(.hidden)
+            }
+
             if !catalog.skins.isEmpty && filteredSkins.isEmpty {
-                Text("No skins match that search.")
+                Text(emptyResultMessage)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -55,7 +81,15 @@ struct SkinBrowserView: View {
                 skinRow(skin)
             }
         }
-        .searchable(text: $searchText, prompt: "Search skins")
+        // Pin this to the drawer. Left alone, iOS 26 puts the field at the
+        // bottom of the screen, which is where our tab bar lives, and the bar
+        // wins on z order. Always rather than automatic, so the field is
+        // sitting there instead of needing a pull down to find it.
+        .searchable(
+            text: $searchText,
+            placement: .navigationBarDrawer(displayMode: .always),
+            prompt: "Search skins"
+        )
         .navigationTitle("Skins")
         .navigationBarTitleDisplayMode(.inline)
         .task { await catalog.fetch() }
@@ -95,14 +129,40 @@ struct SkinBrowserView: View {
         Set(skinLibrary.importedDescriptors.compactMap(\.catalogID))
     }
 
+    /// Everything the filter allows, before the search query narrows it. Kept
+    /// apart so the empty state can tell which of the two emptied the list.
+    private var filteredByCategory: [CatalogSkin] {
+        let installed = installedFiles
+        switch filter {
+        case .all: return catalog.skins
+        case .installed: return catalog.skins.filter { installed.contains($0.file) }
+        case .ready: return catalog.skins.filter(\.isIOSReady)
+        }
+    }
+
     private var filteredSkins: [CatalogSkin] {
         let installed = installedFiles
-        let matches = searchText.isEmpty ? catalog.skins : catalog.skins.filter { skin in
-            skin.name.localizedCaseInsensitiveContains(searchText)
-                || (skin.author?.localizedCaseInsensitiveContains(searchText) ?? false)
+        // localizedStandard rather than localizedCaseInsensitive so an accent
+        // in the catalog doesn't hide a skin from someone typing without one.
+        let matches = searchText.isEmpty ? filteredByCategory : filteredByCategory.filter { skin in
+            skin.name.localizedStandardContains(searchText)
+                || (skin.author?.localizedStandardContains(searchText) ?? false)
         }
         return matches.filter { installed.contains($0.file) }
             + matches.filter { !installed.contains($0.file) }
+    }
+
+    /// Blame whichever one actually emptied the list. Telling someone their
+    /// search found nothing when it was the filter is just misleading.
+    private var emptyResultMessage: String {
+        if filteredByCategory.isEmpty {
+            switch filter {
+            case .all: return "No skins match that search."
+            case .installed: return "You haven't installed any skins yet."
+            case .ready: return "No skins ship a recommended layout yet."
+            }
+        }
+        return "No skins match that search."
     }
 
     private func subtitle(for skin: CatalogSkin) -> String? {


### PR DESCRIPTION
Two unrelated fixes, kept together to save a round trip.

### What changed

* The search bar on the skin browser sits under the title again instead of at the bottom of the screen, where the tab bar was covering it and you could not tap it.
* Searching skins is more forgiving, so an accent in a name no longer hides a skin from someone typing without one.
* The skin browser has an All, Installed and Ready filter, and when the list comes back empty it now says whether it was the filter or the search that emptied it.
* Fastmem stays off once its reservation has failed, instead of being switched back on by the next settings reload.

### The search bar

iOS 26 moved the default position of a search field to the bottom of the screen on iPhone, for thumb reach. We do not use a TabView, we put our own tab bar in that same strip and give it a z index of a thousand, so the bar was painting straight over the field. It is pinned to the navigation bar drawer now, and always visible rather than appearing on a pull down, which reads the same on every version we support.

Nothing was ever wrong with the filtering itself. It has always matched on name and author, and it has always been wired to the list. Only the field was out of reach.

Ready in the filter means the skin ships a layout for iOS. The others still install, they just leave you to place the buttons yourself.

### Fastmem

Fastmem wants a 4 GB virtual reservation and does not always get one on a small device. That case is already handled: the area is marked permanently unavailable and fastmem is forced off for the life of the process. The INI still says it is on though, so every settings reload switched it back on, and the disable was being put back by hand afterwards at each call site. Two of the three did that. The one that runs on every ELF change did not, which left the emulator emitting fastmem code against mappings that were never made.

You can watch it happen in a log from an iPhone SE 2. The EE dispatcher is 956 bytes when the game boots and 968 after the ELF lands, and the twelve bytes between the two are the fastmem base load, which is the only branch in that whole region that depends on runtime config. On a device where the reservation succeeds it is 968 both times.

The disable now lives in LoadCoreSettings, which every reload path goes through, so a path added later cannot quietly miss it.

Built for device. The search bar was checked on an iPhone 17 Pro simulator on 26.5, which is where the bottom placement reproduces.
