### PR TITLE
iOS: bring rumble back, and give the phone's own rumble some range

### DIFF
--- a/pcsx2/Input/InputManager.cpp
+++ b/pcsx2/Input/InputManager.cpp
@@ -28,6 +28,10 @@
 #include <variant>
 #include <vector>
 
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
 // ------------------------------------------------------------------------
 // Constants
 // ------------------------------------------------------------------------
@@ -1458,8 +1462,19 @@ void InputManager::SetUSBVibrationIntensity(u32 port, float large_or_single_moto
 namespace Native { void onPadRumble(int pad, int largeMotor, int smallMotor); }
 #endif
 
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+// Same story as Android above: iOS drives pads through its own SDL bridge and binds no
+// motors, so s_pad_vibration_array is empty and the loop below never reaches a motor.
+// Hand every intensity change to the iOS rumble queue, which the VM thread drains once a
+// frame and turns into SDL rumble, a CoreHaptics pulse, or the phone's own taptic engine.
+extern "C" void ARMSX2_iOSUpdatePadVibration(u32 pad_index, float large_intensity, float small_intensity);
+#endif
+
 void InputManager::SetPadVibrationIntensity(u32 pad_index, float large_or_single_motor_intensity, float small_motor_intensity)
 {
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+	ARMSX2_iOSUpdatePadVibration(pad_index, large_or_single_motor_intensity, small_motor_intensity);
+#endif
 #ifdef __ANDROID__
 	if (pad_index < Pad::NUM_CONTROLLER_PORTS)
 	{
@@ -1524,6 +1539,12 @@ void InputManager::SetPadVibrationIntensity(u32 pad_index, float large_or_single
 
 void InputManager::PauseVibration()
 {
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+	// Nothing else stops the motor on the iOS path, so without this a pad that was
+	// rumbling when you opened the menu keeps rumbling behind it.
+	for (u32 pad_index = 0; pad_index < Pad::NUM_CONTROLLER_PORTS; pad_index++)
+		ARMSX2_iOSUpdatePadVibration(pad_index, 0.0f, 0.0f);
+#endif
 	for (PadVibrationBinding& binding : s_pad_vibration_array)
 	{
 		for (u32 motor_index = 0; motor_index < MAX_MOTORS_PER_PAD; motor_index++)

--- a/platforms/ios/app/src/main/cpp/IOS/GamepadHaptics.mm
+++ b/platforms/ios/app/src/main/cpp/IOS/GamepadHaptics.mm
@@ -38,7 +38,6 @@ static constexpr u16 ARMSX2_GAMEPAD_RUMBLE_MAX_INTENSITY = 0x7000;
 static CHHapticEngine* s_nativePulseHapticEngine[ARMSX2_MAX_IOS_GAMEPADS] = {};
 static std::atomic<u32> s_nativePulseHapticStopGeneration[ARMSX2_MAX_IOS_GAMEPADS];
 static std::atomic<u32> s_loggedNativePulseHapticEvents{0};
-static GCController* s_nativeHapticController = nil;
 static CHHapticEngine* s_nativeHapticEngine = nil;
 static id<CHHapticAdvancedPatternPlayer> s_nativeHapticPlayer = nil;
 static u32 s_nativeAppliedGamepadRumble = 0;
@@ -518,7 +517,8 @@ static void ARMSX2StopNativeGamepadRumbleOnMain()
         NSError* error = nil;
         [s_nativeHapticPlayer stopAtTime:CHHapticTimeImmediate error:&error];
         if (error)
-            Console.WriteLn("[ARMSX2 iOS Gamepad] Native rumble stop failed: %s", error.localizedDescription.UTF8String ?: "unknown");
+            Console.WriteLn("[ARMSX2 iOS Gamepad] Device rumble stop failed: %s", error.localizedDescription.UTF8String ?: "unknown");
+        [s_nativeHapticPlayer release];
         s_nativeHapticPlayer = nil;
     }
 }
@@ -528,9 +528,9 @@ static void ARMSX2ResetNativeGamepadRumbleOnMain()
     ARMSX2StopNativeGamepadRumbleOnMain();
     if (s_nativeHapticEngine) {
         [s_nativeHapticEngine stopWithCompletionHandler:nil];
+        [s_nativeHapticEngine release];
         s_nativeHapticEngine = nil;
     }
-    s_nativeHapticController = nil;
     s_nativeAppliedGamepadRumble = 0;
     s_nativeAppliedGamepadRumbleValid = false;
     s_loggedNativeGamepadRumbleReady = false;
@@ -546,6 +546,18 @@ static GCController* ARMSX2FindNativeHapticController()
     return nil;
 }
 
+// True on a phone with a taptic engine. iPads and the older phones have none, and
+// asking them to play a pattern just fails every frame, so check once and remember.
+static bool ARMSX2DeviceSupportsHaptics()
+{
+    static const bool supported = [] {
+        if (@available(iOS 13.0, *))
+            return [CHHapticEngine capabilitiesForHardware].supportsHaptics != NO;
+        return false;
+    }();
+    return supported;
+}
+
 static bool ARMSX2EnsureNativeGamepadRumbleOnMain(float intensity, float sharpness)
 {
     if (@available(iOS 14.0, *)) {
@@ -553,26 +565,23 @@ static bool ARMSX2EnsureNativeGamepadRumbleOnMain(float intensity, float sharpne
         return false;
     }
 
-    GCController* controller = ARMSX2FindNativeHapticController();
-    if (!controller) {
+    if (!ARMSX2DeviceSupportsHaptics()) {
         if (!s_loggedNativeGamepadRumbleUnavailable) {
-            Console.WriteLn("[ARMSX2 iOS Gamepad] Native controller haptics unavailable");
+            Console.WriteLn("[ARMSX2 iOS Gamepad] Device haptics unavailable on this hardware");
             s_loggedNativeGamepadRumbleUnavailable = true;
         }
-        ARMSX2ResetNativeGamepadRumbleOnMain();
         return false;
     }
 
-    if (s_nativeHapticController != controller) {
-        ARMSX2ResetNativeGamepadRumbleOnMain();
-        s_nativeHapticController = controller;
-    }
-
     if (!s_nativeHapticEngine) {
-        s_nativeHapticEngine = [controller.haptics createEngineWithLocality:GCHapticsLocalityAll];
+        // alloc/init, so the static owns it outright and releases on teardown. The
+        // controller path next door uses a factory method and has to retain instead.
+        NSError* create_error = nil;
+        s_nativeHapticEngine = [[CHHapticEngine alloc] initAndReturnError:&create_error];
         if (!s_nativeHapticEngine) {
             if (!s_loggedNativeGamepadRumbleUnavailable) {
-                Console.WriteLn("[ARMSX2 iOS Gamepad] Native haptic engine creation failed");
+                Console.WriteLn("[ARMSX2 iOS Gamepad] Device haptic engine creation failed: %s",
+                    create_error.localizedDescription.UTF8String ?: "unknown");
                 s_loggedNativeGamepadRumbleUnavailable = true;
             }
             return false;
@@ -580,17 +589,26 @@ static bool ARMSX2EnsureNativeGamepadRumbleOnMain(float intensity, float sharpne
 
         s_nativeHapticEngine.playsHapticsOnly = YES;
         s_nativeHapticEngine.autoShutdownEnabled = YES;
+        // The engine shuts itself down when idle and again when the app backgrounds.
+        // Drop the player so the next rumble rebuilds it; the engine restarts above.
+        // CoreHaptics calls these back on a queue of its own choosing, and everything
+        // else here touches the player from main. Hop before releasing it, or the
+        // release races the main thread still using it.
         s_nativeHapticEngine.stoppedHandler = ^(CHHapticEngineStoppedReason reason) {
-            s_nativeHapticPlayer = nil;
-            s_nativeAppliedGamepadRumble = 0;
-            s_nativeAppliedGamepadRumbleValid = false;
-            Console.WriteLn("[ARMSX2 iOS Gamepad] Native haptic engine stopped reason=%ld", static_cast<long>(reason));
+            dispatch_async(dispatch_get_main_queue(), ^{
+                ARMSX2StopNativeGamepadRumbleOnMain();
+                s_nativeAppliedGamepadRumble = 0;
+                s_nativeAppliedGamepadRumbleValid = false;
+            });
+            Console.WriteLn("[ARMSX2 iOS Gamepad] Device haptic engine stopped reason=%ld", static_cast<long>(reason));
         };
         s_nativeHapticEngine.resetHandler = ^{
-            s_nativeHapticPlayer = nil;
-            s_nativeAppliedGamepadRumble = 0;
-            s_nativeAppliedGamepadRumbleValid = false;
-            Console.WriteLn("[ARMSX2 iOS Gamepad] Native haptic engine reset");
+            dispatch_async(dispatch_get_main_queue(), ^{
+                ARMSX2StopNativeGamepadRumbleOnMain();
+                s_nativeAppliedGamepadRumble = 0;
+                s_nativeAppliedGamepadRumbleValid = false;
+            });
+            Console.WriteLn("[ARMSX2 iOS Gamepad] Device haptic engine reset");
         };
     }
 
@@ -602,20 +620,20 @@ static bool ARMSX2EnsureNativeGamepadRumbleOnMain(float intensity, float sharpne
 
     if (!s_nativeHapticPlayer) {
         NSArray<CHHapticEventParameter*>* params = @[
-            [[CHHapticEventParameter alloc] initWithParameterID:CHHapticEventParameterIDHapticIntensity value:intensity],
-            [[CHHapticEventParameter alloc] initWithParameterID:CHHapticEventParameterIDHapticSharpness value:sharpness]
+            [[[CHHapticEventParameter alloc] initWithParameterID:CHHapticEventParameterIDHapticIntensity value:intensity] autorelease],
+            [[[CHHapticEventParameter alloc] initWithParameterID:CHHapticEventParameterIDHapticSharpness value:sharpness] autorelease]
         ];
-        CHHapticEvent* event = [[CHHapticEvent alloc] initWithEventType:CHHapticEventTypeHapticContinuous
+        CHHapticEvent* event = [[[CHHapticEvent alloc] initWithEventType:CHHapticEventTypeHapticContinuous
                                                               parameters:params
                                                             relativeTime:0.0
-                                                                 duration:1.0];
-        CHHapticPattern* pattern = [[CHHapticPattern alloc] initWithEvents:@[event] parameters:@[] error:&error];
+                                                                 duration:1.0] autorelease];
+        CHHapticPattern* pattern = [[[CHHapticPattern alloc] initWithEvents:@[event] parameters:@[] error:&error] autorelease];
         if (!pattern) {
             Console.WriteLn("[ARMSX2 iOS Gamepad] Native haptic pattern failed: %s", error.localizedDescription.UTF8String ?: "unknown");
             return false;
         }
 
-        s_nativeHapticPlayer = [s_nativeHapticEngine createAdvancedPlayerWithPattern:pattern error:&error];
+        s_nativeHapticPlayer = [[s_nativeHapticEngine createAdvancedPlayerWithPattern:pattern error:&error] retain];
         if (!s_nativeHapticPlayer) {
             Console.WriteLn("[ARMSX2 iOS Gamepad] Native haptic player failed: %s", error.localizedDescription.UTF8String ?: "unknown");
             return false;
@@ -624,26 +642,26 @@ static bool ARMSX2EnsureNativeGamepadRumbleOnMain(float intensity, float sharpne
         s_nativeHapticPlayer.loopEnabled = YES;
         s_nativeHapticPlayer.loopEnd = 1.0;
         if (![s_nativeHapticPlayer startAtTime:CHHapticTimeImmediate error:&error]) {
-            Console.WriteLn("[ARMSX2 iOS Gamepad] Native haptic player start failed: %s", error.localizedDescription.UTF8String ?: "unknown");
+            Console.WriteLn("[ARMSX2 iOS Gamepad] Device haptic player start failed: %s", error.localizedDescription.UTF8String ?: "unknown");
+            [s_nativeHapticPlayer release];
             s_nativeHapticPlayer = nil;
             return false;
         }
 
         if (!s_loggedNativeGamepadRumbleReady) {
-            NSString* vendor = controller.vendorName ?: @"unknown controller";
-            Console.WriteLn("[ARMSX2 iOS Gamepad] Native controller rumble active: %s", vendor.UTF8String);
+            Console.WriteLn("[ARMSX2 iOS Gamepad] Device rumble active (continuous haptics)");
             s_loggedNativeGamepadRumbleReady = true;
         }
     }
 
     const float sharpnessControl = std::clamp((sharpness * 2.0f) - 1.0f, -1.0f, 1.0f);
     NSArray<CHHapticDynamicParameter*>* dynamicParams = @[
-        [[CHHapticDynamicParameter alloc] initWithParameterID:CHHapticDynamicParameterIDHapticIntensityControl value:intensity relativeTime:0.0],
-        [[CHHapticDynamicParameter alloc] initWithParameterID:CHHapticDynamicParameterIDHapticSharpnessControl value:sharpnessControl relativeTime:0.0]
+        [[[CHHapticDynamicParameter alloc] initWithParameterID:CHHapticDynamicParameterIDHapticIntensityControl value:intensity relativeTime:0.0] autorelease],
+        [[[CHHapticDynamicParameter alloc] initWithParameterID:CHHapticDynamicParameterIDHapticSharpnessControl value:sharpnessControl relativeTime:0.0] autorelease]
     ];
 
     if (![s_nativeHapticPlayer sendParameters:dynamicParams atTime:CHHapticTimeImmediate error:&error]) {
-        Console.WriteLn("[ARMSX2 iOS Gamepad] Native haptic update failed: %s", error.localizedDescription.UTF8String ?: "unknown");
+        Console.WriteLn("[ARMSX2 iOS Gamepad] Device haptic update failed: %s", error.localizedDescription.UTF8String ?: "unknown");
         ARMSX2StopNativeGamepadRumbleOnMain();
         return false;
     }
@@ -658,7 +676,13 @@ static void ARMSX2ApplyNativeGamepadRumbleOnMain(u32 packed)
 
     const float large = ARMSX2RumbleLargeIntensity(packed);
     const float small = ARMSX2RumbleSmallIntensity(packed);
-    const float intensity = std::clamp(std::max(large, small), 0.0f, 1.0f);
+    // Straight off the packed value, so the phone gets the whole 0..1 motor range
+    // rather than the 0x7000 ceiling the controller motors are held to. Read every
+    // time so dragging the slider is felt on the next rumble instead of next launch.
+    const float strength = s_settings_interface
+        ? std::clamp(s_settings_interface->GetFloatValue("ARMSX2iOS/UI", "PhoneRumbleStrength", 1.0f), 0.0f, 1.0f)
+        : 1.0f;
+    const float intensity = std::clamp(std::max(large, small) * strength, 0.0f, 1.0f);
     if (intensity <= 0.01f) {
         ARMSX2StopNativeGamepadRumbleOnMain();
         s_nativeAppliedGamepadRumble = packed;
@@ -953,8 +977,12 @@ void ARMSX2ApplyPendingGamepadRumble(unsigned int gamepad_index)
 
     if (!wants_rumble) {
         const u32 slot = gamepad_index;
+        const u32 native_packed_stop = packed;
         dispatch_async(dispatch_get_main_queue(), ^{
             ARMSX2StopNativeGamepadRumblePulseOnMain(slot);
+            // The device engine loops until it is told otherwise, so the zero has to
+            // reach it or the phone keeps buzzing after the game has stopped asking.
+            ARMSX2ApplyNativeGamepadRumbleOnMain(native_packed_stop);
         });
     }
 
@@ -1028,10 +1056,19 @@ void ARMSX2ApplyPendingGamepadRumble(unsigned int gamepad_index)
         dispatch_async(dispatch_get_main_queue(), ^{
             ARMSX2ApplyNativeGamepadRumblePulseOnMain(slot, native_packed, "no-sdl-gamepad");
         });
-        // No SDL gamepad and no native haptic controller: fall back to the
-        // device taptic engine so rumble is felt on phones (e.g. Kishi 3).
+        // No SDL gamepad and no native haptic controller: rumble the phone itself
+        // so it is felt on handheld grips (e.g. Kishi 3). The continuous engine
+        // sustains and tracks intensity; the one-shot tap is what is left on an
+        // iPad or an older phone with no taptic engine.
         if (!ARMSX2FindNativeHapticController()) {
-            [ARMSX2Bridge triggerDeviceHapticLarge:large small:small];
+            if (ARMSX2DeviceSupportsHaptics()) {
+                const u32 native_packed_device = packed;
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    ARMSX2ApplyNativeGamepadRumbleOnMain(native_packed_device);
+                });
+            } else {
+                [ARMSX2Bridge triggerDeviceHapticLarge:large small:small];
+            }
         }
     }
 

--- a/platforms/ios/app/src/main/cpp/IOS/GamepadHaptics.mm
+++ b/platforms/ios/app/src/main/cpp/IOS/GamepadHaptics.mm
@@ -688,6 +688,7 @@ static void ARMSX2StopNativeGamepadRumblePulseOnMain(u32 slot)
 				exception.name.UTF8String ?: "unknown",
 				exception.reason.UTF8String ?: "unknown");
 		}
+		[s_nativePulseHapticEngine[slot] release];
 		s_nativePulseHapticEngine[slot] = nil;
 	}
 }
@@ -880,7 +881,11 @@ static bool ARMSX2ApplyNativeGamepadRumblePulseOnMain(u32 slot, u32 packed, cons
 		return false;
 	}
 
-	s_nativePulseHapticEngine[slot] = engine;
+	// createEngineWithLocality: hands back an autoreleased engine and this file is MRC,
+	// so without the retain the pool drains it at the end of this run loop turn and the
+	// delayed stop below messages freed memory.
+	[s_nativePulseHapticEngine[slot] release];
+	s_nativePulseHapticEngine[slot] = [engine retain];
 	const u32 stop_generation = s_nativePulseHapticStopGeneration[slot].fetch_add(1, std::memory_order_relaxed) + 1;
 	const u32 log_index = s_loggedNativePulseHapticEvents.fetch_add(1, std::memory_order_relaxed);
 	if (log_index < 16) {
@@ -906,6 +911,7 @@ static bool ARMSX2ApplyNativeGamepadRumblePulseOnMain(u32 slot, u32 packed, cons
 					exception.name.UTF8String ?: "unknown",
 					exception.reason.UTF8String ?: "unknown");
 			}
+			[s_nativePulseHapticEngine[slot] release];
 			s_nativePulseHapticEngine[slot] = nil;
 		}
 	});

--- a/platforms/ios/app/src/main/cpp/IOS/HostImpls.mm
+++ b/platforms/ios/app/src/main/cpp/IOS/HostImpls.mm
@@ -328,6 +328,12 @@ namespace Host
         {
             ARMSX2RefreshIOSGamepads();
             for (u32 gamepad_index = 0; gamepad_index < ARMSX2_MAX_IOS_GAMEPADS; gamepad_index++) {
+                // Before the gamepad check, not after: this is what falls back to the
+                // phone's own taptic engine, and that case is precisely the one where
+                // there is no gamepad in the slot. It returns immediately when there
+                // is nothing pending, so idle slots cost nothing.
+                ARMSX2ApplyPendingGamepadRumble(gamepad_index);
+
                 SDL_Gamepad* gamepad = s_gamepads[gamepad_index];
                 if (!gamepad)
                     continue;
@@ -340,7 +346,6 @@ namespace Host
                 if (!gamepad_pad)
                     continue;
 
-                ARMSX2ApplyPendingGamepadRumble(gamepad_index);
                 ARMSX2ApplyIOSGamepadInput(gamepad_index, gamepad, gamepad_pad, gamepad_index == 0);
             }
         }

--- a/platforms/ios/app/src/main/swift/Models/GameEventHaptics.swift
+++ b/platforms/ios/app/src/main/swift/Models/GameEventHaptics.swift
@@ -11,7 +11,6 @@ final class GameEventHaptics {
     private var mediumGenerator: UIImpactFeedbackGenerator?
     private var lastFire = Date.distantPast
     private var hapticsEnabled = true
-    private var releasedForEmulationOnlyMode = false
 
     private init() {
         hapticsEnabled = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "HapticFeedback", defaultValue: true)
@@ -20,7 +19,7 @@ final class GameEventHaptics {
     /// Called from the bridge (game rumble path) when no rumble-capable controller is connected.
     /// Respects the user's HapticFeedback setting and throttles to avoid motor fatigue.
     func trigger(large: UInt16, small: UInt16) {
-        guard hapticsEnabled, !releasedForEmulationOnlyMode else { return }
+        guard hapticsEnabled else { return }
         guard large > 0 || small > 0 else { return }
         let now = Date()
         // Throttle to ~20 Hz so sustained rumble does not peg the haptic engine.
@@ -49,12 +48,12 @@ final class GameEventHaptics {
     }
 
     func prepareForGameplaySession() {
-        releasedForEmulationOnlyMode = false
         refreshEnabled()
     }
 
+    /// Drops the cached generators. trigger() builds them again on demand, so this is a
+    /// resource release and not an off switch: rumble after this still gets through.
     func releaseForEmulationOnlyMode() {
-        releasedForEmulationOnlyMode = true
         heavyGenerator = nil
         mediumGenerator = nil
         lastFire = .distantPast

--- a/platforms/ios/app/src/main/swift/Models/GameEventHaptics.swift
+++ b/platforms/ios/app/src/main/swift/Models/GameEventHaptics.swift
@@ -44,7 +44,10 @@ final class GameEventHaptics {
             mediumGenerator = created
             generator = created
         }
-        generator.impactOccurred(intensity: CGFloat(max(0.3, min(1.0, intensity))))
+        // No floor. It used to be 0.3, which flattened every weak rumble onto the same
+        // knock as a medium one. This path is only reached on hardware with no taptic
+        // engine to run the continuous one, so it is a fallback rather than the norm.
+        generator.impactOccurred(intensity: CGFloat(min(1.0, intensity)))
     }
 
     func prepareForGameplaySession() {

--- a/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
@@ -1505,6 +1505,15 @@ final class SettingsStore {
         _padOpacityConfig.writer(_padOpacityConfig.section, _padOpacityConfig.key, padOpacity)
         _padOpacityConfig.onSet?(padOpacity)
     }}
+    let _phoneRumbleStrengthConfig = Setting<Float>(
+        section: "ARMSX2iOS/UI", key: "PhoneRumbleStrength", default: 1.0,
+        suppressible: false,
+        writer: ARMSX2Bridge.setINIFloat)
+    var phoneRumbleStrength: Float = 1.0 { didSet {
+        guard !(_phoneRumbleStrengthConfig.suppressible && suppressINIWrites) else { return }
+        _phoneRumbleStrengthConfig.writer(_phoneRumbleStrengthConfig.section, _phoneRumbleStrengthConfig.key, phoneRumbleStrength)
+        _phoneRumbleStrengthConfig.onSet?(phoneRumbleStrength)
+    }}
     let _hapticFeedbackConfig = Setting<Bool>(
         section: "ARMSX2iOS/UI", key: "HapticFeedback", default: true,
         suppressible: false,
@@ -2053,6 +2062,7 @@ final class SettingsStore {
         // UI
         padOpacity = ARMSX2Bridge.getINIFloat("ARMSX2iOS/UI", key: "PadOpacity", defaultValue: 0.6)
         hapticFeedback = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "HapticFeedback", defaultValue: true)
+        phoneRumbleStrength = ARMSX2Bridge.getINIFloat("ARMSX2iOS/UI", key: "PhoneRumbleStrength", defaultValue: 1.0)
         dpadDiagonalsEnabled = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "DpadDiagonalsEnabled", defaultValue: true)
         faceComboZonesEnabled = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "FaceComboZonesEnabled", defaultValue: true)
         virtualPadSkin = VirtualPadSkin(rawValue: Int(ARMSX2Bridge.getINIInt("ARMSX2iOS/UI", key: "VirtualPadSkin", defaultValue: 0))) ?? .armsx2Refresh
@@ -2298,6 +2308,7 @@ final class SettingsStore {
         osdShowDeviceStats = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "OsdShowDeviceStats", defaultValue: osdPreset != .off)
         padOpacity = ARMSX2Bridge.getINIFloat("ARMSX2iOS/UI", key: "PadOpacity", defaultValue: 0.6)
         hapticFeedback = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "HapticFeedback", defaultValue: true)
+        phoneRumbleStrength = ARMSX2Bridge.getINIFloat("ARMSX2iOS/UI", key: "PhoneRumbleStrength", defaultValue: 1.0)
         dpadDiagonalsEnabled = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "DpadDiagonalsEnabled", defaultValue: true)
         faceComboZonesEnabled = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "FaceComboZonesEnabled", defaultValue: true)
         virtualPadSkin = VirtualPadSkin(rawValue: Int(ARMSX2Bridge.getINIInt("ARMSX2iOS/UI", key: "VirtualPadSkin", defaultValue: 0))) ?? .armsx2Refresh

--- a/platforms/ios/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift
@@ -199,6 +199,14 @@ struct VirtualPadSettingsView: View {
 
             Section(settings.localized("Feedback")) {
                 Toggle(settings.localized("Haptic Feedback"), isOn: $settings.hapticFeedback)
+
+                VStack(alignment: .leading) {
+                    Text("\(settings.localized("Phone Rumble Strength")): \(Int(settings.phoneRumbleStrength * 100))%")
+                    Slider(value: $settings.phoneRumbleStrength, in: 0.0...1.0, step: 0.05)
+                }
+                Text(settings.localized("How hard the phone itself rumbles when no controller is connected. Has no effect on a controller's own motors."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section(settings.localized("Layout")) {


### PR DESCRIPTION
Rumble has been dead on iOS since the move to a single shared core, so 2.4.1, 2.5.0 and 2.5.1 all shipped without it. This brings it back and then gives the phone's own rumble a usable range.

### What changed

* Controller rumble works again.
* Phone rumble works again, on games played without a controller.
* Phone rumble sustains for as long as the game asks for it, and its strength tracks what the game is doing, instead of one weak tap of a fixed size.
* New Phone Rumble Strength slider under Virtual Pad, Feedback. Full by default.
* Rumble stops when you pause, rather than carrying on behind the menu.
* Phone haptics survive Emulation Only Mode instead of staying off for the rest of the session.

### Why it was dead

ARMSX2_iOSUpdatePadVibration is the only thing that ever writes the iOS rumble queue, and nothing had called it since the mono core move. It used to be hooked into InputManager::SetPadVibrationIntensity as a patch on the iOS tree's own copy of the core, and when we adopted the shared one the patch did not come along. One dead producer starves all three consumers, which is why SDL rumble, the CoreHaptics pulse and the phone's taptic fallback all went silent together rather than one at a time.

Android hit exactly this from exactly this migration and was fixed three days later. That fix is still sitting in the same function and says so in its comment. The iOS block goes right beside it.

Worth knowing for anyone adding a platform hook there: InputManager.cpp had no TargetConditionals.h, so TARGET_OS_IPHONE was undefined and the guard would have compiled the whole thing straight back out while the build stayed green. The include is guarded the way Host.cpp does it.

Three more things sat behind the dead call site. The per frame pump ran the rumble step only after confirming a gamepad was in the slot, and the phone fallback exists for the case where there is no gamepad in the slot, so it was unreachable. Emulation Only Mode set a flag that turned phone haptics off and is only cleared on a branch that returning to a stripped VM does not take. And the per slot pulse engine was an autoreleased object living in a static in a file built without ARC, then messaged again a third of a second later.

### Why the phone felt the same every time

Everything is capped at 0x7000, which is 44 percent of full scale, and the Swift side then floored it at 0.3. The chain came out as max(0.3, min(0.4375, motor / 255)), so motor bytes 1 to 76 all produced 0.300 and 112 to 255 all produced 0.4375. Of 256 possible values, 35 changed anything. On top of that UIImpactFeedbackGenerator knocks once and cannot be sustained or changed afterwards, and the dedup gate skips a packed value that has not moved, so a game holding the motor for two seconds got a single blip.

There was already a continuous CoreHaptics implementation in the file, written and never called by anything: a looped continuous event with an advanced player whose intensity is updated live. It was controller specific in two lines, so it creates a device engine now and the phone gets sustained rumble that follows the motor. That deleted the dead path rather than adding a new one.

The phone reads the packed value unclamped so it gets the whole range, multiplied by the new slider. The 0x7000 cap stays where it was tuned, on the controller motors. Hardware with no taptic engine keeps the old tap, minus the 0.3 floor.

Reviving that code meant fixing what it had been getting away with while nothing ran it. The engine comes from alloc/init now so the static owns it, the player still comes from a factory method and needs the retain, and the dynamic parameter array was leaking on every intensity update. The stopped and reset handlers hop to main before touching the player, since CoreHaptics calls them back on a queue of its own and everything else there runs on main. The zero has to reach the engine too, since a looped player runs until told otherwise.

Confirmed working on device for controller and phone. The strength slider and the Emulation Only Mode round trip are the parts that have had the least time on real hardware.
