### PR TITLE
iOS: A12 launch crash, rumble intensity, and a gamepad haptics audit

### DIFF
--- a/platforms/ios/app/src/main/cpp/IOS/GamepadHaptics.mm
+++ b/platforms/ios/app/src/main/cpp/IOS/GamepadHaptics.mm
@@ -35,11 +35,29 @@ static constexpr u32 ARMSX2_GAMEPAD_RUMBLE_DURATION_MS = 220;
 static constexpr double ARMSX2_GAMEPAD_RUMBLE_FORCE_STOP_SECONDS = 0.30;
 static constexpr u16 ARMSX2_GAMEPAD_RUMBLE_MAX_INTENSITY = 0x7000;
 
+// The two PS2 motors feel nothing alike, so the phone plays them as two channels
+// rather than flattening them into one number. Taptic Engine sharpness runs 80 Hz
+// at 0.0 up to 230 Hz at 1.0, hitting hardest around 0.73, so the heavy motor sits
+// below that and the buzzer above it.
+enum : u32
+{
+    ARMSX2_RUMBLE_CHANNEL_LARGE = 0,
+    ARMSX2_RUMBLE_CHANNEL_SMALL = 1,
+    ARMSX2_RUMBLE_CHANNEL_COUNT = 2,
+};
+static constexpr float ARMSX2_RUMBLE_CHANNEL_SHARPNESS[ARMSX2_RUMBLE_CHANNEL_COUNT] = { 0.35f, 0.85f };
+// The PS2 small motor has one speed and no analog control at all, so "on" is just
+// a level we pick. Matching the real pad means it does not vary.
+static constexpr float ARMSX2_SMALL_MOTOR_LEVEL = 0.55f;
+// Down at the bottom of the range the engine barely moves, so a faint rumble reads
+// as nothing at all. Lift the floor without touching the top.
+static constexpr float ARMSX2_RUMBLE_FLOOR = 0.12f;
+
 static CHHapticEngine* s_nativePulseHapticEngine[ARMSX2_MAX_IOS_GAMEPADS] = {};
 static std::atomic<u32> s_nativePulseHapticStopGeneration[ARMSX2_MAX_IOS_GAMEPADS];
 static std::atomic<u32> s_loggedNativePulseHapticEvents{0};
 static CHHapticEngine* s_nativeHapticEngine = nil;
-static id<CHHapticAdvancedPatternPlayer> s_nativeHapticPlayer = nil;
+static id<CHHapticAdvancedPatternPlayer> s_nativeHapticPlayer[ARMSX2_RUMBLE_CHANNEL_COUNT] = {};
 static u32 s_nativeAppliedGamepadRumble = 0;
 static bool s_nativeAppliedGamepadRumbleValid = false;
 static bool s_loggedNativeGamepadRumbleReady = false;
@@ -511,16 +529,23 @@ extern "C" void ARMSX2_iOSUpdatePadVibration(u32 pad_index, float large_intensit
     s_pendingGamepadRumble[gamepad_index].store(packed, std::memory_order_relaxed);
 }
 
+static void ARMSX2StopRumbleChannelOnMain(u32 channel)
+{
+    if (channel >= ARMSX2_RUMBLE_CHANNEL_COUNT || !s_nativeHapticPlayer[channel])
+        return;
+
+    NSError* error = nil;
+    [s_nativeHapticPlayer[channel] stopAtTime:CHHapticTimeImmediate error:&error];
+    if (error)
+        Console.WriteLn("[ARMSX2 iOS Gamepad] Device rumble stop failed: %s", error.localizedDescription.UTF8String ?: "unknown");
+    [s_nativeHapticPlayer[channel] release];
+    s_nativeHapticPlayer[channel] = nil;
+}
+
 static void ARMSX2StopNativeGamepadRumbleOnMain()
 {
-    if (s_nativeHapticPlayer) {
-        NSError* error = nil;
-        [s_nativeHapticPlayer stopAtTime:CHHapticTimeImmediate error:&error];
-        if (error)
-            Console.WriteLn("[ARMSX2 iOS Gamepad] Device rumble stop failed: %s", error.localizedDescription.UTF8String ?: "unknown");
-        [s_nativeHapticPlayer release];
-        s_nativeHapticPlayer = nil;
-    }
+    for (u32 channel = 0; channel < ARMSX2_RUMBLE_CHANNEL_COUNT; channel++)
+        ARMSX2StopRumbleChannelOnMain(channel);
 }
 
 static void ARMSX2ResetNativeGamepadRumbleOnMain()
@@ -558,7 +583,7 @@ static bool ARMSX2DeviceSupportsHaptics()
     return supported;
 }
 
