### PR TITLE
iOS: stop per-game settings closing the running game's disc, and reload once per save

### DIFF
--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
@@ -62,6 +62,7 @@ extern "C" void ARMSX2_iOSCopyDeviceStats(int* outBatteryPercent, int* outTherma
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cctype>
 #include <cmath>
 #include <cstdio>
@@ -3973,6 +3974,30 @@ extern "C" void ARMSX2_CaptureGraphicsHackState(void)
     return si.GetBoolValue(section.UTF8String, key.UTF8String, def);
 }
 
+// The per-game panel writes every field it owns when you press Save, and each write
+// used to queue a reload of its own. One tap came out the other side as seventy-odd
+// full config reloads, each re-reading the INI, re-running GameDB and rebuilding the
+// GS config. Let the last write in a burst be the one that reloads.
+static void ARMSX2RequestPerGameSettingsReload()
+{
+    static std::atomic<uint64_t> s_generation{0};
+    const uint64_t mine = s_generation.fetch_add(1, std::memory_order_relaxed) + 1;
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, static_cast<int64_t>(0.05 * NSEC_PER_SEC)),
+        dispatch_get_main_queue(), ^{
+            // Someone wrote after us, so they own the reload.
+            if (s_generation.load(std::memory_order_relaxed) != mine)
+                return;
+
+            // EmuConfig and the MTGS ring are the CPU thread's; this runs on the UI thread.
+            Host::RunOnCPUThread([]() {
+                VMManager::ReloadGameSettings();
+                if (MTGS::IsOpen())
+                    MTGS::ApplySettings();
+            });
+        });
+}
+
 + (void)setPerGameINIInt:(nonnull NSString *)section key:(nonnull NSString *)key value:(int)value forISO:(nonnull NSString *)isoName {
     std::string serial;
     u32 crc = 0;
@@ -4054,12 +4079,7 @@ extern "C" void ARMSX2_CaptureGraphicsHackState(void)
     si.SetIntValue(section.UTF8String, key.UTF8String, value);
     Error error;
     si.Save(&error);
-    // EmuConfig and the MTGS ring are the CPU thread's; this runs on the UI thread.
-    Host::RunOnCPUThread([]() {
-        VMManager::ReloadGameSettings();
-        if (MTGS::IsOpen())
-            MTGS::ApplySettings();
-    });
+    ARMSX2RequestPerGameSettingsReload();
 }
 
 + (void)setPerGameINIBoolForCurrentGame:(nonnull NSString *)section key:(nonnull NSString *)key value:(BOOL)value {
@@ -4072,12 +4092,7 @@ extern "C" void ARMSX2_CaptureGraphicsHackState(void)
     si.SetBoolValue(section.UTF8String, key.UTF8String, value);
     Error error;
     si.Save(&error);
-    // EmuConfig and the MTGS ring are the CPU thread's; this runs on the UI thread.
-    Host::RunOnCPUThread([]() {
-        VMManager::ReloadGameSettings();
-        if (MTGS::IsOpen())
-            MTGS::ApplySettings();
-    });
+    ARMSX2RequestPerGameSettingsReload();
 }
 
 + (float)getPerGameINIFloat:(nonnull NSString *)section key:(nonnull NSString *)key defaultValue:(float)def forISO:(nonnull NSString *)isoName {
@@ -4124,12 +4139,7 @@ extern "C" void ARMSX2_CaptureGraphicsHackState(void)
     si.SetFloatValue(section.UTF8String, key.UTF8String, value);
     Error error;
     si.Save(&error);
-    // EmuConfig and the MTGS ring are the CPU thread's; this runs on the UI thread.
-    Host::RunOnCPUThread([]() {
-        VMManager::ReloadGameSettings();
-        if (MTGS::IsOpen())
-            MTGS::ApplySettings();
-    });
+    ARMSX2RequestPerGameSettingsReload();
 }
 
 + (void)deletePerGameINIValueForCurrentGame:(nonnull NSString *)section key:(nonnull NSString *)key {
@@ -4144,12 +4154,7 @@ extern "C" void ARMSX2_CaptureGraphicsHackState(void)
     si.RemoveEmptySections();
     Error error;
     si.Save(&error);
-    // EmuConfig and the MTGS ring are the CPU thread's; this runs on the UI thread.
-    Host::RunOnCPUThread([]() {
-        VMManager::ReloadGameSettings();
-        if (MTGS::IsOpen())
-            MTGS::ApplySettings();
-    });
+    ARMSX2RequestPerGameSettingsReload();
 }
 
 + (nonnull NSString *)perGameIdentityKeyForCurrentGame {

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
@@ -929,6 +929,37 @@ static NSString* ARMSX2ResolveISOPath(NSString* isoName)
     return nil;
 }
 
