### PR TITLE
iOS: Preserve Aspect Ratio When Applying Device Presets

### DIFF
--- a/platforms/ios/app/src/main/swift/Models/SettingsPresetCatalog.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsPresetCatalog.swift
@@ -33,9 +33,9 @@ enum BuiltInSettingsPreset: String, CaseIterable, Identifiable {
     var detail: String {
         switch self {
         case .defaultPreset:
-            return "Default disables Fast Boot, PNACH Cheats, Widescreen Patches, Fast CDVD, FXAA, CAS Sharpening, OPH Flag Hack, Emulation-Only Mode, and the background in Settings; restores Internal Resolution to 1x Native, Aspect Ratio to Auto, and Queue Size to 8; and selects the White Colored Virtual Pad skin."
+            return "Default disables Fast Boot, PNACH Cheats, Widescreen Patches, Fast CDVD, FXAA, CAS Sharpening, OPH Flag Hack, Emulation-Only Mode, and the background in Settings; restores Internal Resolution to 1x Native and Queue Size to 8; and selects the White Colored Virtual Pad skin."
         case .ultraQuality:
-            return "Ultra Quality enables Fast Boot, PNACH Cheats, Widescreen Patches, Fast CDVD, FXAA, CAS Sharpening, and the background in Settings; sets Internal Resolution to 2x (1024x896), Aspect Ratio to Stretch to Window, and Queue Size to 2. OPH Flag Hack and Emulation-Only Mode are disabled. The selected Virtual Pad skin is preserved."
+            return "Ultra Quality enables Fast Boot, PNACH Cheats, Widescreen Patches, Fast CDVD, FXAA, CAS Sharpening, and the background in Settings; sets Internal Resolution to 2x (1024x896) and Queue Size to 2. OPH Flag Hack and Emulation-Only Mode are disabled. The selected Virtual Pad skin is preserved."
         case .highQuality:
             return "High Quality uses the Ultra Quality settings, including the background in Settings, with Internal Resolution set to 1x Native (512x448). The selected Virtual Pad skin is preserved."
         case .highQuality30FPS:
@@ -63,7 +63,6 @@ enum BuiltInSettingsPreset: String, CaseIterable, Identifiable {
             settings.fastCDVD == configuration.fastCDVD &&
             settings.fxaa == configuration.fxaa &&
             (settings.casMode > 0) == configuration.casSharpening &&
-            settings.aspectRatio == configuration.aspectRatio &&
             settings.vsyncQueueSize == configuration.vsyncQueueSize &&
             settings.upscaleMultiplier == configuration.upscaleMultiplier &&
             settings.gameFixEnabled("OPHFlagHack") == configuration.ophFlagHack &&
@@ -87,7 +86,6 @@ enum BuiltInSettingsPreset: String, CaseIterable, Identifiable {
         settings.fastCDVD = configuration.fastCDVD
         settings.fxaa = configuration.fxaa
         settings.casMode = configuration.casSharpening ? 1 : 0
-        settings.aspectRatio = configuration.aspectRatio
         settings.vsyncQueueSize = configuration.vsyncQueueSize
         settings.upscaleMultiplier = configuration.upscaleMultiplier
         settings.setGameFix("OPHFlagHack", configuration.ophFlagHack)
@@ -109,7 +107,6 @@ enum BuiltInSettingsPreset: String, CaseIterable, Identifiable {
                 fastCDVD: false,
                 fxaa: false,
                 casSharpening: false,
-                aspectRatio: 1,
                 vsyncQueueSize: 8,
                 upscaleMultiplier: 1,
                 ophFlagHack: false,
@@ -154,7 +151,6 @@ enum BuiltInSettingsPreset: String, CaseIterable, Identifiable {
             fastCDVD: true,
             fxaa: true,
             casSharpening: true,
-            aspectRatio: 0,
             vsyncQueueSize: 2,
             upscaleMultiplier: upscaleMultiplier,
             ophFlagHack: false,
@@ -169,7 +165,6 @@ enum BuiltInSettingsPreset: String, CaseIterable, Identifiable {
         var fastCDVD: Bool
         var fxaa: Bool
         var casSharpening: Bool
-        var aspectRatio: Int
         var vsyncQueueSize: Int
         var upscaleMultiplier: Float
         var ophFlagHack: Bool


### PR DESCRIPTION
# iOS: Preserve Aspect Ratio When Applying Device Presets

## Summary

This pull request removes Aspect Ratio from the built-in Device Presets under:

```text
Settings > Settings Presets > Device Presets
```

Applying Default, Ultra Quality, High Quality, High Quality 30 FPS, Performance, or Ultra Performance now preserves the Aspect Ratio already selected by the user.

## Problem

The built-in quality and performance presets previously treated Aspect Ratio as part of their managed configuration:

- Default changed Aspect Ratio to Auto.
- The quality and performance presets changed Aspect Ratio to Stretch to Window.

Aspect Ratio is a display preference rather than a performance tier. Applying a graphics or emulation preset could therefore unexpectedly stretch or reshape the image, even when the user wanted to keep a native, automatic, 4:3, 16:9, or custom display choice.

Aspect Ratio was also included in the preset-active comparison. If a user changed only Aspect Ratio after applying a Device Preset, the preset would stop displaying as active even though every setting that the preset should manage still matched.

## Changes

### Device Preset application

Removed the assignment that wrote the built-in preset configuration into:

```swift
settings.aspectRatio
```

Applying any built-in Device Preset now leaves the current Aspect Ratio unchanged.

### Active-preset detection

Removed Aspect Ratio from `BuiltInSettingsPreset.isActive` matching.

The selected indicator now reflects only the settings actually managed by Device Presets. A user can change Aspect Ratio independently without making an otherwise matching Device Preset appear inactive.

### Preset configuration model

Removed the unused `aspectRatio` field and its preset-specific values from the private built-in `Configuration` structure.

This prevents Aspect Ratio from being accidentally restored to Device Preset application in a later refactor and keeps the configuration model aligned with actual behavior.

### User-facing descriptions

Updated the detailed descriptions for Default and Ultra Quality:

- Default no longer states that it restores Aspect Ratio to Auto.
- Ultra Quality no longer states that it changes Aspect Ratio to Stretch to Window.

The Device Presets footer can therefore continue to state that presets change only the listed settings.

## Preserved behavior

This change is intentionally limited to the built-in Device Presets.

The following behavior is unchanged:

- Manual Aspect Ratio selection in Graphics settings.
- Per-game Aspect Ratio overrides.
- Exporting Aspect Ratio in user-created `.ini` preset files.
- Importing Aspect Ratio from user-created `.ini` preset files.
- Internal Resolution settings in all Device Presets.
- FXAA and CAS Sharpening settings.
- Queue Size settings.
- Fast Boot, PNACH, widescreen patch, Fast CDVD, OPH Flag Hack, and Emulation-Only Mode settings.
- Background visibility and Virtual Pad skin behavior.

## Result by preset

| Device Preset | Previous Aspect Ratio behavior | New behavior | | --- | --- | --- |
| Default | Forced Auto | Preserves current value | | Ultra Quality | Forced Stretch to Window | Preserves current value | | High Quality | Inherited Stretch to Window | Preserves current value | | High Quality 30 FPS | Inherited Stretch to Window | Preserves current value | | Performance | Inherited Stretch to Window | Preserves current value | | Ultra Performance | Inherited Stretch to Window | Preserves current value |

## Performance impact

There is no runtime emulation performance cost. Preset application performs one fewer setting assignment and active-preset detection performs one fewer comparison.

The change does not affect the renderer, emulation threads, game boot, frame pacing, or gameplay resource usage.

## Changed file

- `platforms/ios/app/src/main/swift/Models/SettingsPresetCatalog.swift`

## Integration

The worktree was rebased onto the latest `origin/master` before this change was applied.

Base revision:

```text
daed4ed4a7842a9d5804520014dfea23fe8a1d3a
```

## Validation

- Confirmed that `SettingsPresetCatalog.swift` no longer references Aspect Ratio.
- Confirmed that custom preset import/export support remains present in `SettingsPresetFile.swift`.
- `git diff --check` passed for the changed preset catalog.
- Full unsigned iOS IPA build completed successfully with `build-ios-ipa.sh`.

### Did you use AI to help find, test, or implement this issue or feature?
Yes, to generate this PR.md.