### PR TITLE
vtlb: bound the page protection table indexes

### DIFF
--- a/pcsx2/vtlb.cpp
+++ b/pcsx2/vtlb.cpp
@@ -1556,8 +1556,19 @@ void mmap_MarkCountedRamPage(u32 paddr)
 
 	paddr &= ~__pagemask;
 
+	// Same story as the fault handler: anything PSM resolves outside main RAM is
+	// ROM or VU memory, which is never under EE write protection, so there is
+	// nothing here to mark. Bounded the way mmap_GetRamPageInfo already does it.
+	// The old int also went negative for a pointer below Main and indexed
+	// backwards out of the array. No caller reaches either case today, they all
+	// come through mmap_GetRamPageInfo first, but it is a nasty thing to leave
+	// lying around for the next one.
 	uptr ptr = (uptr)PSM(paddr);
-	int rampage = (ptr - (uptr)eeMem->Main) >> __pageshift;
+	uptr rampage = ptr - (uptr)eeMem->Main;
+	if (!ptr || rampage >= Ps2MemSize::ExposedRam)
+		return;
+
+	rampage >>= __pageshift;
 
 	// Important: Update the ReverseRamMap here because TLB changes could alter the paddr
 	// mapping into eeMem->Main.
@@ -1574,7 +1585,8 @@ void mmap_MarkCountedRamPage(u32 paddr)
 
 	m_PageProtectInfo[rampage].Mode = ProtMode_Write;
 	HostSys::MemProtect(&eeMem->Main[rampage << __pageshift], __pagesize, PageAccess_ReadOnly());
-	vtlb_UpdateFastmemProtection(rampage << __pageshift, __pagesize, PageAccess_ReadOnly());
+	// Narrowing is safe, the bound above keeps this under ExposedRam.
+	vtlb_UpdateFastmemProtection(static_cast<u32>(rampage << __pageshift), __pagesize, PageAccess_ReadOnly());
 }
 
 // offset - offset of address relative to psM.
@@ -1607,9 +1619,16 @@ PageFaultHandler::HandlerResult PageFaultHandler::HandlePageFault(void* exceptio
 		// this was inside the fastmem area. check if it's a code page
 		// fprintf(stderr, "Fault on fastmem %p vaddr %08X\n", info.addr, vaddr);
 
+		// PSM resolves the whole physical map, not just main RAM, so a fault on
+		// VU memory or ROM arrives here with an offset way past the end of the
+		// table. Reading it is out of bounds, and if the aliased value happens to
+		// match ProtMode_Write we walk into mmap_ClearCpuBlock and write a
+		// ProtMode over whatever follows the array. The branch below has always
+		// had this check; this one never did.
 		uptr ptr = (uptr)PSM(vaddr);
 		uptr offset = (ptr - (uptr)eeMem->Main);
-		if (ptr && m_PageProtectInfo[offset >> __pageshift].Mode == ProtMode_Write)
+		if (ptr && offset < Ps2MemSize::ExposedRam &&
+			m_PageProtectInfo[offset >> __pageshift].Mode == ProtMode_Write)
 		{
 			// fprintf(stderr, "Not backpatching code write at %08X\n", vaddr);
 			mmap_ClearCpuBlock(offset);


### PR DESCRIPTION
## What changed

* Fixed memory corruption that could crash the emulator with no warning and nothing in the log. It was found through a Namco Museum 50th Anniversary crash on an M2 iPad, but it is not specific to that game and it is not specific to iOS.

## What was happening

A tester reported Namco Museum crashing when starting one of the arcade titles from the museum menu, after half a minute of clean play at full speed. He described it as a software renderer crash. It was not: both software rasterizer workers were parked, and the faulting thread was the CPU thread in recompiled EE code.

The store that died was a softmem write through a page table entry whose high word had gone from 1 to 2. `ProtMode_Manual` is 2, it is a `u32`, and it sits at offset four of an eight byte record. Something had written a protection mode over the top half of a `vtlbdata.pmap` pointer.

It comes from the fastmem branch of `PageFaultHandler::HandlePageFault`. `PSM` is `vtlb_GetPhyPtr`, which resolves the whole physical map rather than just main RAM, so a fault on VU memory arrives there with an offset far past the end of `m_PageProtectInfo`, a fixed 8192 entry table. Nothing bounded it. The read alone is out of bounds, and when the aliased value happens to equal `ProtMode_Write` the handler carries on into `mmap_ClearCpuBlock` and performs the write.

The branch twenty lines below it has always had that bound check. This one never did. Now it does the same thing.

Nothing real is suppressed by the check. Anything `PSM` resolves outside main RAM is ROM or VU memory, and neither is ever under EE self modifying code write protection, so the correct handling for those faults is the else branch that was already there, which hands them to the backpatcher.

`mmap_MarkCountedRamPage` had the same unbounded index with a signed `int` on top of it, which went negative and indexed backwards whenever the pointer landed below `Main`. Bounded the same way `mmap_GetRamPageInfo` already does it. No caller reaches either case today because they all filter through `mmap_GetRamPageInfo` first, so that half closes a trap rather than fixing live breakage. Clang had been warning about that conversion the whole time; the warning goes away with the fix.

## Why it survived this long

Several things had to line up at once. 16 KB pages mean VU0 memory can never be folded into fastmem, so it faults on every touch. The arena base makes the aliased half read as exactly `ProtMode_Write`, so the guard passes because of what it is corrupting. And the game has to touch VU0 memory from the EE and then reprogram the TLB to spread the poisoned entry around. It writes once and stops, so it leaves nothing behind in the log.

## About 2.5.1 specifically

The bad index is long standing and inherited from upstream. What changed recently is where the stray write lands.

Comparing the two shipped binaries with `nm`:

* 2.5.1 puts `vtlbdata` 32 bytes past the end of `m_PageProtectInfo`, both in the same section.
* 2.5.0 puts them 50.7 MB apart, in different sections.

So the write exists in both, but only in 2.5.1 does it land on the page map. Enabling link time optimisation for the core moved `vtlb.cpp` into a separate library and repacked the layout. This does not mean 2.5.0 is safe, only that it corrupts something else.

## Testing

Builds clean, and the fix removes one of the three existing compiler warnings in this file without adding any.

Not yet confirmed on hardware. The fix is provable by reading the code and cannot suppress a fault that mattered, but a tester with Namco Museum is what actually closes this out. Worth a sanity pass on a couple of ordinary titles too, since self modifying code protection is exactly what this path exists for.

## Worth following up separately

* There is a second unbounded route via BIOS ROM that would land in `vtlbdata.RWFT`, which holds handler function pointers rather than data. The recompiler path into it is guarded, so it is not obviously reachable, but it is worth cross checking against other unexplained crashes before dismissing it.
* This is upstream PCSX2 code, not something this fork introduced, so it is worth reporting there. Any host with 16 KB pages can reach it.