-static bool ARMSX2EnsureNativeGamepadRumbleOnMain(float intensity, float sharpness)
+static bool ARMSX2EnsureNativeRumbleEngineOnMain()
 {
     if (@available(iOS 14.0, *)) {
     } else {
@@ -590,10 +615,10 @@ static bool ARMSX2EnsureNativeGamepadRumbleOnMain(float intensity, float sharpne
         s_nativeHapticEngine.playsHapticsOnly = YES;
         s_nativeHapticEngine.autoShutdownEnabled = YES;
         // The engine shuts itself down when idle and again when the app backgrounds.
-        // Drop the player so the next rumble rebuilds it; the engine restarts above.
+        // Drop both players so the next rumble rebuilds them; the engine restarts above.
         // CoreHaptics calls these back on a queue of its own choosing, and everything
-        // else here touches the player from main. Hop before releasing it, or the
-        // release races the main thread still using it.
+        // else here touches the players from main. Hop before releasing them, or the
+        // release races the main thread still using them.
         s_nativeHapticEngine.stoppedHandler = ^(CHHapticEngineStoppedReason reason) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 ARMSX2StopNativeGamepadRumbleOnMain();
@@ -618,51 +643,81 @@ static bool ARMSX2EnsureNativeGamepadRumbleOnMain(float intensity, float sharpne
         return false;
     }
 
-    if (!s_nativeHapticPlayer) {
-        NSArray<CHHapticEventParameter*>* params = @[
-            [[[CHHapticEventParameter alloc] initWithParameterID:CHHapticEventParameterIDHapticIntensity value:intensity] autorelease],
-            [[[CHHapticEventParameter alloc] initWithParameterID:CHHapticEventParameterIDHapticSharpness value:sharpness] autorelease]
-        ];
-        CHHapticEvent* event = [[[CHHapticEvent alloc] initWithEventType:CHHapticEventTypeHapticContinuous
-                                                              parameters:params
-                                                            relativeTime:0.0
-                                                                 duration:1.0] autorelease];
-        CHHapticPattern* pattern = [[[CHHapticPattern alloc] initWithEvents:@[event] parameters:@[] error:&error] autorelease];
-        if (!pattern) {
-            Console.WriteLn("[ARMSX2 iOS Gamepad] Native haptic pattern failed: %s", error.localizedDescription.UTF8String ?: "unknown");
-            return false;
-        }
+    return true;
+}
 
-        s_nativeHapticPlayer = [[s_nativeHapticEngine createAdvancedPlayerWithPattern:pattern error:&error] retain];
-        if (!s_nativeHapticPlayer) {
-            Console.WriteLn("[ARMSX2 iOS Gamepad] Native haptic player failed: %s", error.localizedDescription.UTF8String ?: "unknown");
-            return false;
-        }
+// Each channel loops one continuous event at full intensity and its own fixed
+// sharpness, and the live parameter below does the rest. The base has to be 1.0:
+// IntensityControl multiplies it rather than replacing it, so anything less than
+// full here becomes a ceiling nothing can get past.
+static bool ARMSX2EnsureRumbleChannelOnMain(u32 channel)
+{
+    if (s_nativeHapticPlayer[channel])
+        return true;
 
-        s_nativeHapticPlayer.loopEnabled = YES;
-        s_nativeHapticPlayer.loopEnd = 1.0;
-        if (![s_nativeHapticPlayer startAtTime:CHHapticTimeImmediate error:&error]) {
-            Console.WriteLn("[ARMSX2 iOS Gamepad] Device haptic player start failed: %s", error.localizedDescription.UTF8String ?: "unknown");
-            [s_nativeHapticPlayer release];
-            s_nativeHapticPlayer = nil;
-            return false;
-        }
-
-        if (!s_loggedNativeGamepadRumbleReady) {
-            Console.WriteLn("[ARMSX2 iOS Gamepad] Device rumble active (continuous haptics)");
-            s_loggedNativeGamepadRumbleReady = true;
-        }
+    NSError* error = nil;
+    NSArray<CHHapticEventParameter*>* params = @[
+        [[[CHHapticEventParameter alloc] initWithParameterID:CHHapticEventParameterIDHapticIntensity value:1.0f] autorelease],
+        [[[CHHapticEventParameter alloc] initWithParameterID:CHHapticEventParameterIDHapticSharpness
+                                                       value:ARMSX2_RUMBLE_CHANNEL_SHARPNESS[channel]] autorelease]
+    ];
+    CHHapticEvent* event = [[[CHHapticEvent alloc] initWithEventType:CHHapticEventTypeHapticContinuous
+                                                          parameters:params
+                                                        relativeTime:0.0
+                                                             duration:1.0] autorelease];
+    CHHapticPattern* pattern = [[[CHHapticPattern alloc] initWithEvents:@[event] parameters:@[] error:&error] autorelease];
+    if (!pattern) {
+        Console.WriteLn("[ARMSX2 iOS Gamepad] Native haptic pattern failed: %s", error.localizedDescription.UTF8String ?: "unknown");
+        return false;
     }
 
-    const float sharpnessControl = std::clamp((sharpness * 2.0f) - 1.0f, -1.0f, 1.0f);
+    s_nativeHapticPlayer[channel] = [[s_nativeHapticEngine createAdvancedPlayerWithPattern:pattern error:&error] retain];
+    if (!s_nativeHapticPlayer[channel]) {
+        Console.WriteLn("[ARMSX2 iOS Gamepad] Native haptic player failed: %s", error.localizedDescription.UTF8String ?: "unknown");
+        return false;
+    }
+
+    s_nativeHapticPlayer[channel].loopEnabled = YES;
+    s_nativeHapticPlayer[channel].loopEnd = 1.0;
+    if (![s_nativeHapticPlayer[channel] startAtTime:CHHapticTimeImmediate error:&error]) {
+        Console.WriteLn("[ARMSX2 iOS Gamepad] Device haptic player start failed: %s", error.localizedDescription.UTF8String ?: "unknown");
+        [s_nativeHapticPlayer[channel] release];
+        s_nativeHapticPlayer[channel] = nil;
+        return false;
+    }
+
+    if (!s_loggedNativeGamepadRumbleReady) {
+        Console.WriteLn("[ARMSX2 iOS Gamepad] Device rumble active (continuous haptics)");
+        s_loggedNativeGamepadRumbleReady = true;
+    }
+
+    return true;
+}
+
+// Expects the engine to already be up, which is the caller's job.
+static bool ARMSX2SetRumbleChannelOnMain(u32 channel, float level)
+{
+    if (channel >= ARMSX2_RUMBLE_CHANNEL_COUNT)
+        return false;
+
+    if (level <= 0.01f) {
+        ARMSX2StopRumbleChannelOnMain(channel);
+        return true;
+    }
+
+    if (!ARMSX2EnsureRumbleChannelOnMain(channel))
+        return false;
+
+    const float intensity = std::clamp(level, 0.0f, 1.0f);
+    NSError* error = nil;
     NSArray<CHHapticDynamicParameter*>* dynamicParams = @[
-        [[[CHHapticDynamicParameter alloc] initWithParameterID:CHHapticDynamicParameterIDHapticIntensityControl value:intensity relativeTime:0.0] autorelease],
-        [[[CHHapticDynamicParameter alloc] initWithParameterID:CHHapticDynamicParameterIDHapticSharpnessControl value:sharpnessControl relativeTime:0.0] autorelease]
+        [[[CHHapticDynamicParameter alloc] initWithParameterID:CHHapticDynamicParameterIDHapticIntensityControl
+                                                         value:intensity relativeTime:0.0] autorelease]
     ];
 
-    if (![s_nativeHapticPlayer sendParameters:dynamicParams atTime:CHHapticTimeImmediate error:&error]) {
+    if (![s_nativeHapticPlayer[channel] sendParameters:dynamicParams atTime:CHHapticTimeImmediate error:&error]) {
         Console.WriteLn("[ARMSX2 iOS Gamepad] Device haptic update failed: %s", error.localizedDescription.UTF8String ?: "unknown");
-        ARMSX2StopNativeGamepadRumbleOnMain();
+        ARMSX2StopRumbleChannelOnMain(channel);
         return false;
     }
 
@@ -674,24 +729,30 @@ static void ARMSX2ApplyNativeGamepadRumbleOnMain(u32 packed)
 	if (s_nativeAppliedGamepadRumbleValid && packed == s_nativeAppliedGamepadRumble)
 		return;
 
-    const float large = ARMSX2RumbleLargeIntensity(packed);
-    const float small = ARMSX2RumbleSmallIntensity(packed);
     // Straight off the packed value, so the phone gets the whole 0..1 motor range
     // rather than the 0x7000 ceiling the controller motors are held to. Read every
     // time so dragging the slider is felt on the next rumble instead of next launch.
     const float strength = s_settings_interface
         ? std::clamp(s_settings_interface->GetFloatValue("ARMSX2iOS/UI", "PhoneRumbleStrength", 1.0f), 0.0f, 1.0f)
         : 1.0f;
-    const float intensity = std::clamp(std::max(large, small) * strength, 0.0f, 1.0f);
-    if (intensity <= 0.01f) {
-        ARMSX2StopNativeGamepadRumbleOnMain();
-        s_nativeAppliedGamepadRumble = packed;
-        s_nativeAppliedGamepadRumbleValid = true;
-        return;
-    }
+    // The heavy motor carries everything the game varies, so it drives its own
+    // channel and keeps its range. The buzzer is on or off on a real pad, so it gets
+    // a fixed level. Maxing the two together, which is what used to happen here,
+    // meant one touch of the buzzer pinned the lot to full and buried the heavy motor.
+    const float large_raw = ARMSX2RumbleLargeIntensity(packed);
+    // Lift the game's value clear of the floor before the slider scales it, so a
+    // faint rumble is felt as faint while the slider can still take it to nothing.
+    const float large = (large_raw > 0.01f)
+        ? (ARMSX2_RUMBLE_FLOOR + ((1.0f - ARMSX2_RUMBLE_FLOOR) * large_raw)) * strength
+        : 0.0f;
+    const float small = (ARMSX2RumbleSmallIntensity(packed) > 0.01f) ? (ARMSX2_SMALL_MOTOR_LEVEL * strength) : 0.0f;
 
-    const float sharpness = std::clamp(0.20f + (small * 0.65f) - (large * 0.10f), 0.0f, 1.0f);
-    if (ARMSX2EnsureNativeGamepadRumbleOnMain(intensity, sharpness)) {
+    if ((large > 0.01f || small > 0.01f) && !ARMSX2EnsureNativeRumbleEngineOnMain())
+        return;
+
+    const bool large_ok = ARMSX2SetRumbleChannelOnMain(ARMSX2_RUMBLE_CHANNEL_LARGE, large);
+    const bool small_ok = ARMSX2SetRumbleChannelOnMain(ARMSX2_RUMBLE_CHANNEL_SMALL, small);
+    if (large_ok && small_ok) {
         s_nativeAppliedGamepadRumble = packed;
         s_nativeAppliedGamepadRumbleValid = true;
 	}
@@ -1067,7 +1128,10 @@ void ARMSX2ApplyPendingGamepadRumble(unsigned int gamepad_index)
                     ARMSX2ApplyNativeGamepadRumbleOnMain(native_packed_device);
                 });
             } else {
-                [ARMSX2Bridge triggerDeviceHapticLarge:large small:small];
+                // Unclamped on purpose. 0x7000 is the ceiling the controller motors are
+                // held to, and the tap on the other side divides by the full 16 bit
+                // range, so passing the clamped pair capped this path at 44 percent.
+                [ARMSX2Bridge triggerDeviceHapticLarge:((packed >> 16) & 0xffffu) small:(packed & 0xffffu)];
             }
         }
     }
@@ -1150,6 +1214,28 @@ extern "C" void ARMSX2_iOSTestGamepadRumble(void)
             dispatch_async(dispatch_get_main_queue(), ^{
                 ARMSX2ApplyNativeGamepadRumblePulseOnMain(native_slot, test_packed, "test-no-sdl-gamepad");
             });
+        }
+
+        // The pulse path above wants a real controller and quietly does nothing
+        // without one, so there was no way to feel the phone's own rumble short of
+        // launching a game. Step the heavy motor up, then buzz the small one, so
+        // both channels and the strength slider can be checked from settings.
+        if (!ARMSX2FindNativeHapticController() && ARMSX2DeviceSupportsHaptics()) {
+            static constexpr struct { double delay; float large; float small; } ramp[] = {
+                { 0.00, 0.20f, 0.0f },
+                { 0.30, 0.60f, 0.0f },
+                { 0.60, 1.00f, 0.0f },
+                { 0.95, 0.00f, 1.0f },
+                { 1.25, 0.00f, 0.0f },
+            };
+            for (const auto& step : ramp) {
+                const u32 step_packed = ARMSX2PackGamepadRumble(step.large, step.small);
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, static_cast<int64_t>(step.delay * NSEC_PER_SEC)),
+                    dispatch_get_main_queue(), ^{
+                        ARMSX2ApplyNativeGamepadRumbleOnMain(step_packed);
+                    });
+            }
+            Console.WriteLn("[ARMSX2 iOS Gamepad] Test device rumble ramp queued");
         }
         anyNativeFallback = true;
     }