+static BOOL ARMSX2PerGameIdentityForCurrentGame(std::string* serial, u32* crc);
+
+// There is one process-wide InputIsoFile, shared between the running VM and every
+// metadata scan, so scanning the disc a game is playing from closes it out from
+// under the game. GameList.h says as much above PopulateEntryFromPath: do not call
+// it while the system is running. Everything after that reads zero blocks and the
+// game starves while the emulator carries on at full speed, which is a miserable
+// thing to debug from a bug report.
+static bool ARMSX2PathIsRunningDisc(NSString* resolvedPath)
+{
+    if (resolvedPath.length == 0 || !VMManager::HasValidVM())
+        return false;
+
+    const std::string running = VMManager::GetDiscPath();
+    return !running.empty() && running == resolvedPath.UTF8String;
+}
+
+static void ARMSX2NoteRunningDiscScan(NSString* path)
+{
+    // Once is enough. This went unnoticed for a long time precisely because it was
+    // silent; if something finds a new way in, it should show up in an ordinary log
+    // rather than needing a special build with a backtrace in it.
+    static bool warned = false;
+    if (warned)
+        return;
+
+    warned = true;
+    Console.Warning("Not scanning '%s' while a VM is running; using the game list cache instead.",
+        path.UTF8String);
+}
+
 static BOOL ARMSX2PopulateGameListEntryForISO(NSString* isoName, GameList::Entry* entry, NSString** resolvedPath)
 {
     NSString* path = ARMSX2ResolveISOPath(isoName);
@@ -937,6 +968,25 @@ static BOOL ARMSX2PopulateGameListEntryForISO(NSString* isoName, GameList::Entry
 
     if (path.length == 0 || !entry)
         return NO;
+
+    // Any VM, not just one playing this particular file. InputIsoFile::Open closes
+    // whatever is already open before it opens anything, so scanning some unrelated
+    // image while a game is running kills that game's disc just the same.
+    if (VMManager::HasValidVM())
+    {
+        ARMSX2NoteRunningDiscScan(path);
+
+        // Cache only, and a miss fails rather than falling through to a scan. The
+        // worst case is a missing cover or title while a game is up; the
+        // alternative is killing the disc out from under it.
+        const auto lock = GameList::GetLock();
+        const GameList::Entry* cached = GameList::GetEntryForPath(path.UTF8String);
+        if (!cached)
+            return NO;
+
+        *entry = *cached;
+        return YES;
+    }
 
     return GameList::PopulateEntryFromPath(path.UTF8String, entry) ? YES : NO;
 }
@@ -2165,6 +2215,13 @@ static void ARMSX2SetPatchEnableListForIdentity(NSArray<NSString*>* values, cons
 // game-settings writer.
 static BOOL ARMSX2PerGameIdentityForISO(NSString* isoName, std::string* serial, u32* crc)
 {
+    // The VM already knows what it booted, so asking the disc is both slower and,
+    // until this check existed, destructive. Taking it here rather than relying on
+    // the cache below also means this keeps working when the game list has no
+    // entry for the running game.
+    if (ARMSX2PathIsRunningDisc(ARMSX2ResolveISOPath(isoName)))
+        return ARMSX2PerGameIdentityForCurrentGame(serial, crc);
+
     GameList::Entry entry;
     NSString* resolvedPath = nil;
     if (!ARMSX2PopulateGameListEntryForISO(isoName, &entry, &resolvedPath) || entry.crc == 0)


### PR DESCRIPTION
## What changed

* Fixed the game freezing shortly after saving anything in per game settings. It was reported as a savestate problem and as a crash; it was neither.
* Saving per game settings is no longer slow. One press of Save was doing seventy one full settings reloads. It now does one.

## The freeze

Reported as "after modifying any setting, even the resolution, the savestate before the change cannot be read and it crashes". The real behaviour, once reproduced with logs, was that the savestate loaded perfectly well and the game froze a moment later, with no crash at all. The emulator was still running at 59.9 fps the whole time. Only the game was stuck.

The logs had 11,782 of these:

```
isoFile error: Block index is past the end of file! (1150251 >= 0).
```

The right hand side is the block count, and it is zero, so the disc was closed. Every read fails from that point. GTA:SA streams constantly so it locks up almost at once. A game that streams less would have looked fine until the next time it needed the disc, which is why this was so hard to pin down and why it kept getting blamed on savestates.

There is one process wide `InputIsoFile` shared between the running VM and every metadata scan. `InputIsoFile::Open` closes whatever is already open before opening anything, so scanning any image while a game is running leaves that game with a closed disc. `GameList.h` says so directly above the function:

```cpp
/// Do *not* call while the system is running, it will mess with CDVD state.
bool PopulateEntryFromPath(const std::string& path, GameList::Entry* entry);
```

The way in was `savePerGameCompatibility`. It threads `useCurrent` through every write except one, the renderer, which deliberately uses the `forISO:` variant so the value lands in the INI without applying mid game. That intent is correct. What is not obvious is that the `forISO:` variants resolve identity through `PopulateEntryFromPath`. Since most people have no per game renderer override it is the delete branch that runs, so this fired on every press of Save no matter which setting was actually changed.

So the bridge no longer scans while a VM is up. Identity for the running game comes from what the VM already knows. Anything needing a full entry gets it from the game list cache, and a cache miss fails rather than falling back to a scan. Worst case is a missing cover or title while a game is up, against killing that game's disc.

The guard is on any VM rather than only on the image being scanned, because `Open` closes the current one regardless of which file is opened next, so scanning something unrelated does the same damage.

It also logs once, the first time anything asks for a scan while a VM is running. This went unnoticed for a long time precisely because it was completely silent; it took a throwaway build with a backtrace in `Close` to find at all.

## The seventy one reloads

Each per game setter writes its one key and then queues a full reload, so a panel that writes every field it owns gets a reload per field. Each of those re reads the INI, re runs the GameDB fixups and rebuilds the GS config, which is most of why saving anything took a visible moment.

The reload is now coalesced. A write schedules one shortly after, and if another write lands first it hands the job over, so the last write in a burst is the one that reloads.

This is deliberately in the bridge rather than a begin and end batch for the panel to bracket its save with. The disc bug above happened because a caller did not know a rule it was supposed to follow, and a bracket is the same shape: anything added later that forgets to wrap goes quietly back to the old behaviour. This way there is no rule to remember.

The cost is that a change applies about fifty milliseconds after the last write instead of immediately, and if the app is backgrounded inside that window the live apply is skipped, though the file is already written so it lands on the next boot.

Only the `ForCurrentGame` setters are touched. The `forISO:` ones never reloaded; they exist precisely to write the file without applying it.

## Testing

Both verified on device against logs, before and after.

* `isoFile error` while playing: 11,782 before, 0 after.
* Settings applies per press of Save: 71 before, 2 after.

The two remaining applies are two separate write bursts about 120 ms apart, each coalesced correctly, rather than the debounce failing.

Also checked after the change: the library still shows covers and titles while a game is running, savestates save and load, and the only disc closes left in the log are the library scan before boot and `VMManager::Shutdown` on quit.
