### PR TITLE
iOS: read JIT activity under the validation lock

### DIFF
--- a/common/Darwin/DarwinMisc.cpp
+++ b/common/Darwin/DarwinMisc.cpp
@@ -779,19 +779,24 @@ bool DarwinMisc::ValidateJITAlive()
 		return false;
 	}
 
-	// Check activity before inspecting mapping state. The platform drains any
-	// canary which passed this check before allowing JIT execution to resume.
+	// A canceled dispatch timer may already be inside its event handler.
+	// Hold the same lock used by MunmapCodeDualMap so the code page remains
+	// mapped until this validation completes.
+	std::lock_guard<std::mutex> validation_lock(s_jit_validation_mutex);
+
+	// Read activity under the lock rather than before taking it.
+	// WaitForJITValidation only drains a handler that already holds the lock, so
+	// a check out here leaves a gap where the VM goes active between the check
+	// and the acquire, and the canary below then flips protection on a page the
+	// EE thread is running out of. Inside the lock there are only two orderings
+	// and both are safe: finish before the drain returns, or take the lock after
+	// it and see the VM is busy.
 	if (s_jit_activity_query && s_jit_activity_query())
 	{
 		std::fprintf(stderr, "@@JIT_KEEPALIVE@@ alive=1 cs_debugged=1 canary=skipped-vm-active\n");
 		std::fflush(stderr);
 		return true;
 	}
-
-	// A canceled dispatch timer may already be inside its event handler.
-	// Hold the same lock used by MunmapCodeDualMap so the code page remains
-	// mapped until this validation completes.
-	std::lock_guard<std::mutex> validation_lock(s_jit_validation_mutex);
 
 	// Check 2: JIT code memory still writable? Write a canary, read it back.
 	// Interpreter sessions have no code mapping and never start the idle timer;


### PR DESCRIPTION
## What changed

* Closed a small race in the JIT keepalive check that could in principle crash the emulator at the moment a game starts.

## Detail

The hybrid JIT safety change added a lock so the idle keepalive canary cannot run while code memory is being unmapped. That is the important half and it works. The activity check that decides whether to skip the canary sits outside that lock though, and that leaves a smaller gap behind.

WaitForJITValidation drains by taking the mutex and dropping it again, so it only ever waits for a handler that has already acquired the lock. A handler that passed the activity check but has not reached the acquire yet is invisible to it. The boot path sets the VM active, cancels the timer and drains, all of which that handler misses, and then it carries on and flips protection across the whole code arena while the EE thread is executing out of it. The comment above ARMSX2JITWorkerBusy already calls that an instant instruction abort, and it is the same shape as the Devil May Cry crash.

Reading activity inside the lock leaves only two possible orderings and both are fine. Either the handler gets there first and the drain waits for it to restore the canary byte, or it gets there second, sees the VM is busy, and returns without touching anything.

## Testing

Builds clean on current master, and the binary scan for post A12 instructions still comes back at zero.

The window is a few instructions against a twelve second timer, so this was never reproducible on demand and the fix is not observable at runtime either. The change is a reordering of two existing blocks with no behaviour difference in any case where the race does not occur.