--- a/platforms/ios/app/src/main/cpp/IOS/GamepadHaptics.mm
+++ b/platforms/ios/app/src/main/cpp/IOS/GamepadHaptics.mm
@@ -20,9 +20,17 @@
 #import "ARMSX2Bridge.h"
 
 #pragma mark - Gamepad state
+// Touched only by the CPU thread, from inside the pump. Anything that used to
+// reach in here from the main queue now works off the caches below instead, so
+// a controller can be closed without a queued block finding freed memory.
 SDL_Gamepad* s_gamepads[ARMSX2_MAX_IOS_GAMEPADS] = {};
 static std::atomic<u32> s_pendingGamepadRumble[ARMSX2_MAX_IOS_GAMEPADS];
-static std::atomic<u32> s_gamepadRumbleStopGeneration[ARMSX2_MAX_IOS_GAMEPADS];
+// SDL_GetTicks value after which the slot gets a stop, or 0 for nothing pending.
+static std::atomic<u64> s_gamepadRumbleStopDeadlineMs[ARMSX2_MAX_IOS_GAMEPADS];
+// Worked out once when the pad is opened, so the name lookup does not have to
+// happen on whichever thread is asking.
+static std::atomic<bool> s_gamepadIsJoyCon[ARMSX2_MAX_IOS_GAMEPADS];
+static std::atomic<bool> s_gamepadRumbleTestRequested{false};
 static u32 s_appliedGamepadRumble[ARMSX2_MAX_IOS_GAMEPADS] = {};
 static bool s_appliedGamepadRumbleValid[ARMSX2_MAX_IOS_GAMEPADS] = {};
 static bool s_loggedGamepadRumbleFailure = false;
