### PR TITLE
iOS: Adjustable Core Haptics, Quick Menu Stop, and Full Default Preset Reset

### DIFF
--- a/platforms/ios/app/src/main/cpp/IOS/GamepadHaptics.mm
+++ b/platforms/ios/app/src/main/cpp/IOS/GamepadHaptics.mm
@@ -62,12 +62,24 @@ static constexpr double ARMSX2_RUMBLE_SMALL_ATTACK_SECONDS = 0.028;
 static constexpr double ARMSX2_RUMBLE_LARGE_RELEASE_SECONDS = 0.120;
 static constexpr double ARMSX2_RUMBLE_SMALL_RELEASE_SECONDS = 0.060;
 static constexpr double ARMSX2_RUMBLE_CROSSFADE_SECONDS = 0.045;
+static constexpr float ARMSX2_PHONE_RUMBLE_BASELINE_SETTING = 0.25f;
+static constexpr float ARMSX2_PHONE_RUMBLE_MAX_GAIN = 3.0f;
+static constexpr float ARMSX2_PHONE_RUMBLE_MEDIUM_THRESHOLD = 0.34f;
+static constexpr float ARMSX2_PHONE_RUMBLE_HARD_THRESHOLD = 0.67f;
+
+enum class ARMSX2PhoneRumbleClass : u8
+{
+    Weak,
+    Medium,
+    Hard,
+};
 
 struct ARMSX2RumbleEnvelope
 {
     float start_level = 0.0f;
     float target_level = 0.0f;
     double start_time = 0.0;
+    double hold_duration = 0.0;
     double duration = 0.0;
 };
 
@@ -77,6 +89,7 @@ static std::atomic<u32> s_loggedNativePulseHapticEvents{0};
 static CHHapticEngine* s_nativeHapticEngine = nil;
 static id<CHHapticAdvancedPatternPlayer> s_nativeHapticPlayer[ARMSX2_RUMBLE_CHANNEL_COUNT] = {};
 static ARMSX2RumbleEnvelope s_nativeHapticEnvelope[ARMSX2_RUMBLE_CHANNEL_COUNT];
+static float s_nativeHapticReleaseScale[ARMSX2_RUMBLE_CHANNEL_COUNT] = { 1.0f, 1.0f };
 static u32 s_nativeHapticStopGeneration[ARMSX2_RUMBLE_CHANNEL_COUNT] = {};
 static bool s_nativeHapticEngineRunning = false;
 static std::atomic<int> s_nativeHapticSourceGamepad{-1};
@@ -572,6 +585,7 @@ static void ARMSX2StopRumbleChannelOnMain(u32 channel)
     }
 
     s_nativeHapticEnvelope[channel] = {};
+    s_nativeHapticReleaseScale[channel] = 1.0f;
 }
 
 static void ARMSX2StopNativeGamepadRumbleOnMain()
@@ -765,7 +779,16 @@ static float ARMSX2CurrentRumbleLevel(u32 channel, double now)
     if (envelope.duration <= 0.0)
         return envelope.target_level;
 
-    const double progress = std::clamp((now - envelope.start_time) / envelope.duration, 0.0, 1.0);
+    const double elapsed = now - envelope.start_time;
+    if (elapsed <= envelope.hold_duration)
+        return envelope.start_level;
+
+    const double fade_duration = envelope.duration - envelope.hold_duration;
+    if (fade_duration <= 0.0)
+        return envelope.target_level;
+
+    const double progress = std::clamp(
+        (elapsed - envelope.hold_duration) / fade_duration, 0.0, 1.0);
     return std::clamp(envelope.start_level +
         ((envelope.target_level - envelope.start_level) * static_cast<float>(progress)), 0.0f, 1.0f);
 }
@@ -790,14 +813,18 @@ static double ARMSX2RumbleTransitionDuration(u32 channel, float current, float t
     return base_duration * distance_scale;
 }
 
-// Expects the engine to already be up, which is the caller's job. Curves model
-// the inertia of a physical eccentric motor while retaining immediate response.
-static bool ARMSX2SetRumbleChannelOnMain(u32 channel, float level)
+// Expects the engine to already be up, which is the caller's job. Extended
+// releases hold their current force first, then use the normal 1x fade duration.
+// This keeps the additional duration perceptible instead of stretching one weak,
+// slow fade across the entire envelope.
+static bool ARMSX2SetRumbleChannelOnMain(u32 channel, float level, float release_scale)
 {
     if (channel >= ARMSX2_RUMBLE_CHANNEL_COUNT)
         return false;
 
     const float target = std::clamp(level, 0.0f, 1.0f);
+    if (target > 0.001f)
+        s_nativeHapticReleaseScale[channel] = std::clamp(release_scale, 1.0f, 3.0f);
     if (target > 0.001f && !ARMSX2EnsureRumbleChannelOnMain(channel))
         return false;
 
@@ -812,12 +839,20 @@ static bool ARMSX2SetRumbleChannelOnMain(u32 channel, float level)
         std::abs(s_nativeHapticEnvelope[channel].target_level - target) < 0.002f)
         return true;
 
-    const double duration = ARMSX2RumbleTransitionDuration(channel, current, target);
+    const double fade_duration = ARMSX2RumbleTransitionDuration(channel, current, target);
+    const double hold_duration = (target <= 0.001f)
+        ? fade_duration * (static_cast<double>(s_nativeHapticReleaseScale[channel]) - 1.0)
+        : 0.0;
+    const double duration = hold_duration + fade_duration;
     NSError* error = nil;
