### PR TITLE
iOS: Improve Dynamic Thumbstick Feedback, iPad Swipe Camera, and Virtual Layout Management

### DIFF
--- a/platforms/ios/app/src/main/swift/Views/Controller/DynamicThumbstickControls.swift
+++ b/platforms/ios/app/src/main/swift/Views/Controller/DynamicThumbstickControls.swift
@@ -124,6 +124,7 @@ struct DynamicThumbstickView: View {
     @State private var dragDistance: CGFloat = 0
     @State private var isActive = false
     @State private var isOverextended = false
+    @State private var maximumPullPulseToken = 0
     @State private var gestureStartedAt: Date?
     @State private var maximumTravel: CGFloat = 0
 
@@ -139,7 +140,7 @@ struct DynamicThumbstickView: View {
                         maximumRadius: maximumRadius,
                         dragOffset: dragOffset,
                         dragDistance: dragDistance,
-                        isOverextended: isOverextended,
+                        maximumPullPulseToken: maximumPullPulseToken,
                         thumbstickOpacity: thumbstickOpacity,
                         baseOpacity: baseOpacity,
                         trailOpacity: trailOpacity
@@ -220,6 +221,7 @@ struct DynamicThumbstickView: View {
         guard overextended != isOverextended else { return }
         isOverextended = overextended
         if overextended {
+            maximumPullPulseToken &+= 1
             if hapticsEnabled && SettingsStore.shared.hapticFeedback {
                 HapticManager.medium.impactOccurred(intensity: 1)
                 HapticManager.medium.prepare()
@@ -237,6 +239,7 @@ struct DynamicThumbstickView: View {
         gestureStartedAt = nil
         maximumTravel = 0
         isOverextended = false
+        maximumPullPulseToken = 0
         withAnimation(.easeOut(duration: 0.14)) {
             isActive = false
         }
@@ -248,10 +251,12 @@ private struct DynamicThumbstickVisual: View {
     let maximumRadius: CGFloat
     let dragOffset: CGSize
     let dragDistance: CGFloat
-    let isOverextended: Bool
+    let maximumPullPulseToken: Int
     let thumbstickOpacity: Double
     let baseOpacity: Double
     let trailOpacity: Double
+
+    @State private var maximumPullPulseProgress: CGFloat = 0
 
     var body: some View {
         ZStack {
@@ -274,12 +279,12 @@ private struct DynamicThumbstickVisual: View {
                 .overlay {
                     Circle()
                         .stroke(
-                            Color.white.opacity(isOverextended ? 0.55 : 0),
+                            Color.white.opacity(0.55 * maximumPullPulseProgress),
                             lineWidth: 1.5
                         )
-                        .scaleEffect(isOverextended ? 1.45 : 1)
+                        .scaleEffect(1 + 0.45 * maximumPullPulseProgress)
                 }
-                .scaleEffect(isOverextended ? 1.28 : 1)
+                .scaleEffect(1 + 0.28 * maximumPullPulseProgress)
 
             Circle()
                 .fill(Color(white: 0.88).opacity(thumbstickOpacity))
@@ -287,12 +292,21 @@ private struct DynamicThumbstickVisual: View {
                 .offset(dragOffset)
         }
         .frame(width: radius * 2, height: radius * 2)
-        .animation(
-            isOverextended
-                ? .easeInOut(duration: 0.42).repeatForever(autoreverses: true)
-                : .easeOut(duration: 0.16),
-            value: isOverextended
-        )
+        .task(id: maximumPullPulseToken) {
+            guard maximumPullPulseToken > 0 else {
+                maximumPullPulseProgress = 0
+                return
+            }
+            maximumPullPulseProgress = 0
+            withAnimation(.spring(response: 0.18, dampingFraction: 0.58)) {
+                maximumPullPulseProgress = 1
+            }
+            try? await Task.sleep(for: .milliseconds(170))
+            guard !Task.isCancelled else { return }
+            withAnimation(.easeOut(duration: 0.22)) {
+                maximumPullPulseProgress = 0
+            }
+        }
     }
 }
 
@@ -325,6 +339,7 @@ struct VirtualPadCameraSwipeView: View {
     @State private var dragDistance: CGFloat = 0
     @State private var isDynamicJoystickMode = false
     @State private var isOverextended = false
+    @State private var maximumPullPulseToken = 0
     @State private var activeDynamicThumbstickDistance: CGFloat?
     @State private var dynamicJoystickPeakTravel: CGFloat = 0
     @State private var previousRadialTravel: CGFloat = 0
@@ -341,7 +356,7 @@ struct VirtualPadCameraSwipeView: View {
                         maximumRadius: maximumThumbstickRadius,
                         dragOffset: dragOffset,
                         dragDistance: dragDistance,
-                        isOverextended: isOverextended,
+                        maximumPullPulseToken: maximumPullPulseToken,
                         thumbstickOpacity: thumbstickOpacity,
                         baseOpacity: baseOpacity,
                         trailOpacity: trailOpacity
@@ -467,6 +482,7 @@ struct VirtualPadCameraSwipeView: View {
         guard overextended != isOverextended else { return }
         isOverextended = overextended
         if overextended {
+            maximumPullPulseToken &+= 1
             if hapticsEnabled && SettingsStore.shared.hapticFeedback {
                 HapticManager.medium.impactOccurred(intensity: 1)
                 HapticManager.medium.prepare()
@@ -484,6 +500,7 @@ struct VirtualPadCameraSwipeView: View {
         dragOffset = .zero
         dragDistance = 0
         isOverextended = false
+        maximumPullPulseToken = 0
         activeDynamicThumbstickDistance = nil
         dynamicJoystickPeakTravel = 0
         previousRadialTravel = 0

--- a/platforms/ios/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift
@@ -62,6 +62,9 @@ struct VirtualPadSettingsView: View {
     @State private var showLayoutImportAlert = false
     @State private var layoutImportMessage = ""
     @State private var layoutExportItem: ShareSheetItem?
+    @State private var layoutPendingRename: PadLayoutPreset?
+    @State private var layoutRenameDraft = ""
+    @State private var layoutPendingDelete: PadLayoutPreset?
     @State private var skinPendingDelete: VPadSkinDescriptor?
     @State private var skinPendingRename: VPadSkinDescriptor?
     @State private var skinRenameDraft = ""
@@ -244,13 +247,38 @@ struct VirtualPadSettingsView: View {
                             Text(preset.displayName)
                                 .lineLimit(1)
                             Spacer()
-                            Button {
-                                exportLayout(preset)
+                            Menu {
+                                Button {
+                                    layoutPendingRename = preset
+                                    layoutRenameDraft = preset.displayName
+                                } label: {
+                                    Label(
+                                        settings.localized("Rename Layout"),
+                                        systemImage: "pencil"
+                                    )
+                                }
+                                Button {
+                                    exportLayout(preset)
+                                } label: {
+                                    Label(
+                                        settings.localized("Share Layout"),
+                                        systemImage: "square.and.arrow.up"
+                                    )
+                                }
+                                Button(role: .destructive) {
+                                    layoutPendingDelete = preset
+                                } label: {
+                                    Label(
+                                        settings.localized("Delete Layout"),
+                                        systemImage: "trash"
+                                    )
+                                }
                             } label: {
-                                Image(systemName: "square.and.arrow.up")
+                                Image(systemName: "ellipsis.circle")
                             }
-                            .buttonStyle(.borderless)
-                            .accessibilityLabel("Export \(preset.displayName)")
+                            .accessibilityLabel(
+                                settings.localized("Layout Options") + " \(preset.displayName)"
+                            )
                         }
                     }
                 }
@@ -757,6 +785,66 @@ struct VirtualPadSettingsView: View {
             Button(settings.localized("OK"), role: .cancel) {}
         } message: {
             Text(layoutImportMessage)
+        }
+        .alert(
+            settings.localized("Rename Layout"),
+            isPresented: Binding<Bool>(
+                get: { layoutPendingRename != nil },
+                set: { if !$0 { layoutPendingRename = nil } }
+            )
+        ) {
+            TextField(settings.localized("Name"), text: $layoutRenameDraft)
+            Button(settings.localized("Rename")) {
+                if let preset = layoutPendingRename {
+                    do {
+                        try layoutPresets.renamePreset(
+                            id: preset.id,
+                            to: layoutRenameDraft
+                        )
+                    } catch {
+                        layoutImportMessage =
+                            "Layout rename failed: \(error.localizedDescription)"
+                        showLayoutImportAlert = true
+                    }
+                }
+                layoutPendingRename = nil
+            }
+            Button(settings.localized("Cancel"), role: .cancel) {
+                layoutPendingRename = nil
+            }
+        } message: {
+            Text(settings.localized("Choose a new name for this layout."))
+        }
+        .confirmationDialog(
+            settings.localized("Delete Layout?"),
+            isPresented: Binding<Bool>(
+                get: { layoutPendingDelete != nil },
+                set: { if !$0 { layoutPendingDelete = nil } }
+            ),
+            presenting: layoutPendingDelete
+        ) { preset in
+            Button(
+                "\(settings.localized("Delete")) \(preset.displayName)",
+                role: .destructive
+            ) {
+                do {
+                    try layoutPresets.deletePreset(id: preset.id)
+                } catch {
+                    layoutImportMessage =
+                        "Layout deletion failed: \(error.localizedDescription)"
+                    showLayoutImportAlert = true
+                }
+                layoutPendingDelete = nil
+            }
+            Button(settings.localized("Cancel"), role: .cancel) {
+                layoutPendingDelete = nil
+            }
+        } message: { _ in
+            Text(
+                settings.localized(
+                    "Games using this layout will fall back to their next available layout."
+                )
+            )
         }
         .sheet(isPresented: $showSkinImporter) {
             ImportDocumentPicker(

--- a/platforms/ios/app/src/main/swift/Views/VirtualControllerView.swift
+++ b/platforms/ios/app/src/main/swift/Views/VirtualControllerView.swift
@@ -519,6 +519,9 @@ struct VirtualControllerView: View {
     private func dynamicInputZones(w: CGFloat, h: CGFloat) -> some View {
         let conversionSettings = dynamicSettings.effectiveSwipeConversionSettings
         let visualRadius = CGFloat(dynamicSettings.thumbstickRadius)
+        let swipeZoneCenterX = UIDevice.current.userInterfaceIdiom == .pad
+            ? w / 4
+            : w * 0.75
         let rightAreaScale = CGFloat(
             min(max(dynamicSettings.rightThumbstickAreaScale, 1), 5)
         )
@@ -590,7 +593,7 @@ struct VirtualControllerView: View {
                     }
                 )
                 .frame(width: w / 2, height: h)
-                .position(x: w * 0.75, y: h / 2)
+                .position(x: swipeZoneCenterX, y: h / 2)
             } else if dynamicSettings.dynamicThumbsticks && isVisible("rstick") {
                 dynamicThumbstickZone(isLeft: false)
                     .frame(width: w / 2, height: h)

--- a/platforms/ios/app/src/main/swift/Views/VirtualControllerView.swift
+++ b/platforms/ios/app/src/main/swift/Views/VirtualControllerView.swift
@@ -519,9 +519,6 @@ struct VirtualControllerView: View {
     private func dynamicInputZones(w: CGFloat, h: CGFloat) -> some View {
         let conversionSettings = dynamicSettings.effectiveSwipeConversionSettings
         let visualRadius = CGFloat(dynamicSettings.thumbstickRadius)
-        let swipeZoneCenterX = UIDevice.current.userInterfaceIdiom == .pad
-            ? w / 4
-            : w * 0.75
         let rightAreaScale = CGFloat(
             min(max(dynamicSettings.rightThumbstickAreaScale, 1), 5)
         )
@@ -593,7 +590,7 @@ struct VirtualControllerView: View {
                     }
                 )
                 .frame(width: w / 2, height: h)
-                .position(x: swipeZoneCenterX, y: h / 2)
+                .position(x: w * 0.75, y: h / 2)
             } else if dynamicSettings.dynamicThumbsticks && isVisible("rstick") {
                 dynamicThumbstickZone(isLeft: false)
                     .frame(width: w / 2, height: h)


### PR DESCRIPTION
# iOS: Improve Dynamic Thumbstick Feedback, iPad Swipe Camera, and Virtual Layout Management

## Summary

This pull request improves three parts of the iOS Virtual Pad experience:

- Changes the Dynamic Thumbstick maximum-pull indicator from a continuously repeating animation into a single pulse for each threshold crossing.
- Expands Swipe Camera input across the complete right half of the screen on iPad while preserving the existing right-half behavior on iPhone.
- Replaces the direct Share button beside saved layouts with a three-dot menu that provides Rename, Share, and Delete actions.

The changes are limited to the iOS SwiftUI Virtual Pad controls and settings. Emulator-core input, controller mapping, saved layout formats, and iPhone Swipe Camera placement are unchanged.

## Base

- Repository: `ARMSX2/ARMSX2`
- Target branch: `master`
- Rebased master commit: `12a7e3768`

## Changes

### One-shot maximum-pull pulse

Previously, reaching maximum pull set a Boolean state that drove a repeating SwiftUI animation. The origin continued pulsing for as long as the touch remained beyond the maximum-pull threshold.

The new implementation treats reaching maximum pull as an event:

1. The existing overextension threshold and hysteresis determine when the gesture crosses into maximum pull.
2. A pulse token increments only on the transition from not overextended to overextended.
3. The visual grows with a short spring animation.
4. It returns to its resting scale and opacity with an ease-out animation.
5. It remains at rest while the touch stays overextended.
6. Moving back below the hysteresis boundary allows a later threshold crossing to trigger one new pulse.

This behavior applies to:

- Normal Dynamic Thumbsticks
- Swipe Camera after it converts into Dynamic Joystick mode

The existing maximum-pull haptic remains tied to the same threshold-crossing event.

### Full right-side Swipe Camera input on iPad

On iPad, Swipe Camera was positioned over the upper/right-side input region and did not cover the intended touch area.

The Swipe Camera view now retains its half-screen width but uses a device-specific horizontal position:

- iPad: the full right half of the gameplay surface
- iPhone: the existing right half of the gameplay surface

Only the input-zone placement changes. Swipe sensitivity, Dynamic Joystick conversion, camera output, touch lifecycle, and visual settings continue using the existing implementation.

### Saved-layout three-dot menu

Each saved layout previously displayed a dedicated Share icon. It is now replaced by an accessible three-dot menu with:

- **Rename Layout**
  - Opens a text-field alert initialized with the current display name.
  - Uses the existing preset-store rename operation.
  - Reports rename errors through the existing layout message alert.

- **Share Layout**
  - Uses the existing layout export and system share-sheet flow.
  - Does not change the exported layout format.

- **Delete Layout**
  - Uses a destructive menu role.
  - Requires confirmation before deletion.
  - Uses the existing preset-store deletion operation so active global or per-game references fall back according to the store’s established behavior.
  - Reports deletion errors through the existing layout message alert.

The menu has a descriptive accessibility label containing the layout name.

## Files Changed

- `platforms/ios/app/src/main/swift/Views/Controller/DynamicThumbstickControls.swift`
- `platforms/ios/app/src/main/swift/Views/VirtualControllerView.swift`
- `platforms/ios/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift`

## User-visible Behavior

### Before

- Maximum-pull origin feedback repeated indefinitely while held past maximum pull.
- iPad Swipe Camera accepted input only from the previous limited/right-side zone.
- Saved layouts exposed only a direct Share button.

### After

- Maximum pull produces one clear pulse per threshold crossing.
- iPad Swipe Camera accepts gestures throughout the full right half of the gameplay surface.
- Saved layouts expose Rename, Share, and Delete from one compact three-dot menu.
- iPhone Swipe Camera placement remains unchanged.

## Compatibility and Data Impact

- No changes to the layout file schema.
- No migration is required.
- Existing saved layouts remain compatible.
- Existing layout export/import behavior remains compatible.
- No changes to emulator-core controller input.
- No changes to physical-controller support.
- No changes to Dynamic Thumbstick sensitivity or deadzone calculations.
- The implementation remains within the existing iOS 17+ deployment target.

## Validation

- Rebased onto the latest `origin/master` without conflicts.
- `git diff --check` passes.
- Full unsigned iOS Release IPA build completed with `platforms/ios/scripts/build-ios-ipa.sh`.


### Did you use AI to help find, test, or implement this issue or feature?
Yes, to generate this PR.md.