@@ -778,39 +786,25 @@ static void ARMSX2StopNativeGamepadRumblePulseOnMain(u32 slot)
 	}
 }
 
+// Only ever the controller sitting in this slot. There used to be a couple of
+// fallbacks here, one for a single connected controller and one that took any
+// controller with haptics, and both of them answered for slots that have no
+// controller at all. That put player 2's rumble in player 1's hands, and it let
+// one Joy-Con make every slot test positive and kill rumble for everybody.
 static GCController* ARMSX2FindNativeHapticControllerForSlot(u32 slot)
 {
 	NSArray<GCController*>* controllers = [GCController controllers];
-	if (slot < controllers.count) {
-		GCController* controller = controllers[slot];
-		if (controller.haptics)
-			return controller;
-	}
+	if (slot >= controllers.count)
+		return nil;
 
-	if (controllers.count == 1) {
-		GCController* controller = controllers.firstObject;
-		if (controller.haptics)
-			return controller;
-	}
-
-	for (GCController* controller in controllers) {
-		if (controller.haptics)
-			return controller;
-	}
-
-	return nil;
+	GCController* controller = controllers[slot];
+	return controller.haptics ? controller : nil;
 }
 
 static GCController* ARMSX2FindNativeControllerForSlot(u32 slot)
 {
 	NSArray<GCController*>* controllers = [GCController controllers];
-	if (slot < controllers.count)
-		return controllers[slot];
-
-	if (controllers.count == 1)
-		return controllers.firstObject;
-
-	return nil;
+	return (slot < controllers.count) ? controllers[slot] : nil;
 }
 
 static bool ARMSX2NativeControllerLooksLikeJoyCon(GCController* controller)