-    NSArray<CHHapticParameterCurveControlPoint*>* controlPoints = @[
-        [[[CHHapticParameterCurveControlPoint alloc] initWithRelativeTime:0.0 value:current] autorelease],
-        [[[CHHapticParameterCurveControlPoint alloc] initWithRelativeTime:duration value:target] autorelease]
-    ];
+    NSMutableArray<CHHapticParameterCurveControlPoint*>* controlPoints = [NSMutableArray arrayWithObject:
+        [[[CHHapticParameterCurveControlPoint alloc] initWithRelativeTime:0.0 value:current] autorelease]];
+    if (hold_duration > 0.0005) {
+        [controlPoints addObject:[[[CHHapticParameterCurveControlPoint alloc]
+            initWithRelativeTime:hold_duration value:current] autorelease]];
+    }
+    [controlPoints addObject:[[[CHHapticParameterCurveControlPoint alloc]
+        initWithRelativeTime:duration value:target] autorelease]];
     CHHapticParameterCurve* curve = [[[CHHapticParameterCurve alloc]
         initWithParameterID:CHHapticDynamicParameterIDHapticIntensityControl
               controlPoints:controlPoints
@@ -829,7 +864,7 @@ static bool ARMSX2SetRumbleChannelOnMain(u32 channel, float level)
         return false;
     }
 
-    s_nativeHapticEnvelope[channel] = { current, target, now, duration };
+    s_nativeHapticEnvelope[channel] = { current, target, now, hold_duration, duration };
     const u32 generation = ++s_nativeHapticStopGeneration[channel];
     if (target <= 0.001f) {
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
@@ -880,6 +915,61 @@ static void ARMSX2PlayRumbleTransientOnMain(float large, float small)
         s_nativeHapticLastTransientTime = now;
 }
 
+static float ARMSX2PhoneRumbleGain(float setting)
+{
+    const float clamped = std::clamp(setting, 0.0f, 1.0f);
+    if (clamped <= ARMSX2_PHONE_RUMBLE_BASELINE_SETTING)
+        return clamped / ARMSX2_PHONE_RUMBLE_BASELINE_SETTING;
+
+    // The original synthesis becomes the 25% baseline. The upper three quarters
+    // of the slider add gain linearly until 100% reaches three times that baseline.
+    const float normalized = (clamped - ARMSX2_PHONE_RUMBLE_BASELINE_SETTING) /
+        (1.0f - ARMSX2_PHONE_RUMBLE_BASELINE_SETTING);
+    return 1.0f + (normalized * (ARMSX2_PHONE_RUMBLE_MAX_GAIN - 1.0f));
+}
+
+static ARMSX2PhoneRumbleClass ARMSX2ClassifyPhoneRumble(float large, float small)
+{
+    const float source_level = std::max(large, small);
+    if (source_level >= ARMSX2_PHONE_RUMBLE_HARD_THRESHOLD)
+        return ARMSX2PhoneRumbleClass::Hard;
+    if (source_level >= ARMSX2_PHONE_RUMBLE_MEDIUM_THRESHOLD)
+        return ARMSX2PhoneRumbleClass::Medium;
+    return ARMSX2PhoneRumbleClass::Weak;
+}
+
+static float ARMSX2PhoneRumbleReleaseScale(float setting, ARMSX2PhoneRumbleClass rumble_class)
+{
+    const float clamped = std::clamp(setting, ARMSX2_PHONE_RUMBLE_BASELINE_SETTING, 1.0f);
+    switch (rumble_class) {
+        case ARMSX2PhoneRumbleClass::Hard:
+            // Hard effects begin gaining inertia above 50%, reach 2x at 75%,
+            // and finish at a 3x release envelope at maximum strength.
+            return (clamped > 0.50f) ? (1.0f + ((clamped - 0.50f) * 4.0f)) : 1.0f;
+        case ARMSX2PhoneRumbleClass::Medium:
+            // Medium effects retain their original timing through 75%, then
+            // smoothly grow to a 2x release envelope.
+            return (clamped > 0.75f) ? (1.0f + ((clamped - 0.75f) * 4.0f)) : 1.0f;
+        case ARMSX2PhoneRumbleClass::Weak:
+            return 1.0f;
+    }
+
+    return 1.0f;
+}
+
+static float ARMSX2PromoteWeakPhoneRumble(float level, float setting, ARMSX2PhoneRumbleClass rumble_class)
+{
+    if (rumble_class != ARMSX2PhoneRumbleClass::Weak || setting <= 0.75f)
+        return level;
+
+    // The final quarter progressively turns subtle feedback into a normal hard
+    // tap. Its release scale remains 1x, so promotion adds presence, not a long tail.
+    const float promotion = std::clamp((setting - 0.75f) * 4.0f, 0.0f, 1.0f);
+    const float hard_level = std::pow(ARMSX2_PHONE_RUMBLE_HARD_THRESHOLD, 0.78f);
+    const float promoted_level = std::max(level, hard_level);
+    return level + ((promoted_level - level) * promotion);
+}
+
 static void ARMSX2ApplyNativeGamepadRumbleOnMain(u32 packed)
 {
 	if (s_nativeAppliedGamepadRumbleValid && packed == s_nativeAppliedGamepadRumble)
@@ -888,18 +978,41 @@ static void ARMSX2ApplyNativeGamepadRumbleOnMain(u32 packed)
     // Straight off the packed value, so the phone gets the whole 0..1 motor range
     // rather than the 0x7000 ceiling the controller motors are held to. Read every
     // time so dragging the slider is felt on the next rumble instead of next launch.
-    const float strength = s_settings_interface
-        ? std::clamp(s_settings_interface->GetFloatValue("ARMSX2iOS/UI", "PhoneRumbleStrength", 1.0f), 0.0f, 1.0f)
-        : 1.0f;
+    const float strength_setting = s_settings_interface
+        ? s_settings_interface->GetFloatValue(
+              "ARMSX2iOS/UI", "PhoneRumbleStrength", ARMSX2_PHONE_RUMBLE_BASELINE_SETTING)
+        : ARMSX2_PHONE_RUMBLE_BASELINE_SETTING;
+    const bool increase_duration = s_settings_interface
+        ? s_settings_interface->GetBoolValue(
+              "ARMSX2iOS/UI", "IncreaseRumbleDurationAndInterpolation", true)
+        : true;
+    const float strength = ARMSX2PhoneRumbleGain(strength_setting);
     // Preserve low-amplitude detail without imposing a hard floor. The sublinear
     // curve compensates for the phone actuator's less perceptible lower range while
     // keeping the original analog ordering from the PS2 heavy motor.
     const float large_raw = ARMSX2RumbleLargeIntensity(packed);
-    const float large = (large_raw > 0.01f)
+    float large = (large_raw > 0.01f)
         ? std::pow(large_raw, 0.78f) * strength
         : 0.0f;
     const float small_raw = ARMSX2RumbleSmallIntensity(packed);
-    const float small = (small_raw > 0.01f) ? (ARMSX2_SMALL_MOTOR_LEVEL * strength) : 0.0f;
+    const ARMSX2PhoneRumbleClass rumble_class = ARMSX2ClassifyPhoneRumble(large_raw, small_raw);
+    const float release_scale = increase_duration
+        ? ARMSX2PhoneRumbleReleaseScale(strength_setting, rumble_class)
+        : 1.0f;
+    large = (increase_duration && large_raw > 0.01f)
+        ? ARMSX2PromoteWeakPhoneRumble(large, strength_setting, rumble_class)
+        : large;
+    float small = (small_raw > 0.01f) ? (ARMSX2_SMALL_MOTOR_LEVEL * strength) : 0.0f;
+    small = (increase_duration && small_raw > 0.01f)
+        ? ARMSX2PromoteWeakPhoneRumble(small, strength_setting, rumble_class)
+        : small;
+
+    // Turning the extension off also cancels a scale retained by the previous
+    // active effect, so its next stop uses the original 1x release immediately.
+    if (!increase_duration) {
+        for (u32 channel = 0; channel < ARMSX2_RUMBLE_CHANNEL_COUNT; channel++)
+            s_nativeHapticReleaseScale[channel] = 1.0f;
+    }
 
     if ((large > 0.01f || small > 0.01f) && !ARMSX2EnsureNativeRumbleEngineOnMain())
         return;
@@ -915,8 +1028,10 @@ static void ARMSX2ApplyNativeGamepadRumbleOnMain(u32 packed)
     if (large_started || small_started)
         ARMSX2PlayRumbleTransientOnMain(large_started ? large : 0.0f, small_started ? small : 0.0f);
 
-    const bool large_ok = ARMSX2SetRumbleChannelOnMain(ARMSX2_RUMBLE_CHANNEL_LARGE, large);
-    const bool small_ok = ARMSX2SetRumbleChannelOnMain(ARMSX2_RUMBLE_CHANNEL_SMALL, small);
+    const bool large_ok = ARMSX2SetRumbleChannelOnMain(
+        ARMSX2_RUMBLE_CHANNEL_LARGE, large, release_scale);
+    const bool small_ok = ARMSX2SetRumbleChannelOnMain(
+        ARMSX2_RUMBLE_CHANNEL_SMALL, small, release_scale);
     if (large_ok && small_ok) {
         s_nativeAppliedGamepadRumble = packed;
         s_nativeAppliedGamepadRumbleValid = true;

--- a/platforms/ios/app/src/main/swift/Models/SettingsPresetCatalog.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsPresetCatalog.swift
@@ -16,7 +16,7 @@ enum BuiltInSettingsPreset: String, CaseIterable, Identifiable {
     var summary: String {
         switch self {
         case .defaultPreset:
-            return "Restores the graphics and emulation options managed by quality presets to the ARMSX2 defaults."
+            return "Restores ARMSX2 settings to their original defaults."
         case .ultraQuality:
             return "Uses 2x internal resolution with FXAA and CAS Sharpening for maximum image quality."
         case .highQuality:
@@ -33,7 +33,7 @@ enum BuiltInSettingsPreset: String, CaseIterable, Identifiable {
     var detail: String {
         switch self {
         case .defaultPreset:
-            return "Default disables Fast Boot, PNACH Cheats, Widescreen Patches, Fast CDVD, FXAA, CAS Sharpening, OPH Flag Hack, Emulation-Only Mode, and the background in Settings; restores Internal Resolution to 1x Native and Queue Size to 8; and selects the White Colored Virtual Pad skin."
+            return "Default restores emulator, graphics, audio, frame pacing, overlay, controller, Virtual Pad, layout, network, appearance, and Dynamic Control settings. Imported games, BIOS files, memory cards, skins, presets, and account data are preserved."
         case .ultraQuality:
             return "Ultra Quality enables Fast Boot, PNACH Cheats, Widescreen Patches, Fast CDVD, FXAA, CAS Sharpening, and the background in Settings; sets Internal Resolution to 2x (1024x896) and Queue Size to 2. OPH Flag Hack and Emulation-Only Mode are disabled. The selected Virtual Pad skin is preserved."
         case .highQuality:
@@ -79,6 +79,14 @@ enum BuiltInSettingsPreset: String, CaseIterable, Identifiable {
         settings: SettingsStore = .shared,
         skinLibrary: VPadSkinLibraryStore = .shared
     ) {
+        if self == .defaultPreset {
+            settings.resetAllDefaults()
+            skinLibrary.selectSkin(id: VirtualPadSkin.armsx2Refresh.descriptorID)
+            settings.virtualPadSkin = .armsx2Refresh
+            ARMSX2Bridge.flushINISettings()
+            return
+        }
+
         let configuration = self.configuration
         settings.fastBoot = configuration.fastBoot
         settings.enableCheats = configuration.enableCheats
@@ -91,10 +99,6 @@ enum BuiltInSettingsPreset: String, CaseIterable, Identifiable {
         settings.setGameFix("OPHFlagHack", configuration.ophFlagHack)
         settings.emulationOnlyModeEnabled = configuration.emulationOnlyMode
         settings.backgroundEnabledInSettings = configuration.showBackgroundInSettings
-        if self == .defaultPreset {
-            skinLibrary.selectSkin(id: VirtualPadSkin.armsx2Refresh.descriptorID)
-            settings.virtualPadSkin = .armsx2Refresh
-        }
     }
 
     private var configuration: Configuration {

--- a/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
@@ -1506,13 +1506,25 @@ final class SettingsStore {
         _padOpacityConfig.onSet?(padOpacity)
     }}
     let _phoneRumbleStrengthConfig = Setting<Float>(
-        section: "ARMSX2iOS/UI", key: "PhoneRumbleStrength", default: 1.0,
+        section: "ARMSX2iOS/UI", key: "PhoneRumbleStrength", default: 0.25,
         suppressible: false,
         writer: ARMSX2Bridge.setINIFloat)
-    var phoneRumbleStrength: Float = 1.0 { didSet {
+    var phoneRumbleStrength: Float = 0.25 { didSet {
         guard !(_phoneRumbleStrengthConfig.suppressible && suppressINIWrites) else { return }
         _phoneRumbleStrengthConfig.writer(_phoneRumbleStrengthConfig.section, _phoneRumbleStrengthConfig.key, phoneRumbleStrength)
         _phoneRumbleStrengthConfig.onSet?(phoneRumbleStrength)
+    }}
+    let _increaseRumbleDurationAndInterpolationConfig = Setting<Bool>(
+        section: "ARMSX2iOS/UI", key: "IncreaseRumbleDurationAndInterpolation", default: true,
+        suppressible: false,
+        writer: ARMSX2Bridge.setINIBool)
+    var increaseRumbleDurationAndInterpolation: Bool = true { didSet {
+        guard !(_increaseRumbleDurationAndInterpolationConfig.suppressible && suppressINIWrites) else { return }
+        _increaseRumbleDurationAndInterpolationConfig.writer(
+            _increaseRumbleDurationAndInterpolationConfig.section,
+            _increaseRumbleDurationAndInterpolationConfig.key,
+            increaseRumbleDurationAndInterpolation)
+        _increaseRumbleDurationAndInterpolationConfig.onSet?(increaseRumbleDurationAndInterpolation)
     }}
     let _hapticFeedbackConfig = Setting<Bool>(
         section: "ARMSX2iOS/UI", key: "HapticFeedback", default: true,
@@ -2062,7 +2074,8 @@ final class SettingsStore {
         // UI
         padOpacity = ARMSX2Bridge.getINIFloat("ARMSX2iOS/UI", key: "PadOpacity", defaultValue: 0.6)
         hapticFeedback = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "HapticFeedback", defaultValue: true)
-        phoneRumbleStrength = ARMSX2Bridge.getINIFloat("ARMSX2iOS/UI", key: "PhoneRumbleStrength", defaultValue: 1.0)
+        phoneRumbleStrength = ARMSX2Bridge.getINIFloat("ARMSX2iOS/UI", key: "PhoneRumbleStrength", defaultValue: 0.25)
+        increaseRumbleDurationAndInterpolation = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "IncreaseRumbleDurationAndInterpolation", defaultValue: true)
         dpadDiagonalsEnabled = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "DpadDiagonalsEnabled", defaultValue: true)
         faceComboZonesEnabled = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "FaceComboZonesEnabled", defaultValue: true)
         virtualPadSkin = VirtualPadSkin(rawValue: Int(ARMSX2Bridge.getINIInt("ARMSX2iOS/UI", key: "VirtualPadSkin", defaultValue: 0))) ?? .armsx2Refresh
@@ -2308,7 +2321,8 @@ final class SettingsStore {
         osdShowDeviceStats = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "OsdShowDeviceStats", defaultValue: osdPreset != .off)
         padOpacity = ARMSX2Bridge.getINIFloat("ARMSX2iOS/UI", key: "PadOpacity", defaultValue: 0.6)
         hapticFeedback = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "HapticFeedback", defaultValue: true)
-        phoneRumbleStrength = ARMSX2Bridge.getINIFloat("ARMSX2iOS/UI", key: "PhoneRumbleStrength", defaultValue: 1.0)
+        phoneRumbleStrength = ARMSX2Bridge.getINIFloat("ARMSX2iOS/UI", key: "PhoneRumbleStrength", defaultValue: 0.25)
+        increaseRumbleDurationAndInterpolation = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "IncreaseRumbleDurationAndInterpolation", defaultValue: true)
         dpadDiagonalsEnabled = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "DpadDiagonalsEnabled", defaultValue: true)
         faceComboZonesEnabled = ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "FaceComboZonesEnabled", defaultValue: true)
         virtualPadSkin = VirtualPadSkin(rawValue: Int(ARMSX2Bridge.getINIInt("ARMSX2iOS/UI", key: "VirtualPadSkin", defaultValue: 0))) ?? .armsx2Refresh
@@ -2803,4 +2817,5 @@ final class SettingsStore {
         shadeBoostGamma = 50
         // Texture pack and dump toggles are intentionally preserved.
     }
+
 }

--- a/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
@@ -2818,4 +2818,86 @@ final class SettingsStore {
         // Texture pack and dump toggles are intentionally preserved.
     }
 
+    /// Restores application configuration without deleting imported content,
+    /// user-created presets, memory cards, skins, or account credentials.
+    func resetAllDefaults() {
+        resetEmulatorDefaults()
+        resetGraphicsDefaults()
+
+        // Texture replacement settings are intentionally preserved by the
+        // graphics-only reset, but a full reset returns them to fresh-install values.
+        loadTextureReplacements = false
+        loadTextureReplacementsAsync = true
+        precacheTextureReplacements = false
+        texturePreloading = 2
+        dumpReplaceableTextures = false
+        dumpReplaceableMipmaps = false
+        dumpTexturesWithFMVActive = false
+        dumpDirectTextures = true
+        dumpPaletteTextures = true
+
+        framePacingPreset = .optimal
+        adaptiveResolutionEnabled = false
+
+        osdPreset = .off
+        lastActiveOsdPreset = .simple
+        osdPerformancePosition = Self.defaultOsdPerformancePosition
+        osdShowMessages = true
+        osdShowTextureReplacements = false
+        snapshotCustomOsd()
+
+        padOpacity = 0.6
+        phoneRumbleStrength = 0.25
+        increaseRumbleDurationAndInterpolation = true
+        hapticFeedback = true
+        dpadDiagonalsEnabled = true
+        faceComboZonesEnabled = true
+        autoHideVirtualPadWhenControllerConnected = true
+        autoFullscreen = true
+        hideMenuButton = false
+        analogStickScale = 1.0
+        invertLeftStickX = false
+        invertLeftStickY = false
+        invertRightStickX = false
+        invertRightStickY = false
+        appLanguage = .system
+        controllerMultitapMode = 0
+        autoOpenStikDebug = false
+        jitScriptProtocol = .defaultValue
+
+        dev9HddEnabled = false
+        dev9HddFile = "DEV9hdd.raw"
+        dev9EthernetEnabled = false
+        dev9EthDevice = "Auto"
+        dev9InterceptDHCP = false
+        dev9EthLogDHCP = false
+        dev9EthLogDNS = false
+        dev9DNS1Mode = "Auto"
+        dev9DNS1 = "0.0.0.0"
+        dev9DNS2Mode = "Auto"
+        dev9DNS2 = "0.0.0.0"
+
+        dynamicBackgroundsEnabled = true
+        dynamicAppearancePreferences = .standard
+        clearLiquidGlassUI = true
+        clearLiquidGlassUIQuickMenu = false
+        gameCardZoomAnimationEnabled = true
+        backgroundPrimaryAsset = nil
+        backgroundLandscapeAsset = nil
+        backgroundFitMode = .fill
+        backgroundLandscapeFitMode = .fill
+        backgroundVideoMuted = true
+        backgroundDim = 0.0
+        backgroundEnabledInBIOS = true
+        backgroundEnabledInHelp = true
+        backgroundEnabledInSettings = true
+
+        DynamicThumbstickSettings.shared.restoreDefaults()
+        let padLayout = PadLayoutStore.shared
+        padLayout.resetAll()
+        padLayout.resetControlVisibility()
+        padLayout.save()
+        ARMSX2Bridge.resetButtonMappings()
+        ARMSX2Bridge.flushINISettings()
+    }
 }

--- a/platforms/ios/app/src/main/swift/Views/GameScreenView.swift
+++ b/platforms/ios/app/src/main/swift/Views/GameScreenView.swift
@@ -313,6 +313,11 @@ struct GameScreenView: View {
                     onBackToMenu: {
                         appState.returnToMenu()
                     },
+                    onStop: {
+                        if settings.hapticFeedback { HapticManager.medium.impactOccurred() }
+                        overlayRoute = .hidden
+                        ARMSX2Bridge.requestVMStop()
+                    },
                     onResume: {
                         if settings.hapticFeedback { HapticManager.light.impactOccurred() }
                         overlayRoute = .hidden

--- a/platforms/ios/app/src/main/swift/Views/QuickMenuView.swift
+++ b/platforms/ios/app/src/main/swift/Views/QuickMenuView.swift
@@ -24,6 +24,8 @@ enum QuickMenuDestination: Equatable {
 /// view to the bounded card size): two columns when the card is comfortably wide, one column
 /// otherwise. Resume is pinned inside the panel footer so it never detaches or hides rows.
 struct QuickMenuView: View {
+    @State private var showStopConfirmation = false
+
     let settings: SettingsStore
     @Binding var padVisible: Bool
     @Binding var fullScreen: Bool
@@ -42,6 +44,7 @@ struct QuickMenuView: View {
     let onOpen: (QuickMenuDestination) -> Void
     let onClearCache: () -> Void
     let onBackToMenu: () -> Void
+    let onStop: () -> Void
     let onResume: () -> Void
 
     /// Compact sizing for the header/footer on iPad (any orientation) and iPhone landscape; the
@@ -58,6 +61,12 @@ struct QuickMenuView: View {
             \.clearLiquidGlassUIEnabled,
             settings.clearLiquidGlassUIQuickMenu
         )
+        .alert(settings.localized("Stop Emulation?"), isPresented: $showStopConfirmation) {
+            Button(settings.localized("Cancel"), role: .cancel) {}
+            Button(settings.localized("Stop"), role: .destructive, action: onStop)
+        } message: {
+            Text(settings.localized("This will shut down the running game. All unsaved progress will be lost."))
+        }
     }
 
     @ViewBuilder
@@ -92,6 +101,7 @@ struct QuickMenuView: View {
                 LandscapeCommandBar(
                     settings: settings,
                     gameTitle: gameTitle,
+                    onStop: { showStopConfirmation = true },
                     onResume: onResume,
                     iconOnly: width < 380
                 )
@@ -155,11 +165,11 @@ struct QuickMenuView: View {
             cardsContent(twoColumns: twoColumns)
         }
         .safeAreaInset(edge: .bottom, spacing: 0) {
-            OverlayFooter(
-                primaryLabel: settings.localized("Resume"),
-                primarySystemImage: "play.fill",
-                primaryAction: onResume,
-                compact: compact
+            QuickMenuFooter(
+                settings: settings,
+                compact: compact,
+                onStop: { showStopConfirmation = true },
+                onResume: onResume
             )
         }
     }
@@ -273,6 +283,7 @@ struct QuickMenuView: View {
 private struct LandscapeCommandBar: View {
     let settings: SettingsStore
     let gameTitle: String?
+    let onStop: () -> Void
     let onResume: () -> Void
     let iconOnly: Bool
 
@@ -295,6 +306,11 @@ private struct LandscapeCommandBar: View {
                         .layoutPriority(-1)
                 }
                 Spacer(minLength: 8)
+                QuickMenuStopButton(
+                    accessibilityLabel: settings.localized("Stop"),
+                    compact: true,
+                    action: onStop
+                )
                 Button(action: onResume) {
                     if iconOnly {
                         Image(systemName: "play.fill")
@@ -310,5 +326,57 @@ private struct LandscapeCommandBar: View {
             OverlayTheme.separator
                 .frame(height: 0.5)
         }
+    }
+}
+
+private struct QuickMenuFooter: View {
+    let settings: SettingsStore
+    let compact: Bool
+    let onStop: () -> Void
+    let onResume: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            OverlayTheme.separator
+                .frame(height: 0.5)
+            HStack(spacing: compact ? 10 : 12) {
+                QuickMenuStopButton(
+                    accessibilityLabel: settings.localized("Stop"),
+                    compact: compact,
+                    action: onStop
+                )
+                Button(action: onResume) {
+                    Label(settings.localized("Resume"), systemImage: "play.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(compact ? .regular : .large)
+                .tint(OverlayTheme.accent)
+            }
+            .padding(.horizontal, compact ? 18 : 20)
+            .padding(.top, 8)
+            .padding(.bottom, compact ? 10 : 14)
+        }
+    }
+}
+
+private struct QuickMenuStopButton: View {
+    let accessibilityLabel: String
+    let compact: Bool
+    let action: () -> Void
+
+    private var diameter: CGFloat { compact ? 36 : 46 }
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "stop.fill")
+                .font(.system(size: compact ? 13 : 16, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: diameter, height: diameter)
+                .background(Color.red, in: Circle())
+        }
+        .buttonStyle(.plain)
+        .contentShape(Circle())
+        .accessibilityLabel(accessibilityLabel)
     }
 }

--- a/platforms/ios/app/src/main/swift/Views/Settings/SettingsPresetsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/SettingsPresetsView.swift
@@ -94,6 +94,7 @@ struct SettingsPresetsView: View {
     @State private var folderAccess = InitialContentBootstrap.shared
     @State private var presentedSheet: SettingsPresetsSheet?
     @State private var message: SettingsPresetsMessage?
+    @State private var isResetSettingsConfirmationPresented = false
     @State private var exportDocument = SettingsPresetDocument(data: Data())
     @State private var isExportingPreset = false
 
@@ -148,6 +149,20 @@ struct SettingsPresetsView: View {
                 message: Text(settings.localized(message.text)),
                 dismissButton: .default(Text(settings.localized("OK")))
             )
+        }
+        .alert(
+            settings.localized("Reset Settings?"),
+            isPresented: $isResetSettingsConfirmationPresented
+        ) {
+            Button(settings.localized("Cancel"), role: .cancel) {}
+            Button(settings.localized("Reset Settings"), role: .destructive) {
+                BuiltInSettingsPreset.defaultPreset.apply(
+                    settings: settings,
+                    skinLibrary: skinLibrary
+                )
+            }
+        } message: {
+            Text(settings.localized("This will reset all settings to it's original values."))
         }
     }
 
@@ -213,7 +228,11 @@ struct SettingsPresetsView: View {
         Section {
             ForEach(BuiltInSettingsPreset.allCases) { preset in
                 Button {
-                    preset.apply(settings: settings, skinLibrary: skinLibrary)
+                    if preset == .defaultPreset {
+                        isResetSettingsConfirmationPresented = true
+                    } else {
+                        preset.apply(settings: settings, skinLibrary: skinLibrary)
+                    }
                 } label: {
                     HStack(spacing: 12) {
                         VStack(alignment: .leading, spacing: 5) {
@@ -250,7 +269,7 @@ struct SettingsPresetsView: View {
         } header: {
             Text(settings.localized("Device Presets"))
         } footer: {
-            Text(settings.localized(BuiltInSettingsPreset.allCases.map(\.detail).joined(separator: "\n\n") + " Selecting a preset changes only these listed settings."))
+            Text(settings.localized(BuiltInSettingsPreset.allCases.map(\.detail).joined(separator: "\n\n") + " Default restores global settings; other presets change only their listed settings."))
                 .lineLimit(nil)
                 .fixedSize(horizontal: false, vertical: true)
         }

--- a/platforms/ios/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift
@@ -207,9 +207,13 @@ struct VirtualPadSettingsView: View {
                     Text("\(settings.localized("Phone Rumble Strength")): \(Int(settings.phoneRumbleStrength * 100))%")
                     Slider(value: $settings.phoneRumbleStrength, in: 0.0...1.0, step: 0.05)
                 }
-                Text(settings.localized("How hard the phone itself rumbles when no controller is connected. Has no effect on a controller's own motors."))
+                Text(settings.localized("Controls the iPhone Taptic Engine when no controller is connected. 25% preserves the original Core Haptics intensity; 100% applies up to 3x gain, and 0% disables phone rumble. Has no effect on a controller's own motors."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
+
+                Toggle(
+                    settings.localized("Increase Duration of Rumble and Interpolation"),
+                    isOn: $settings.increaseRumbleDurationAndInterpolation)
             }
 
             Section(settings.localized("Layout")) {


### PR DESCRIPTION
# iOS: Adjustable Core Haptics, Quick Menu Stop, and Full Default Preset Reset

## Summary

This pull request contains three intentionally separated iOS commits:

1. **Adjustable Core Haptics, Extended Rumble Envelopes**
2. **Quick Menu Stop**
3. **Default Preset Reset All Settings**

The changes are rebased onto `origin/master` at `7345304c9adcbdda3da5841e503de9556ea29f1b`.

The commits are independent except that commits 1 and 3 both update `SettingsStore.swift`. They should therefore be applied in the order listed above. Each accompanying ZIP contains direct source files with their repository-relative paths and does not depend on a patch file.

## Commit 1 — Adjustable Core Haptics, Extended Rumble Envelopes

### User controls

The existing **Phone Rumble Strength** control under **Settings → Virtual Pad → Feedback** now has a meaningful phone-specific scale:

- `0%` disables iPhone haptics.
- `25%` is the original Core Haptics synthesis intensity and remains the default.
- Values from `25%` to `100%` progressively increase the synthesized Taptic Engine output.
- `100%` provides up to three times the original gain before Core Haptics values are clamped to the hardware-supported range.
- External-controller rumble remains unchanged.

A new **Increase Duration of Rumble and Interpolation** toggle controls the extended physical-motor simulation independently from strength. Turning the toggle off retains adjustable intensity but restores the original timing and release behavior.

### Rumble classification

Phone rumble is classified from the original PS2 motor command before the strength gain is applied:

- **Weak** effects preserve their normal duration. Above 75% strength they progressively gain the presence of a normal hard tap, reaching that level at 100% without acquiring a long release tail.
- **Medium** effects retain normal timing through 75%, then progressively reach a 2× release envelope at 100%.
- **Hard** effects begin gaining additional duration above 50%, reach approximately 2× at 75%, and reach a 3× release envelope at 100%.

This classification prevents the strength slider from flattening every effect into the same response. Small mechanical feedback, medium impacts, and heavy rumble remain distinguishable.

### Extended envelope and interpolation behavior

Longer effects do not stretch one fade over the entire extended duration. The implementation divides the release into two phases:

1. Hold the current force for the extra duration.
2. Run the original 1× fade interpolation at the end.

At the maximum setting:

- A 3× hard effect is felt for the additional 2× interval and then uses the original 1× fade.
- A 2× medium effect is felt for the additional 1× interval and then uses the original 1× fade.

The active release scale is stored per synthesized motor channel. Disabling duration extension immediately returns both channels to the original 1× release behavior, including the next stop event.

### Persistence and compatibility

- Both controls are persisted in the existing iOS settings INI.
- The new strength default is `25%`, matching the previous synthesized output.
- The implementation continues using the existing heavy/low-sharpness and light/high-sharpness Core Haptics channels.
- Intensity, gain, and duration scales are bounded before use.
- No additional polling loop or per-frame SwiftUI work is introduced.

### Files

- `platforms/ios/app/src/main/cpp/IOS/GamepadHaptics.mm`
- `platforms/ios/app/src/main/swift/Models/SettingsStore.swift`
- `platforms/ios/app/src/main/swift/Views/Settings/VirtualPadSettingsView.swift`

## Commit 2 — Quick Menu Stop

### Quick Menu action

The in-game Quick Menu now places a circular red **Stop** button immediately to the left of **Resume** in both portrait and landscape layouts.

- The portrait/regular menu footer contains Stop and Resume in one stable row.
- Compact and landscape presentations use the same stop affordance.
- Very narrow landscape layouts retain the circular stop control while Resume may remain icon-only.
- The stop control has a dedicated accessibility label.

### Confirmation and shutdown

Tapping Stop presents a destructive confirmation:

- Title: **Stop Emulation?**
- Message: **This will shut down the running game. All unsaved progress will be lost.**
- Actions: **Cancel** and destructive **Stop**

After confirmation, ARMSX2:

1. Plays the configured medium interface haptic when UI haptics are enabled.
2. Dismisses the Quick Menu overlay.
3. Requests the existing VM stop path through `ARMSX2Bridge.requestVMStop()`.

The change reuses the established emulator shutdown path instead of duplicating teardown logic.

### Files

- `platforms/ios/app/src/main/swift/Views/GameScreenView.swift`
- `platforms/ios/app/src/main/swift/Views/QuickMenuView.swift`

## Commit 3 — Default Preset Reset All Settings

### Destructive confirmation

Selecting **Settings → Settings Presets → Device Presets → Default** no longer changes settings immediately. It first presents:

- Title: **Reset Settings?**
- Description: **This will reset all settings to it's original values.**
- Actions: **Cancel** and destructive red **Reset Settings**

Cancel leaves the current configuration untouched. The other device presets remain immediate one-tap presets.

### Full default restoration

Confirming the reset restores fresh-install values across the global configuration surface:

- CPU, JIT, speedhacks, patches, cheats, game fixes, Fast Boot, and Emulation-Only Mode.
- Renderer, internal resolution, frame queue, filtering, post-processing, hardware fixes, texture replacement/dump switches, PCRTC, and shade boost.
- Audio synchronization, latency, buffering, volume, fast-forward audio, frame limiter, and frame-pacing preset.
- OSD preset, visibility, notification, and saved custom-overlay defaults.
- Virtual Pad opacity, phone rumble, haptics, combo zones, automatic visibility, fullscreen behavior, stick scale, and axis inversion.
- Dynamic Thumbsticks, swipe/gyro controls, Dynamic Actions, crosshair configuration, sensitivities, and gesture behavior.
- Portrait and landscape Virtual Pad positions, per-button overrides, and control visibility.
- External-controller button mappings and local multiplayer mode.
- DEV9 HDD and Ethernet configuration.
- Language, JIT helper behavior, and JIT script protocol.
- Dynamic Background selection, palettes/effects, custom background selection, fit modes, dimming, background visibility, Liquid Glass options, and Game-Card Zoom Animation.
- The built-in ARMSX2/White Colored Virtual Pad skin is selected as the default skin.

Frame pacing returns to the current fresh-install **Optimal** values, including the current queue/latency defaults, rather than restoring obsolete pre-migration values.

### Preserved user data

The reset is intentionally a configuration reset, not a data wipe. It does not delete:

- Imported games or BIOS files.
- Covers, save states, memory-card contents, PNACH files, or texture packs.
- Imported skins, user-created layouts, or preset files.
- RetroAchievements credentials or other account data.
- Saved access to the selected ARMSX2 import folder.

The active layout returns to its default positions, but stored layout preset files remain available.

### Persistence

All restored INI-backed settings are flushed after the reset. UserDefaults-backed appearance settings update immediately through their existing property observers.

### Files

- `platforms/ios/app/src/main/swift/Models/SettingsPresetCatalog.swift`
- `platforms/ios/app/src/main/swift/Models/SettingsStore.swift`
- `platforms/ios/app/src/main/swift/Views/Settings/SettingsPresetsView.swift`

## Performance and runtime impact

- The Core Haptics changes run only when translating a new phone-rumble command; they do not add emulation-frame work.
- Envelope extension reuses the existing Core Haptics players and two synthesized motor channels.
- The Quick Menu adds no background service. Its confirmation state exists only while the menu view is alive.
- The settings reset runs only after explicit user confirmation and has no gameplay steady-state cost.
- External-controller input and rumble paths are not modified by the phone-rumble strength controls.

## Validation

- Rebased cleanly onto `origin/master` at `7345304c9adcbdda3da5841e503de9556ea29f1b`.
- Source diff passes `git diff --check`.
- The unsigned iOS IPA is built with `platforms/ios/scripts/build-ios-ipa.sh` after packaging.


### Did you use AI to help find, test, or implement this issue or feature?
Yes, to generate the PR.MD