@@ -859,7 +853,9 @@ static bool ARMSX2GamepadSlotLooksLikeJoyCon(u32 slot)
 	if (ARMSX2NativeControllerSlotLooksLikeJoyCon(slot))
 		return true;
 
-	return slot < ARMSX2_MAX_IOS_GAMEPADS && ARMSX2SDLGamepadLooksLikeJoyCon(s_gamepads[slot]);
+	// Cached rather than read off s_gamepads, because this gets asked from the
+	// main queue and the pad it would be naming can be closed at any moment.
+	return slot < ARMSX2_MAX_IOS_GAMEPADS && s_gamepadIsJoyCon[slot].load(std::memory_order_relaxed);
 }
 
 static bool ARMSX2ApplyNativeGamepadRumblePulseOnMain(u32 slot, u32 packed, const char* reason)
@@ -942,15 +938,18 @@ static bool ARMSX2ApplyNativeGamepadRumblePulseOnMain(u32 slot, u32 packed, cons
 
 	const float intensity = std::clamp(raw_intensity, 0.10f, 0.55f);
 	const float sharpness = std::clamp(0.25f + (small * 0.45f), 0.20f, 0.65f);
+	// All four of these were leaking. This file is MRC and a rumbling game comes
+	// through here on every change of value, so it was a steady drip for as long
+	// as a controller was connected.
 	NSArray<CHHapticEventParameter*>* params = @[
-		[[CHHapticEventParameter alloc] initWithParameterID:CHHapticEventParameterIDHapticIntensity value:intensity],
-		[[CHHapticEventParameter alloc] initWithParameterID:CHHapticEventParameterIDHapticSharpness value:sharpness]
+		[[[CHHapticEventParameter alloc] initWithParameterID:CHHapticEventParameterIDHapticIntensity value:intensity] autorelease],
+		[[[CHHapticEventParameter alloc] initWithParameterID:CHHapticEventParameterIDHapticSharpness value:sharpness] autorelease]
 	];
-	CHHapticEvent* event = [[CHHapticEvent alloc] initWithEventType:CHHapticEventTypeHapticContinuous
-	                                                     parameters:params
-	                                                   relativeTime:0.0
-	                                                        duration:0.18];
-	CHHapticPattern* pattern = [[CHHapticPattern alloc] initWithEvents:@[event] parameters:@[] error:&error];
+	CHHapticEvent* event = [[[CHHapticEvent alloc] initWithEventType:CHHapticEventTypeHapticContinuous
+	                                                      parameters:params
+	                                                    relativeTime:0.0
+	                                                         duration:0.18] autorelease];
+	CHHapticPattern* pattern = [[[CHHapticPattern alloc] initWithEvents:@[event] parameters:@[] error:&error] autorelease];
 	if (!pattern) {
 		Console.WriteLn("[ARMSX2 iOS Gamepad] Native haptic pulse pattern failed slot=%u: %s",
 			slot + 1, error.localizedDescription.UTF8String ?: "unknown");
@@ -1027,6 +1026,23 @@ void ARMSX2ApplyPendingGamepadRumble(unsigned int gamepad_index)
 	if (gamepad_index >= ARMSX2_MAX_IOS_GAMEPADS)
 		return;
 
+    // Ahead of the unchanged-value bail below, so a held rumble still gets its
+    // stop. This used to be a dispatch_after onto the main queue holding an
+    // SDL_Gamepad pointer for 300 ms, which is a long time to hope nobody
+    // unplugs anything. The pump runs every frame, so a deadline covers it.
+    const u64 stop_deadline = s_gamepadRumbleStopDeadlineMs[gamepad_index].load(std::memory_order_relaxed);
+    if (stop_deadline != 0 && SDL_GetTicks() >= stop_deadline) {
+        s_gamepadRumbleStopDeadlineMs[gamepad_index].store(0, std::memory_order_relaxed);
+        if (s_gamepads[gamepad_index]) {
+            SDL_RumbleGamepad(s_gamepads[gamepad_index], 0, 0, 0);
+            SDL_RumbleGamepadTriggers(s_gamepads[gamepad_index], 0, 0, 0);
+        }
+        if (!s_loggedSDLGamepadRumbleForceStop) {
+            Console.WriteLn("[ARMSX2 iOS Gamepad] SDL controller rumble force-stopped");
+            s_loggedSDLGamepadRumbleForceStop = true;
+        }
+    }
+
     const u32 packed = s_pendingGamepadRumble[gamepad_index].load(std::memory_order_relaxed);
     if (s_appliedGamepadRumbleValid[gamepad_index] && packed == s_appliedGamepadRumble[gamepad_index])
         return;
@@ -1034,9 +1050,11 @@ void ARMSX2ApplyPendingGamepadRumble(unsigned int gamepad_index)
     const u16 large = std::min<u16>(static_cast<u16>((packed >> 16) & 0xffffu), ARMSX2_GAMEPAD_RUMBLE_MAX_INTENSITY);
     const u16 small = std::min<u16>(static_cast<u16>(packed & 0xffffu), ARMSX2_GAMEPAD_RUMBLE_MAX_INTENSITY);
     const bool wants_rumble = (large != 0 || small != 0);
-    const u32 stop_generation = s_gamepadRumbleStopGeneration[gamepad_index].fetch_add(1, std::memory_order_relaxed) + 1;
 
     if (!wants_rumble) {
+        // The zero goes out through the normal path below, so the deadline has
+        // nothing left to catch.
+        s_gamepadRumbleStopDeadlineMs[gamepad_index].store(0, std::memory_order_relaxed);
         const u32 slot = gamepad_index;
         const u32 native_packed_stop = packed;
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -1081,22 +1099,13 @@ void ARMSX2ApplyPendingGamepadRumble(unsigned int gamepad_index)
                 });
             }
             if (wants_rumble) {
-                const u32 slot = gamepad_index;
-                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, static_cast<int64_t>(ARMSX2_GAMEPAD_RUMBLE_FORCE_STOP_SECONDS * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                    if (slot >= ARMSX2_MAX_IOS_GAMEPADS ||
-                        s_gamepadRumbleStopGeneration[slot].load(std::memory_order_relaxed) != stop_generation)
-                        return;
-
-                    if (s_gamepads[slot]) {
-                        SDL_RumbleGamepad(s_gamepads[slot], 0, 0, 0);
-                        SDL_RumbleGamepadTriggers(s_gamepads[slot], 0, 0, 0);
-                    }
-                    ARMSX2StopNativeGamepadRumblePulseOnMain(slot);
-                    if (!s_loggedSDLGamepadRumbleForceStop) {
-                        Console.WriteLn("[ARMSX2 iOS Gamepad] SDL controller rumble force-stopped");
-                        s_loggedSDLGamepadRumbleForceStop = true;
-                    }
-                });
+                // Each new value pushes the deadline out, so a game holding a
+                // rumble keeps it and a game that goes quiet gets stopped. The
+                // CoreHaptics pulse that used to be torn down alongside this
+                // already schedules its own guarded stop, so it is left to it.
+                s_gamepadRumbleStopDeadlineMs[gamepad_index].store(
+                    SDL_GetTicks() + static_cast<u64>(ARMSX2_GAMEPAD_RUMBLE_FORCE_STOP_SECONDS * 1000.0),
+                    std::memory_order_relaxed);
             }
         } else {
             if (!s_loggedGamepadRumbleFailure) {
@@ -1140,7 +1149,7 @@ void ARMSX2ApplyPendingGamepadRumble(unsigned int gamepad_index)
     s_appliedGamepadRumbleValid[gamepad_index] = true;
 }
 
-extern "C" void ARMSX2_iOSTestGamepadRumble(void)
+static void ARMSX2ServiceGamepadRumbleTest()
 {
     Console.WriteLn("[ARMSX2 iOS Gamepad] Test controller rumble requested");
 
@@ -1164,6 +1173,8 @@ extern "C" void ARMSX2_iOSTestGamepadRumble(void)
             for (u32 slot = 0; slot < ARMSX2_MAX_IOS_GAMEPADS; slot++) {
                 if (!s_gamepads[slot]) {
                     s_gamepads[slot] = SDL_OpenGamepad(ids[id_index]);
+                    if (s_gamepads[slot])
+                        s_gamepadIsJoyCon[slot].store(ARMSX2SDLGamepadLooksLikeJoyCon(s_gamepads[slot]), std::memory_order_relaxed);
                     Console.WriteLn("[ARMSX2 iOS Gamepad] Test SDL open slot=%u id=%d result=%s",
                         slot + 1, ids[id_index],
                         s_gamepads[slot] ? (SDL_GetGamepadName(s_gamepads[slot]) ?: "unknown") : SDL_GetError());
@@ -1248,18 +1259,38 @@ extern "C" void ARMSX2_iOSTestGamepadRumble(void)
 
     Console.WriteLn("[ARMSX2 iOS Gamepad] Native CoreHaptics pulse fallback %s", anyNativeFallback ? "queued when needed" : "not queued");
 
+    // The SDL half of the stop rides the same deadline the pump already checks,
+    // so nothing off this thread ends up holding a gamepad pointer. The
+    // CoreHaptics half has to be on main, and touches no SDL.
+    const u64 deadline = SDL_GetTicks() + 300;
+    for (u32 slot = 0; slot < ARMSX2_MAX_IOS_GAMEPADS; slot++)
+        s_gamepadRumbleStopDeadlineMs[slot].store(deadline, std::memory_order_relaxed);
+
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, static_cast<int64_t>(0.30 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        for (u32 slot = 0; slot < ARMSX2_MAX_IOS_GAMEPADS; slot++) {
-            if (s_gamepads[slot]) {
-                SDL_RumbleGamepad(s_gamepads[slot], 0, 0, 0);
-                SDL_RumbleGamepadTriggers(s_gamepads[slot], 0, 0, 0);
-            }
+        for (u32 slot = 0; slot < ARMSX2_MAX_IOS_GAMEPADS; slot++)
             ARMSX2StopNativeGamepadRumblePulseOnMain(slot);
-            s_pendingGamepadRumble[slot].store(0, std::memory_order_relaxed);
-            s_appliedGamepadRumble[slot] = 0;
-            s_appliedGamepadRumbleValid[slot] = false;
-        }
         Console.WriteLn("[ARMSX2 iOS Gamepad] Test controller rumble stopped");
+    });
+}
+
+extern "C" void ARMSX2_iOSTestGamepadRumble(void)
+{
+    // Called from SwiftUI, so this is the main thread. The pump owns s_gamepads
+    // and will happily close a pad while we are opening one, so hand the work
+    // over when it is running. With no VM there is no pump and nothing to race,
+    // and waiting for one that will never come would just break the button.
+    if (!s_vmThreadActive.load(std::memory_order_relaxed)) {
+        ARMSX2ServiceGamepadRumbleTest();
+        return;
+    }
+
+    s_gamepadRumbleTestRequested.store(true, std::memory_order_relaxed);
+    // A paused VM may not be pumping, and settings is reachable from the pause
+    // menu, so do not let the button quietly do nothing. If the flag is still
+    // sitting there a moment later, nobody is coming for it.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, static_cast<int64_t>(0.25 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        if (s_gamepadRumbleTestRequested.exchange(false, std::memory_order_relaxed))
+            ARMSX2ServiceGamepadRumbleTest();
     });
 }
 
@@ -1270,6 +1301,9 @@ void ARMSX2RefreshIOSGamepads()
     SDL_UpdateGamepads();
     ARMSX2PollNativeGamepadDpadMasks("sdl-refresh");
 
+    if (s_gamepadRumbleTestRequested.exchange(false, std::memory_order_relaxed))
+        ARMSX2ServiceGamepadRumbleTest();
+
     for (u32 slot = 0; slot < ARMSX2_MAX_IOS_GAMEPADS; slot++) {
         SDL_Gamepad* gamepad = s_gamepads[slot];
         if (!gamepad)
@@ -1278,7 +1312,8 @@ void ARMSX2RefreshIOSGamepads()
         if (!SDL_GamepadConnected(gamepad)) {
             Console.WriteLn("[Files] MFi gamepad %u disconnected", slot + 1);
             s_pendingGamepadRumble[slot].store(0, std::memory_order_relaxed);
-            s_gamepadRumbleStopGeneration[slot].fetch_add(1, std::memory_order_relaxed);
+            s_gamepadRumbleStopDeadlineMs[slot].store(0, std::memory_order_relaxed);
+            s_gamepadIsJoyCon[slot].store(false, std::memory_order_relaxed);
             s_appliedGamepadRumble[slot] = 0;
             s_appliedGamepadRumbleValid[slot] = false;
             s_nativeGamepadDpadMask[slot].store(0, std::memory_order_relaxed);
@@ -1321,6 +1356,7 @@ void ARMSX2RefreshIOSGamepads()
 
             s_gamepads[slot] = SDL_OpenGamepad(ids[id_index]);
             if (s_gamepads[slot]) {
+                s_gamepadIsJoyCon[slot].store(ARMSX2SDLGamepadLooksLikeJoyCon(s_gamepads[slot]), std::memory_order_relaxed);
                 dispatch_async(dispatch_get_main_queue(), ^{
                     ARMSX2RefreshNativeGamepadDpadHandlersOnMain("sdl-open");
                 });

--- a/platforms/ios/app/src/main/cpp/cmake/BuildParameters.cmake
+++ b/platforms/ios/app/src/main/cpp/cmake/BuildParameters.cmake
@@ -129,9 +129,17 @@ if("${_PCSX2_TARGET_PROCESSOR}" STREQUAL "x86_64" OR "${_PCSX2_TARGET_PROCESSOR}
 elseif("${_PCSX2_TARGET_PROCESSOR}" STREQUAL "arm64" OR "${_PCSX2_TARGET_PROCESSOR}" STREQUAL "aarch64" OR
        "${CMAKE_OSX_ARCHITECTURES}" STREQUAL "arm64")
 	set(ARCH_ARM64 TRUE)
-	if(APPLE)
+	if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+		message(STATUS "Building for iOS (ARM64, A12 baseline).")
+		# They do not share it. The oldest phone that can install at our deployment
+		# target is an A12, which has no SHA3, and an M1 baseline lets clang fold
+		# XOR chains in the hash and CRC loops into eor3. An A12 then SIGILLs on
+		# the first one it reaches, which the game list scan hits on launch.
+		# -mcpu implies its own architecture, so there is no -march to disagree.
+		add_compile_options("-mcpu=apple-a12")
+	elseif(APPLE)
 		message(STATUS "Building for Apple Silicon (ARM64).")
-		# Min spec is an M1. iOS devices and Apple Silicon Macs (Catalyst) share this.
+		# Min spec is an M1.
 		add_compile_options("-march=armv8.4-a" "-mcpu=apple-m1")
 	elseif(ANDROID)
 		message(STATUS "Building for Android (ARM64).")

--- a/platforms/ios/app/src/main/swift/Models/GameEventHaptics.swift
+++ b/platforms/ios/app/src/main/swift/Models/GameEventHaptics.swift
@@ -26,7 +26,12 @@ final class GameEventHaptics {
         guard now.timeIntervalSince(lastFire) > 0.05 else { return }
         lastFire = now
 
-        let intensity = max(Float(large), Float(small)) / Float(UInt16.max)
+        // The heavy motor is the only one with a speed. The PS2 buzzer is on or off,
+        // so taking the larger of the two used to pin this to full every time a game
+        // so much as touched it.
+        let intensity = large > 0
+            ? Float(large) / Float(UInt16.max)
+            : 0.55
         // Heavy motor (large) dominates; fall back to medium for small-only rumble.
         let generator: UIImpactFeedbackGenerator
         if large > 0 {


### PR DESCRIPTION
## What changed

* Fixed a crash that made the app unusable on iPhone XS, XS Max and XR, iPad Air 3, iPad mini 5, iPad 8, and the A12X and A12Z iPad Pros. It died within a second of launch, and has done in every release so far.
* Phone rumble varies with the game again. Light rumble feels light and heavy feels heavy, instead of everything buzzing at one flat strength.
* The two PS2 motors are played separately, so you get a deep thump from the heavy motor and a sharper buzz from the small one rather than a single flat vibration.
* Test Rumble does something with no controller connected. It runs through three strengths and a buzz, so Phone Rumble Strength can be set without loading a game.
* Fixed a memory leak that ran the whole time a controller was connected and rumbling.
* Closed a case where unplugging a controller mid rumble, or pressing Test Rumble while a game was running, could crash.
* One connected Joy Con no longer switches rumble off for everybody, and player 2's rumble no longer comes out in player 1's controller.

## The launch crash

A crash report from an iPhone XS on 2.5.0 showed SIGILL less than a second after launch, in `ElfObject::GetCRC` during the game list scan. The exception code carries the offending instruction, `0xce000c40`, and that decodes as `eor3`, an ARMv8.2 SHA3 instruction. An A12 has no SHA3.

The iOS build was asking clang for an M1 CPU target, under a comment claiming iOS devices and Apple Silicon Macs share a minimum spec. They do not. The oldest phone that can install at our deployment target is an iPhone XS, and an M1 baseline lets clang fold the XOR chains in the hash and CRC loops into `eor3` and `bcax`.

It is not one unlucky function. The shipped 2.5.0 binary has 36 `eor3` and 16 `bcax` spread across twelve of them, including `LoadBIOS`, `mVUcomputeProgramHash`, the memory card CRC and save paths, and the XXH3 hashing the texture cache leans on. An A12 reaches one of those almost immediately whatever it does.

iOS now builds against an A12 CPU target, the oldest device we accept. macOS and Catalyst keep the M1 baseline, which is right for them. Choosing the oldest supported device rather than switching off the one offending instruction means a future compiler that fancies some other newer feature gets refused at compile time instead of turning into another crash report.

## The rumble intensity work

A tester reported the phone rumble sustaining correctly but playing at one flat strength. Four things were stacked up behind that: the two motors were combined with `max()` even though the small one has no speed control and arrives as a flat 1.0, the intensity sent live multiplies the pattern's own rather than replacing it so the first value of a burst became its ceiling, sharpness was applied twice because its live control is an offset rather than a replacement, and the frequency mapping sat the binary buzzer on the taptic engine's peak while the analog motor played where it can barely be felt. Each motor now drives its own channel.

## The haptics audit

Reading the whole of `GamepadHaptics.mm` after a run of bugs kept coming out of it. Four objects were leaking per rumble event in the controller path. The SDL gamepad array was in use from two threads, with the pump closing pads on the CPU thread while main queue blocks held pointers into it and the Test Rumble button opened gamepads straight into it from the main thread. That array is now only touched by the pump.

## Testing

Builds clean, and an `otool` scan confirms the count of `eor3`, `bcax`, `xar`, `rax1`, `sha512`, `sm3` and `sm4` in the binary goes from 52 to zero.

The rest needs a real device and a real controller and is not verified on hardware yet. The launch crash fix wants confirming by whoever filed the report, since they have the iPhone XS.
