### PR TITLE
Load AetherSX2/NetherSX2 save states

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -871,6 +871,11 @@ static u32 cdvdRotationTime(CDVD_MODE_TYPE mode)
 	}
 }
 
+void cdvdRecalculateRotSpeed()
+{
+	cdvd.RotSpeed = cdvdRotationTime(static_cast<CDVD_MODE_TYPE>(cdvdIsDVD()));
+}
+
 static uint cdvdBlockReadTime(CDVD_MODE_TYPE mode) noexcept
 {
 	// CAV Read speed is roughly 41% in the centre full speed on outer edge. I imagine it's more logarithmic than this

--- a/pcsx2/CDVD/CDVD.h
+++ b/pcsx2/CDVD/CDVD.h
@@ -170,6 +170,9 @@ extern void cdvdLoadNVRAM();
 extern void cdvdSaveNVRAM();
 extern void cdvdReset();
 extern void cdvdVsync();
+// Recomputes cdvd.RotSpeed for the current disc type; used when restoring
+// state that predates the field (legacy savestates).
+extern void cdvdRecalculateRotSpeed();
 extern void cdvdActionInterrupt();
 extern void cdvdSectorReady();
 extern void cdvdReadInterrupt();

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -268,6 +268,7 @@ set(pcsx2SPU2Sources
 	SPU2/RegTable.cpp
 	SPU2/Reverb.cpp
 	SPU2/spu2freeze.cpp
+	SPU2/spu2freeze-legacy.cpp
 	SPU2/spu2sys.cpp
 	SPU2/Wavedump_wav.cpp
 )

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -108,6 +108,7 @@ set(pcsx2Sources
 	R5900OpcodeImpl.cpp
 	R5900OpcodeTables.cpp
 	SaveState.cpp
+	SaveStateLegacy.cpp
 	ShiftJisToUnicode.cpp
 	Sif.cpp
 	Sif0.cpp
@@ -190,6 +191,7 @@ set(pcsx2Headers
 	R5900.h
 	R5900OpcodeTables.h
 	SaveState.h
+	SaveStateLegacy.h
 	ShaderCacheVersion.h
 	Sifcmd.h
 	Sif.h

--- a/pcsx2/SPU2/spu2.h
+++ b/pcsx2/SPU2/spu2.h
@@ -86,6 +86,10 @@ u16 SPU2read(u32 mem);
 void SPU2async();
 s32 SPU2freeze(FreezeAction mode, freezeData* data);
 
+// Partial restore from a legacy-format (AetherSX2-era) SPU2 block, whose tail
+// cannot be replayed. See the definition for what is and is not kept.
+s32 SPU2freezeLegacy(const void* data, size_t size);
+
 void SPU2readDMA4Mem(u16* pMem, u32 size);
 void SPU2writeDMA4Mem(u16* pMem, u32 size);
 void SPU2interruptDMA4();

--- a/pcsx2/SPU2/spu2freeze-legacy.cpp
+++ b/pcsx2/SPU2/spu2freeze-legacy.cpp
@@ -1,0 +1,491 @@
+// SPDX-FileCopyrightText: 2026 yaps2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+// Restores the SPU2 block of an AetherSX2/NetherSX2-era save state. The block
+// is a raw memcpy of that era's SPU2 globals, so it is read here as byte-exact
+// era structures and mapped field-by-field onto today's; nothing about it can
+// go through the normal thaw path. Kept out of spu2freeze.cpp so that the file
+// upstream maintains stays untouched.
+
+#include "SPU2/defs.h"
+#include "SPU2/spu2.h"
+#include "IopHw.h"
+#include "IopMem.h"
+#include "R3000A.h"
+
+#include "common/Console.h"
+
+#include <cstring>
+
+// The core and voice structures as AetherSX2-era builds wrote them. Layout per
+// upstream PCSX2 7e939b75 (pcsx2/SPU2/defs.h); the 0x9A2C era at 0312e902 has
+// the identical layout, differing only in method declarations and in the
+// signedness of names outside V_Core, none of which moves a field. Sizes are
+// static_asserted below against the offsets the format walker measured on real
+// files, so a host-ABI surprise fails the build rather than the load.
+namespace LegacySPU2
+{
+	struct VolumeLR
+	{
+		s32 Left;
+		s32 Right;
+	};
+
+	// Superseded by a bitfield-plus-Counter form; only the register value and
+	// the current level survive into it, and the bitfields decode from the
+	// register value for free because they union with it.
+	struct VolumeSlide
+	{
+		s16 Reg_VOL;
+		s32 Value;
+		s8 Increment;
+		s8 Mode;
+	};
+
+	struct VolumeSlideLR
+	{
+		VolumeSlide Left;
+		VolumeSlide Right;
+	};
+
+	// Widened to s32 since. u128-aligned in the original via a union overlay
+	// that nothing reads back.
+	struct VoiceGates
+	{
+		s16 DryL, DryR, WetL, WetR;
+	};
+
+	// The original overlays these on a u128 — two u64s, so 8-aligned, which
+	// pads the gates out from the voice gates that precede them. Getting this
+	// wrong slides the gates and all four volumes 4 bytes without changing the
+	// size of the core, because the alignment padding in front of the voice
+	// array silently absorbs it.
+	struct alignas(8) CoreGates
+	{
+		s16 InpL, InpR, SndL, SndR, ExtL, ExtR;
+		s16 _u128_overlay_pad[2];
+	};
+
+	struct ADSR
+	{
+		u32 reg32;
+		s32 Value;
+		u8 Phase;
+		bool Releasing;
+	};
+
+	// Maps field-for-field except the decoder internals: the sample-decode
+	// pipeline was re-architected since (PV1..PV4/SCurrent gave way to a decode
+	// FIFO), so the position inside the current 28-sample block does not carry
+	// across and the block restarts — a sub-millisecond hiccup per voice, once.
+	struct Voice
+	{
+		u32 PlayCycle;
+		u32 LoopCycle;
+		u32 PendingLoopStartA;
+		bool PendingLoopStart;
+		VolumeSlideLR Volume;
+		ADSR Adsr;
+		u16 Pitch;
+		u32 LoopStartA;
+		u32 StartA;
+		u32 NextA;
+		s32 Prev1;
+		s32 Prev2;
+		bool Modulated;
+		bool Noise;
+		s8 LoopMode;
+		s8 LoopFlags;
+		s32 SP;
+		s32 SPc;
+		s32 PV4;
+		s32 PV3;
+		s32 PV2;
+		s32 PV1;
+		s32 OutX;
+		s32 NextCrest;
+		u64 SBuffer; // s16* in the original — a host pointer, never dereferenced
+		s32 SCurrent;
+	};
+
+	struct Reverb
+	{
+		s16 IN_COEF_L, IN_COEF_R;
+		u32 APF1_SIZE, APF2_SIZE;
+		s16 APF1_VOL, APF2_VOL;
+		u32 SAME_L_SRC, SAME_R_SRC, DIFF_L_SRC, DIFF_R_SRC;
+		u32 SAME_L_DST, SAME_R_DST, DIFF_L_DST, DIFF_R_DST;
+		s16 IIR_VOL, WALL_VOL;
+		u32 COMB1_L_SRC, COMB1_R_SRC, COMB2_L_SRC, COMB2_R_SRC;
+		u32 COMB3_L_SRC, COMB3_R_SRC, COMB4_L_SRC, COMB4_R_SRC;
+		s16 COMB1_VOL, COMB2_VOL, COMB3_VOL, COMB4_VOL;
+		u32 APF1_L_DST, APF1_R_DST, APF2_L_DST, APF2_R_DST;
+	};
+
+	// Pre-clipped reverb pointers, dropped since — recomputed on demand now.
+	struct ReverbBuffers
+	{
+		s32 _offsets[28];
+		bool NeedsUpdated;
+	};
+
+	struct CoreRegs
+	{
+		u32 PMON, NON, VMIXL, VMIXR, VMIXEL, VMIXER, ENDX;
+		u16 MMIX, STATX, ATTR, _1AC;
+	};
+
+	struct Core
+	{
+		u32 Index;
+		VoiceGates VoiceGates_[24];
+		CoreGates DryGate;
+		CoreGates WetGate;
+		VolumeSlideLR MasterVol;
+		VolumeLR ExtVol;
+		VolumeLR InpVol;
+		VolumeLR FxVol;
+		Voice Voices[24];
+		u32 IRQA;
+		u32 TSA;
+		u32 ActiveTSA;
+		bool IRQEnable;
+		bool FxEnable;
+		bool Mute;
+		bool AdmaInProgress;
+		s8 DMABits;
+		u8 NoiseClk;
+		u32 NoiseCnt;
+		u32 NoiseOut;
+		u16 AutoDMACtrl;
+		s32 DMAICounter;
+		u32 LastClock;
+		u32 InputDataLeft;
+		u32 InputDataTransferred;
+		u32 InputPosWrite;
+		u32 InputDataProgress;
+		Reverb Revb;
+		ReverbBuffers RevBuffers;
+		s32 RevbDownBuf[2][64];
+		s32 RevbUpBuf[2][64];
+		u32 RevbSampleBufPos;
+		u32 EffectsStartA;
+		u32 EffectsEndA;
+		u32 ExtEffectsStartA;
+		u32 ExtEffectsEndA;
+		u32 ReverbX;
+		s32 EffectsBufferSize;
+		u32 EffectsBufferStart;
+		CoreRegs Regs;
+		s32 LastEffectLeft, LastEffectRight;
+		u8 CoreEnabled;
+		u8 AttrBit0;
+		u8 DmaMode;
+		bool DmaStarted;
+		u32 AutoDmaFree;
+		u64 DMAPtr; // u16* in the original — a host pointer, never dereferenced
+		u64 DMARPtr; // ditto
+		u32 ReadSize;
+		bool IsDMARead;
+		u32 KeyOn;
+		u16 psxSoundDataTransferControl;
+		u16 psxSPUSTAT;
+	};
+
+	struct Tail
+	{
+		u16 SpdifOut, SpdifInfo, SpdifUnknown1, SpdifMode;
+		u16 SpdifMedia, SpdifUnknown2, SpdifProtection;
+		u16 OutPos;
+		u16 InputPos;
+		u32 Cycles;
+		u32 lClocks;
+		int PlayMode;
+	};
+
+	static_assert(sizeof(Voice) == 128, "legacy V_Voice is 128 bytes");
+	static_assert(offsetof(Core, DMAPtr) == 4744, "legacy V_Core DMA pointers sit at +4744");
+	static_assert(sizeof(Core) == 4776, "legacy V_Core is 4776 bytes");
+	static_assert(sizeof(Tail) == 32, "legacy SPU2 tail is 32 bytes");
+
+	// The size and the DMA-pointer offset above both sit past the voice array,
+	// whose 8-byte alignment absorbs any drift in front of it — so neither can
+	// see a mis-sized gate or volume. These pin the region they are blind to.
+	static_assert(offsetof(Core, DryGate) == 200, "gates follow the voice gates on an 8-byte boundary");
+	static_assert(offsetof(Core, MasterVol) == 232, "master volume follows both core gates");
+	static_assert(offsetof(Core, ExtVol) == 256, "the three plain volumes follow master volume");
+	static_assert(offsetof(Core, Voices) == 280, "the voice array closes the mixer region");
+	static_assert(offsetof(Core, Revb) == 3408, "reverb registers follow the DMA and noise scalars");
+	static_assert(offsetof(Core, Regs) == 4688, "core registers follow the reverb buffers");
+
+	// A volume slide keeps its register value and its current level; the slide
+	// bitfields overlay the register value, and the ramp counter restarts.
+	//
+	// Every volume level in these eras is 31-bit (Max = 0x7FFFFFFF); today's
+	// mixer runs them at 15 bits (Max = 0x7FFF) and multiplies in s32. A raw
+	// copy is therefore not one binade loud — it overflows the multiply, and
+	// every sample in the mix comes out as sign-flipped hash. This was the
+	// "static" that survived every other bisect: a full-volume legacy level
+	// amplifies anything, even a freshly reset core's near-silence, into
+	// full-scale broadband noise.
+	static V_VolumeSlide MapVolumeSlide(const VolumeSlide& src)
+	{
+		V_VolumeSlide dst;
+		dst.Reg_VOL = static_cast<u16>(src.Reg_VOL);
+		dst.Counter = 0;
+		dst.Value = src.Value >> 16;
+		return dst;
+	}
+
+	static V_VolumeLR MapVolume(const VolumeLR& src)
+	{
+		V_VolumeLR dst;
+		dst.Left = src.Left >> 16;
+		dst.Right = src.Right >> 16;
+		return dst;
+	}
+
+	// The envelope value was 31-bit then and is 15-bit now, and the phase walked
+	// attack=1 through release-end=6 with a separate Releasing flag, where today
+	// release is a phase of its own. The flag folds in exactly as the era's own
+	// Calculate() folded it on entry; the two terminal phases (sustain-end,
+	// release-end) land on stopped with the envelope at zero.
+	static void MapVoice(V_Voice& dst, const Voice& src)
+	{
+		dst.Volume.Left = MapVolumeSlide(src.Volume.Left);
+		dst.Volume.Right = MapVolumeSlide(src.Volume.Right);
+
+		dst.ADSR.reg32 = src.Adsr.reg32;
+		dst.ADSR.UpdateCache();
+		dst.ADSR.Counter = 0;
+		dst.ADSR.Value = src.Adsr.Value >> 16;
+
+		u8 phase = src.Adsr.Phase;
+		if (src.Adsr.Releasing && phase < 5)
+			phase = 5;
+		switch (phase)
+		{
+			case 1:
+				dst.ADSR.Phase = V_ADSR::PHASE_ATTACK;
+				break;
+			case 2:
+				dst.ADSR.Phase = V_ADSR::PHASE_DECAY;
+				break;
+			case 3:
+				dst.ADSR.Phase = V_ADSR::PHASE_SUSTAIN;
+				break;
+			case 5:
+				dst.ADSR.Phase = V_ADSR::PHASE_RELEASE;
+				break;
+			default:
+				dst.ADSR.Phase = V_ADSR::PHASE_STOPPED;
+				dst.ADSR.Value = 0;
+				break;
+		}
+
+		dst.Pitch = src.Pitch;
+		dst.LoopStartA = src.LoopStartA;
+		dst.StartA = src.StartA;
+		dst.NextA = src.NextA;
+		dst.Prev1 = src.Prev1;
+		dst.Prev2 = src.Prev2;
+		dst.Modulated = src.Modulated;
+		dst.Noise = src.Noise;
+		dst.LoopMode = src.LoopMode;
+		dst.LoopFlags = src.LoopFlags;
+		dst.SP = src.SP;
+		dst.OutX = src.OutX;
+
+		// As the native thaw does: point the decode buffer at the cache entry
+		// for the current read address (Sampledata is an array member, so the
+		// pointer stays valid across the cache wipe). The index is masked
+		// because NextA comes off disk.
+		dst.SBuffer = pcm_cache_data[(dst.NextA & 0xFFFFF) / pcm_WordsPerBlock].Sampledata;
+	}
+
+	// Restores a core from the era block. The mixer configuration is state a
+	// game writes once — at boot, or on a scene change — and then never again,
+	// so resetting it and waiting for the game means waiting forever: master
+	// volume stays zero and the console stays silent for the session. The
+	// streaming and DMA state is state the restored IOP driver believes is
+	// live: left at reset, the driver waits forever for a completion interrupt
+	// no counter is going to deliver, while the input ring loops its last
+	// half-filled window as broadband noise under whatever else is playing.
+	static void RestoreCore(V_Core& dst, const Core& src)
+	{
+		for (uint v = 0; v < V_Core::NumVoices; v++)
+		{
+			dst.VoiceGates[v].DryL = src.VoiceGates_[v].DryL;
+			dst.VoiceGates[v].DryR = src.VoiceGates_[v].DryR;
+			dst.VoiceGates[v].WetL = src.VoiceGates_[v].WetL;
+			dst.VoiceGates[v].WetR = src.VoiceGates_[v].WetR;
+			MapVoice(dst.Voices[v], src.Voices[v]);
+		}
+
+		const auto map_core_gate = [](V_CoreGates& d, const CoreGates& s) {
+			d.InpL = s.InpL;
+			d.InpR = s.InpR;
+			d.SndL = s.SndL;
+			d.SndR = s.SndR;
+			d.ExtL = s.ExtL;
+			d.ExtR = s.ExtR;
+		};
+		map_core_gate(dst.DryGate, src.DryGate);
+		map_core_gate(dst.WetGate, src.WetGate);
+
+		dst.MasterVol.Left = MapVolumeSlide(src.MasterVol.Left);
+		dst.MasterVol.Right = MapVolumeSlide(src.MasterVol.Right);
+		dst.ExtVol = MapVolume(src.ExtVol);
+		dst.InpVol = MapVolume(src.InpVol);
+		dst.FxVol = MapVolume(src.FxVol);
+
+		dst.IRQA = src.IRQA;
+		dst.IRQEnable = src.IRQEnable;
+		dst.FxEnable = src.FxEnable;
+		dst.Mute = src.Mute;
+		dst.NoiseClk = src.NoiseClk;
+
+		// Reverb registers are byte-identical across the eras; the pre-clipped
+		// buffer pointers beside them are derived on demand now, and the filter
+		// history is transient, so both stay at their reset values.
+		static_assert(sizeof(Reverb) == sizeof(V_Reverb), "reverb registers did not change shape");
+		std::memcpy(&dst.Revb, &src.Revb, sizeof(V_Reverb));
+		dst.EffectsStartA = src.EffectsStartA;
+		dst.EffectsEndA = src.EffectsEndA;
+
+		static_assert(sizeof(CoreRegs) == sizeof(V_CoreRegs), "core registers did not change shape");
+		std::memcpy(&dst.Regs, &src.Regs, sizeof(V_CoreRegs));
+
+		dst.CoreEnabled = src.CoreEnabled;
+		dst.AttrBit0 = src.AttrBit0;
+		dst.psxSoundDataTransferControl = src.psxSoundDataTransferControl;
+		dst.psxSPUSTAT = src.psxSPUSTAT;
+
+		// The streaming input path and the in-flight DMA. The IOP driver on
+		// the other side of the restored RAM armed all of this and is
+		// waiting on its completion interrupt; CheckDMAProgress() picks the
+		// counters up and delivers it.
+		dst.TSA = src.TSA;
+		dst.ActiveTSA = src.ActiveTSA;
+		dst.AdmaInProgress = src.AdmaInProgress;
+		dst.DMABits = src.DMABits;
+		dst.AutoDMACtrl = src.AutoDMACtrl;
+		dst.InputDataLeft = src.InputDataLeft;
+		dst.InputDataTransferred = src.InputDataTransferred;
+		dst.InputPosWrite = src.InputPosWrite;
+		dst.InputDataProgress = src.InputDataProgress;
+		dst.DmaMode = src.DmaMode;
+		dst.DmaStarted = src.DmaStarted;
+		dst.AutoDmaFree = src.AutoDmaFree;
+		dst.ReadSize = src.ReadSize;
+		dst.IsDMARead = src.IsDMARead;
+		dst.KeyOn = src.KeyOn;
+		dst.DMAICounter = src.DMAICounter;
+		dst.LastClock = psxRegs.cycle;
+
+		// These eras memcpy'd the whole core into the block, so its two DMA
+		// pointers are raw pointers into another process. Left null, the
+		// write path rebuilds its own from the restored IOP-side DMA
+		// registers (the savestate HACKFIX in AutoDMAReadBuffer and
+		// FinishDMAwrite); the read path dereferences without that heal, so
+		// rebuild it here — the era stored the transfer's end address in the
+		// channel TADR register, and ReadSize words of it remain.
+		dst.DMAPtr = nullptr;
+		dst.DMARPtr = nullptr;
+		if (dst.IsDMARead && dst.ReadSize)
+		{
+			const u32 tadr = (dst.Index == 0) ? HW_DMA4_TADR : HW_DMA7_TADR;
+			dst.DMARPtr = reinterpret_cast<u16*>(iopPhysMem((tadr - dst.ReadSize * 2) & 0x1FFFFF));
+		}
+	}
+
+	// The head of the block is era-invariant: the save id, 64KB of raw register
+	// memory, 2MB of sample memory, then the self-version. Only the tail
+	// (V_Core/V_Voice, and the mixer scalars after it) has been re-laid-out
+	// upstream, repeatedly, without the self-version ever being bumped — so the
+	// self-version cannot arbitrate the tail and SPU2Savestate::ThawIt must
+	// never see one of these blocks.
+	static constexpr size_t UNKREGS_OFFSET = 4;
+	static constexpr size_t MEM_OFFSET = 0x10004;
+	static constexpr size_t VERSION_OFFSET = 0x210004;
+	static constexpr size_t CORES_OFFSET = 0x210008;
+	static constexpr size_t BLOCK_SIZE = CORES_OFFSET + 2 * sizeof(Core) + sizeof(Tail);
+	static_assert(BLOCK_SIZE == 2172280, "every AetherSX2-era SPU2 block is this size");
+
+	// The id and self-version every AetherSX2/NetherSX2-written block carries.
+	// Spelled out rather than shared with the current save path so that bumping
+	// ours does not silently start rejecting legacy files.
+	static constexpr u32 SAVE_ID = 0x1227521;
+	static constexpr u32 SAVE_VERSION = 0x000e;
+} // namespace LegacySPU2
+
+// Restores register and sample memory, and — mapped field-by-field through
+// RestoreCore — each core's mixer, voice, streaming and DMA state, then the
+// SPDIF/ring/playmode tail. What does not carry across is each voice's position
+// inside its current 28-sample decode block, and the two host DMA pointers,
+// which the engine rebuilds from the restored IOP-side DMA registers.
+s32 SPU2freezeLegacy(const void* data, size_t size)
+{
+	using namespace LegacySPU2;
+
+	if (size != BLOCK_SIZE)
+	{
+		Console.Error("(LegacyState) SPU2 block is %zu bytes, not the %zu an AetherSX2-era block occupies.",
+			size, BLOCK_SIZE);
+		return -1;
+	}
+
+	const u8* const block = static_cast<const u8*>(data);
+	u32 id, version;
+	std::memcpy(&id, block, sizeof(id));
+	std::memcpy(&version, block + VERSION_OFFSET, sizeof(version));
+
+	if (id != SAVE_ID || version != SAVE_VERSION)
+	{
+		Console.Error("(LegacyState) SPU2 block is not an AetherSX2-era block (id %08X, version %X).", id, version);
+		return -1;
+	}
+
+	// Wipes the register and sample memory and re-inits both cores, so it has
+	// to happen before the memory is copied back in.
+	SPU2::Reset(false);
+
+	std::memcpy(spu2regs, block + UNKREGS_OFFSET, 0x10000);
+	std::memcpy(_spu2mem, block + MEM_OFFSET, 0x200000);
+
+	// The block came out of a zip read buffer, so copy each structure out
+	// rather than reading it in place at an unknown alignment.
+	for (int c = 0; c < 2; c++)
+	{
+		Core core;
+		std::memcpy(&core, block + CORES_OFFSET + c * sizeof(core), sizeof(core));
+		RestoreCore(Cores[c], core);
+	}
+
+	// The digital-output registers, the input ring positions, the sample
+	// counter and the play mode — kept coherent with the ring contents and
+	// stream counters restored above. lClocks is resynced below instead of
+	// taken from the block: it was 32 bits in these eras, and the resync
+	// against the restored IOP clock is exact anyway.
+	Tail tail;
+	std::memcpy(&tail, block + CORES_OFFSET + 2 * sizeof(Core), sizeof(tail));
+	Spdif.Out = tail.SpdifOut;
+	Spdif.Info = tail.SpdifInfo;
+	Spdif.Unknown1 = tail.SpdifUnknown1;
+	Spdif.Mode = tail.SpdifMode;
+	Spdif.Media = tail.SpdifMedia;
+	Spdif.Unknown2 = tail.SpdifUnknown2;
+	Spdif.Protection = tail.SpdifProtection;
+	OutPos = tail.OutPos;
+	InputPos = tail.InputPos;
+	Cycles = tail.Cycles;
+	PlayMode = tail.PlayMode;
+
+	// The ADPCM decode cache indexes sample memory, which just changed under
+	// it. (The native thaw wipes it for the same reason.)
+	std::memset(pcm_cache_data, 0, pcm_BlockCount * sizeof(PcmCacheEntry));
+
+	lClocks = psxRegs.cycle;
+
+	return 0;
+}

--- a/pcsx2/SPU2/spu2freeze.cpp
+++ b/pcsx2/SPU2/spu2freeze.cpp
@@ -4,9 +4,6 @@
 #include "SPU2/defs.h"
 #include "SPU2/spu2.h" // hopefully temporary, until I resolve lClocks depdendency
 #include "IopMem.h"
-#include "R3000A.h"
-
-#include "common/Console.h"
 
 #include <cstring>
 
@@ -166,58 +163,4 @@ s32 SPU2Savestate::ThawIt(DataBlock& spud)
 s32 SPU2Savestate::SizeIt()
 {
 	return sizeof(DataBlock);
-}
-
-s32 SPU2freezeLegacy(const void* data, size_t size)
-{
-	using namespace SPU2Savestate;
-
-	// The head of the block is era-invariant: the save id, 64KB of raw
-	// register memory, 2MB of sample memory, then the self-version. Only the
-	// tail (V_Core/V_Voice, and the mixer scalars after it) has been re-laid
-	// out upstream, repeatedly, without the self-version ever being bumped —
-	// so the self-version cannot arbitrate the tail and ThawIt must never see
-	// one of these blocks.
-	//
-	// Restored: register and sample memory. Not restored: the decoded core and
-	// voice state, which is reset instead. Voices restart silent and pick the
-	// game's state back up as it writes registers; a mid-note load loses the
-	// note. Replaying the old core layout is a fidelity pass we have not done.
-	static constexpr size_t LEGACY_UNKREGS_OFFSET = 4;
-	static constexpr size_t LEGACY_MEM_OFFSET = 0x10004;
-	static constexpr size_t LEGACY_VERSION_OFFSET = 0x210004;
-	static constexpr size_t LEGACY_HEAD_SIZE = 0x210008;
-	// The self-version in every AetherSX2/NetherSX2-written block. Spelled out
-	// rather than compared against SAVE_VERSION so that bumping ours does not
-	// silently start rejecting legacy files.
-	static constexpr u32 LEGACY_SAVE_VERSION = 0x000e;
-
-	if (size < LEGACY_HEAD_SIZE)
-	{
-		Console.Error("(LegacyState) SPU2 block is %zu bytes, too short to hold register and sample memory.", size);
-		return -1;
-	}
-
-	const u8* const block = static_cast<const u8*>(data);
-	u32 id, version;
-	std::memcpy(&id, block, sizeof(id));
-	std::memcpy(&version, block + LEGACY_VERSION_OFFSET, sizeof(version));
-
-	if (id != SAVE_ID || version != LEGACY_SAVE_VERSION)
-	{
-		Console.Error("(LegacyState) SPU2 block is not an AetherSX2-era block (id %08X, version %X).", id, version);
-		return -1;
-	}
-
-	// Wipes the register and sample memory and re-inits both cores, so it has
-	// to happen before the memory is copied back in.
-	SPU2::Reset(false);
-
-	std::memcpy(spu2regs, block + LEGACY_UNKREGS_OFFSET, 0x10000);
-	std::memcpy(_spu2mem, block + LEGACY_MEM_OFFSET, 0x200000);
-
-	wipe_the_cache();
-	lClocks = psxRegs.cycle;
-
-	return 0;
 }

--- a/pcsx2/SPU2/spu2freeze.cpp
+++ b/pcsx2/SPU2/spu2freeze.cpp
@@ -4,6 +4,9 @@
 #include "SPU2/defs.h"
 #include "SPU2/spu2.h" // hopefully temporary, until I resolve lClocks depdendency
 #include "IopMem.h"
+#include "R3000A.h"
+
+#include "common/Console.h"
 
 #include <cstring>
 
@@ -163,4 +166,58 @@ s32 SPU2Savestate::ThawIt(DataBlock& spud)
 s32 SPU2Savestate::SizeIt()
 {
 	return sizeof(DataBlock);
+}
+
+s32 SPU2freezeLegacy(const void* data, size_t size)
+{
+	using namespace SPU2Savestate;
+
+	// The head of the block is era-invariant: the save id, 64KB of raw
+	// register memory, 2MB of sample memory, then the self-version. Only the
+	// tail (V_Core/V_Voice, and the mixer scalars after it) has been re-laid
+	// out upstream, repeatedly, without the self-version ever being bumped —
+	// so the self-version cannot arbitrate the tail and ThawIt must never see
+	// one of these blocks.
+	//
+	// Restored: register and sample memory. Not restored: the decoded core and
+	// voice state, which is reset instead. Voices restart silent and pick the
+	// game's state back up as it writes registers; a mid-note load loses the
+	// note. Replaying the old core layout is a fidelity pass we have not done.
+	static constexpr size_t LEGACY_UNKREGS_OFFSET = 4;
+	static constexpr size_t LEGACY_MEM_OFFSET = 0x10004;
+	static constexpr size_t LEGACY_VERSION_OFFSET = 0x210004;
+	static constexpr size_t LEGACY_HEAD_SIZE = 0x210008;
+	// The self-version in every AetherSX2/NetherSX2-written block. Spelled out
+	// rather than compared against SAVE_VERSION so that bumping ours does not
+	// silently start rejecting legacy files.
+	static constexpr u32 LEGACY_SAVE_VERSION = 0x000e;
+
+	if (size < LEGACY_HEAD_SIZE)
+	{
+		Console.Error("(LegacyState) SPU2 block is %zu bytes, too short to hold register and sample memory.", size);
+		return -1;
+	}
+
+	const u8* const block = static_cast<const u8*>(data);
+	u32 id, version;
+	std::memcpy(&id, block, sizeof(id));
+	std::memcpy(&version, block + LEGACY_VERSION_OFFSET, sizeof(version));
+
+	if (id != SAVE_ID || version != LEGACY_SAVE_VERSION)
+	{
+		Console.Error("(LegacyState) SPU2 block is not an AetherSX2-era block (id %08X, version %X).", id, version);
+		return -1;
+	}
+
+	// Wipes the register and sample memory and re-inits both cores, so it has
+	// to happen before the memory is copied back in.
+	SPU2::Reset(false);
+
+	std::memcpy(spu2regs, block + LEGACY_UNKREGS_OFFSET, 0x10000);
+	std::memcpy(_spu2mem, block + LEGACY_MEM_OFFSET, 0x200000);
+
+	wipe_the_cache();
+	lClocks = psxRegs.cycle;
+
+	return 0;
 }

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -1136,7 +1136,7 @@ bool SaveState_ReadScreenshot(const std::string& filename, u32* out_width, u32* 
 	return SaveState_ReadScreenshot(zf.get(), out_width, out_height, out_pixels);
 }
 
-static bool CheckVersion(const std::string& filename, zip_t* zf, Error* error)
+static bool CheckVersion(const std::string& filename, zip_t* zf, u32* out_savever, Error* error)
 {
 	u32 savever;
 
@@ -1146,6 +1146,8 @@ static bool CheckVersion(const std::string& filename, zip_t* zf, Error* error)
 		Error::SetString(error, "Savestate file does not contain version indicator.");
 		return false;
 	}
+
+	*out_savever = savever;
 
 	char version_string[STATE_PCSX2_VERSION_SIZE];
 	if (zip_fread(zff.get(), version_string, STATE_PCSX2_VERSION_SIZE) == STATE_PCSX2_VERSION_SIZE)
@@ -1192,7 +1194,7 @@ static zip_int64_t CheckFileExistsInState(zip_t* zf, const char* name, bool requ
 	return index;
 }
 
-static bool LoadInternalStructuresState(zip_t* zf, s64 index, Error* error)
+static bool LoadInternalStructuresState(zip_t* zf, s64 index, u32 savever, Error* error)
 {
 	zip_stat_t zst;
 	if (zip_stat_index(zf, index, 0, &zst) != 0 || zst.size > std::numeric_limits<int>::max())
@@ -1208,9 +1210,10 @@ static bool LoadInternalStructuresState(zip_t* zf, s64 index, Error* error)
 		return false;
 
 	memLoadingState state(buffer);
+	state.SetVersion(savever);
 	if (!state.FreezeBios())
 		return false;
-	
+
 	if (!state.FreezeInternals(error))
 		return false;
 
@@ -1266,7 +1269,8 @@ static bool SaveState_UnzipFromZip(zip_t* zf_raw, const std::string& filename, E
 	} zf{zf_raw};
 
 	// look for version and screenshot information in the zip stream:
-	if (!CheckVersion(filename, zf.get(), error))
+	u32 savever = 0;
+	if (!CheckVersion(filename, zf.get(), &savever, error))
 		return false;
 
 	// check that all parts are included
@@ -1293,7 +1297,7 @@ static bool SaveState_UnzipFromZip(zip_t* zf_raw, const std::string& filename, E
 
 	PreLoadPrep();
 
-	if (!LoadInternalStructuresState(zf.get(), internal_index, error))
+	if (!LoadInternalStructuresState(zf.get(), internal_index, savever, error))
 	{
 		if (!error->IsValid())
 			Error::SetString(error, "Save state corruption in internal structures.");

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -25,6 +25,7 @@
 #include "SIO/Sio2.h"
 #include "SPU2/spu2.h"
 #include "SaveState.h"
+#include "SaveStateLegacy.h"
 #include "StateWrapper.h"
 #include "USB/USB.h"
 #include "VMManager.h"
@@ -357,16 +358,28 @@ static int SysState_MTGSFreeze(FreezeAction mode, freezeData* fP)
 static constexpr SysState_Component SPU2_{ "SPU2", SPU2freeze };
 static constexpr SysState_Component GS{ "GS", SysState_MTGSFreeze };
 
-static bool SysState_ComponentFreezeIn(zip_file_t* zf, SysState_Component comp)
+// `entry_size`, when non-zero, sizes the read from the state file's entry
+// rather than from the component. That is what a legacy block needs: it is
+// whatever size its era wrote, and the component's own version check is what
+// arbitrates it.
+static bool SysState_ComponentFreezeIn(zip_file_t* zf, SysState_Component comp, u32 entry_size = 0)
 {
 	if (!zf)
 		return true;
 
 	freezeData fP = { 0, nullptr };
-	if (comp.freeze(FreezeAction::Size, &fP) != 0)
-		fP.size = 0;
+	if (entry_size > 0)
+	{
+		fP.size = static_cast<int>(entry_size);
+		Console.WriteLn("  Loading %s (legacy format, %d bytes)", comp.name, fP.size);
+	}
+	else
+	{
+		if (comp.freeze(FreezeAction::Size, &fP) != 0)
+			fP.size = 0;
 
-	Console.WriteLn("  Loading %s", comp.name);
+		Console.WriteLn("  Loading %s", comp.name);
+	}
 
 	std::unique_ptr<u8[]> data;
 	if (fP.size > 0)
@@ -469,6 +482,15 @@ public:
 	virtual bool FreezeIn(zip_file_t* zf) const = 0;
 	virtual bool FreezeOut(SaveStateBase& writer) const = 0;
 	virtual bool IsRequired() const = 0;
+
+	// Whether this entry can be carried over from a legacy-format
+	// (AetherSX2-era) save state. When it cannot, the component keeps the
+	// state it booted with, and the entry is not required to be present.
+	virtual bool SupportsLegacy() const { return true; }
+
+	// Loads the entry from a legacy-format state. `size` is the entry's actual
+	// size, which for components whose block changed size is not today's.
+	virtual bool FreezeInLegacy(zip_file_t* zf, u32 size) const { return FreezeIn(zf); }
 };
 
 class MemorySavestateEntry : public BaseSavestateEntry
@@ -619,6 +641,20 @@ public:
 	bool FreezeIn(zip_file_t* zf) const override { return SysState_ComponentFreezeIn(zf, SPU2_); }
 	bool FreezeOut(SaveStateBase& writer) const override { return SysState_ComponentFreezeOut(writer, SPU2_); }
 	bool IsRequired() const override { return true; }
+
+	// The block's self-version never moved while its tail was re-laid-out, so
+	// it cannot go through the normal reader; SPU2freezeLegacy maps that era's
+	// layout across instead. It is read whole, because the layout is a fixed
+	// size that the mapper checks for itself.
+	bool FreezeInLegacy(zip_file_t* zf, u32 /*size*/) const override
+	{
+		const std::optional<std::vector<u8>> data(ReadBinaryFileInZip(zf));
+		if (!data.has_value())
+			return false;
+
+		Console.WriteLn("  Loading SPU2 (legacy format, %zu bytes)", data->size());
+		return SPU2freezeLegacy(data->data(), data->size()) == 0;
+	}
 };
 
 class SavestateEntry_USB final : public BaseSavestateEntry
@@ -630,6 +666,9 @@ public:
 	bool FreezeIn(zip_file_t* zf) const override { return SysState_ComponentFreezeInNew(zf, "USB", &USB::DoState); }
 	bool FreezeOut(SaveStateBase& writer) const override { return SysState_ComponentFreezeOutNew(writer, "USB", 16 * 1024, &USB::DoState); }
 	bool IsRequired() const override { return false; }
+
+	// Legacy states predate the StateWrapper stream this reads.
+	bool SupportsLegacy() const override { return false; }
 };
 
 class SavestateEntry_PAD final : public BaseSavestateEntry
@@ -641,17 +680,25 @@ public:
 	bool FreezeIn(zip_file_t* zf) const override { return SysState_ComponentFreezeInNew(zf, "PAD", &Pad::Freeze); }
 	bool FreezeOut(SaveStateBase& writer) const override { return SysState_ComponentFreezeOutNew(writer, "PAD", 16 * 1024, &Pad::Freeze); }
 	bool IsRequired() const override { return true; }
+
+	// Legacy states hold a raw struct that predates the StateWrapper stream
+	// this reads; the pads keep the type and mode they booted with.
+	bool SupportsLegacy() const override { return false; }
 };
 
 class SavestateEntry_GS final : public BaseSavestateEntry
 {
 public:
-	~SavestateEntry_GS() = default;
+	~SavestateEntry_GS() override = default;
 
-	const char* GetFilename() const { return "GS.bin"; }
-	bool FreezeIn(zip_file_t* zf) const { return SysState_ComponentFreezeIn(zf, GS); }
-	bool FreezeOut(SaveStateBase& writer) const { return SysState_ComponentFreezeOut(writer, GS); }
-	bool IsRequired() const { return true; }
+	const char* GetFilename() const override { return "GS.bin"; }
+	bool FreezeIn(zip_file_t* zf) const override { return SysState_ComponentFreezeIn(zf, GS); }
+	bool FreezeOut(SaveStateBase& writer) const override { return SysState_ComponentFreezeOut(writer, GS); }
+	bool IsRequired() const override { return true; }
+
+	// GS blocks carry their own version, which Defrost still understands back
+	// through the legacy eras; only the size has to come from the entry.
+	bool FreezeInLegacy(zip_file_t* zf, u32 size) const override { return SysState_ComponentFreezeIn(zf, GS, size); }
 };
 
 class SaveStateEntry_Achievements final : public BaseSavestateEntry
@@ -686,6 +733,9 @@ class SaveStateEntry_Achievements final : public BaseSavestateEntry
 	}
 
 	bool IsRequired() const override { return false; }
+
+	// No legacy-era state file carries achievement data.
+	bool SupportsLegacy() const override { return false; }
 };
 
 // (cpuRegs, iopRegs, VPU/GIF/DMAC structures should all remain as part of a larger unified
@@ -1159,7 +1209,7 @@ static bool CheckVersion(const std::string& filename, zip_t* zf, u32* out_saveve
 	// was removed entirely.
 	// check for a "minor" version incompatibility; which happens if the savestate being loaded is a newer version
 	// than the emulator recognizes.  99% chance that trying to load it will just corrupt emulation or crash.
-	if (savever > g_SaveVersion || (savever >> 16) != (g_SaveVersion >> 16))
+	if ((savever > g_SaveVersion || (savever >> 16) != (g_SaveVersion >> 16)) && !SaveStateLegacy::IsSupportedVersion(savever))
 	{
 		std::string current_emulator_version = BuildVersion::GitTag;
 		if (current_emulator_version.empty())
@@ -1211,11 +1261,21 @@ static bool LoadInternalStructuresState(zip_t* zf, s64 index, u32 savever, Error
 
 	memLoadingState state(buffer);
 	state.SetVersion(savever);
+
+	// FreezeBios() is layout-identical in every era we accept, so it runs
+	// before the reader is chosen.
 	if (!state.FreezeBios())
 		return false;
 
-	if (!state.FreezeInternals(error))
+	if (SaveStateLegacy::IsSupportedVersion(savever))
+	{
+		if (!state.FreezeInternalsLegacy(error))
+			return false;
+	}
+	else if (!state.FreezeInternals(error))
+	{
 		return false;
+	}
 
 	return true;
 }
@@ -1273,6 +1333,8 @@ static bool SaveState_UnzipFromZip(zip_t* zf_raw, const std::string& filename, E
 	if (!CheckVersion(filename, zf.get(), &savever, error))
 		return false;
 
+	const bool legacy = SaveStateLegacy::IsSupportedVersion(savever);
+
 	// check that all parts are included
 	const s64 internal_index = CheckFileExistsInState(zf.get(), EntryFilename_InternalStructures, true);
 	s64 entryIndices[std::size(SavestateEntries)];
@@ -1281,7 +1343,10 @@ static bool SaveState_UnzipFromZip(zip_t* zf_raw, const std::string& filename, E
 	bool allPresent = (internal_index >= 0);
 	for (u32 i = 0; i < std::size(SavestateEntries); i++)
 	{
-		const bool required = SavestateEntries[i]->IsRequired();
+		// An entry that cannot be carried over from a legacy state is not
+		// required to be there, since it would be discarded either way.
+		const bool skipped = legacy && !SavestateEntries[i]->SupportsLegacy();
+		const bool required = SavestateEntries[i]->IsRequired() && !skipped;
 		entryIndices[i] = CheckFileExistsInState(zf.get(), SavestateEntries[i]->GetFilename(), required);
 		if (entryIndices[i] < 0 && required)
 		{
@@ -1308,6 +1373,13 @@ static bool SaveState_UnzipFromZip(zip_t* zf_raw, const std::string& filename, E
 
 	for (u32 i = 0; i < std::size(SavestateEntries); ++i)
 	{
+		if (legacy && !SavestateEntries[i]->SupportsLegacy())
+		{
+			Console.WriteLn(Color_Yellow, "  Skipping %s: not readable from a legacy save state, keeping the current state.",
+				SavestateEntries[i]->GetFilename());
+			continue;
+		}
+
 		if (entryIndices[i] < 0)
 		{
 			SavestateEntries[i]->FreezeIn(nullptr);
@@ -1315,7 +1387,21 @@ static bool SaveState_UnzipFromZip(zip_t* zf_raw, const std::string& filename, E
 		}
 
 		auto zff = zip_fopen_index_managed(zf.get(), entryIndices[i], 0);
-		if (!zff || !SavestateEntries[i]->FreezeIn(zff.get()))
+		bool okay = false;
+		if (zff && !legacy)
+		{
+			okay = SavestateEntries[i]->FreezeIn(zff.get());
+		}
+		else if (zff)
+		{
+			// Legacy blocks are whatever size their era wrote, so they are read
+			// against the entry's own size rather than the component's.
+			zip_stat_t zst = {};
+			if (zip_stat_index(zf.get(), entryIndices[i], 0, &zst) == 0 && zst.size <= std::numeric_limits<u32>::max())
+				okay = SavestateEntries[i]->FreezeInLegacy(zff.get(), static_cast<u32>(zst.size));
+		}
+
+		if (!okay)
 		{
 			Error::SetString(error, fmt::format("Save state corruption in {}.", SavestateEntries[i]->GetFilename()));
 			VMManager::Reset();

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -1418,7 +1418,7 @@ static bool SaveState_UnzipFromZip(zip_t* zf_raw, const std::string& filename, E
 		// over are worth knowing about before the player wonders.
 		Host::AddIconOSDMessage("LoadStateLegacy", ICON_FA_FLOPPY_DISK,
 			TRANSLATE_STR("SaveState", "Imported an AetherSX2 save state. Save a new state to convert it. "
-									   "Audio restarts from silence, and controllers keep their current settings."),
+									   "Controllers keep their current settings."),
 			Host::OSD_INFO_DURATION);
 	}
 

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -1410,6 +1410,18 @@ static bool SaveState_UnzipFromZip(zip_t* zf_raw, const std::string& filename, E
 	}
 
 	PostLoadPrep();
+
+	if (legacy)
+	{
+		// Nothing writes this format any more, so say so once per load: saving
+		// again is what converts the state, and the parts we could not carry
+		// over are worth knowing about before the player wonders.
+		Host::AddIconOSDMessage("LoadStateLegacy", ICON_FA_FLOPPY_DISK,
+			TRANSLATE_STR("SaveState", "Imported an AetherSX2 save state. Save a new state to convert it. "
+									   "Audio restarts from silence, and controllers keep their current settings."),
+			Host::OSD_INFO_DURATION);
+	}
+
 	return true;
 }
 

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -98,6 +98,9 @@ public:
 		return (m_version & 0xffff);
 	}
 
+	// Overrides the version with the one read from the state file being loaded.
+	__fi void SetVersion(u32 version) { m_version = version; }
+
 	bool FreezeBios();
 	bool FreezeInternals(Error* error);
 

--- a/pcsx2/SaveState.h
+++ b/pcsx2/SaveState.h
@@ -104,6 +104,11 @@ public:
 	bool FreezeBios();
 	bool FreezeInternals(Error* error);
 
+	// Load-only reader for legacy-format internal-structures blobs (the
+	// AetherSX2/NetherSX2-era majors accepted by
+	// SaveStateLegacy::IsSupportedVersion). Implemented in SaveStateLegacy.cpp.
+	bool FreezeInternalsLegacy(Error* error);
+
 	// Loads or saves an arbitrary data type.  Usable on atomic types, structs, and arrays.
 	// For dynamically allocated pointers use FreezeMem instead.
 	template<typename T>
@@ -121,6 +126,14 @@ public:
 	}
 
 	void PrepBlock( int size );
+
+	// Skips over bytes that have no destination (legacy-format fields that
+	// were removed, or removed-era padding). Bounds-checked via PrepBlock.
+	void FreezeSkip( int size )
+	{
+		PrepBlock( size );
+		CommitBlock( size );
+	}
 
 	template <typename T>
 	void FreezeDeque(std::deque<T>& q)

--- a/pcsx2/SaveStateLegacy.cpp
+++ b/pcsx2/SaveStateLegacy.cpp
@@ -1,0 +1,1165 @@
+// SPDX-FileCopyrightText: 2026 yaps2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+// Deserializer for legacy-format `PCSX2 Internal Structures.dat` blobs, as
+// written by the AetherSX2/NetherSX2 era of upstream PCSX2:
+//
+//   major 0x9A2C — upstream PCSX2 at 0312e902 (AetherSX2 v1.5-era builds)
+//   major 0x9A34 — upstream PCSX2 at 7e939b75 (NetherSX2 v2.1 build 4248)
+//
+// The reader consumes the old byte layout field-by-field directly into live
+// emulator state. Old layouts are declared in OldState below, each cited to
+// the upstream sha its layout was taken from and guarded by a static_assert
+// of the byte-exact size proven against real state files. Two deviations from
+// stock 0312e902 exist in every AetherSX2-written 0x9A2C file (byte-proven,
+// not header-derived): see psxRegisters_9A2C and CyclesBlock_9A2C.
+//
+// Where a block is byte-identical across eras the existing freeze function is
+// reused; everything else is remapped here. All 32-bit cycle counters widen
+// relative to their domain base (WidenCycle) so wrap-straddling deltas
+// survive the u32->u64 conversion.
+
+#include "SaveStateLegacy.h"
+
+#include "CDVD/CDVD.h"
+#include "CDVD/CDVDcommon.h"
+#include "CDVD/Ps1CD.h"
+#include "Config.h"
+#include "Host.h"
+#include "Counters.h"
+#include "GS.h"
+#include "Gif.h"
+#include "Gif_Unit.h"
+#include "IPU/IPU.h"
+#include "IPU/IPUdma.h"
+#include "IPU/IPU_Fifo.h"
+#include "IPU/IPU_MultiISA.h"
+#include "IopBios.h"
+#include "IopCounters.h"
+#include "IopMem.h"
+#include "MTVU.h"
+#include "MemoryTypes.h"
+#include "R3000A.h"
+#include "R5900.h"
+#include "SIO/Multitap/MultitapProtocol.h"
+#include "SIO/Sio.h"
+#include "SIO/Sio0.h"
+#include "SIO/Sio2.h"
+#include "SaveState.h"
+#include "Sif.h"
+#include "VMManager.h"
+#include "VUmicro.h"
+#include "Vif_Dma.h"
+#include "Vif_Dynarec.h"
+#include "ps2/BiosTools.h"
+
+#include "common/Assertions.h"
+#include "common/Console.h"
+#include "common/Error.h"
+
+#include <cstring>
+#include <memory>
+
+bool SaveStateLegacy::IsSupportedVersion(u32 savever)
+{
+	const u32 major = savever >> 16;
+	return major == 0x9A2C || major == 0x9A34;
+}
+
+namespace OldState
+{
+	// layout per upstream PCSX2 0312e902, pcsx2/R5900.h (32-bit cycle counters).
+	// GPR/HI/LO/CP0/PERF register blocks are era-stable; the current types are
+	// reused for them.
+	struct cpuRegisters_9A2C
+	{
+		GPRregs GPR;
+		GPR_reg HI;
+		GPR_reg LO;
+		CP0regs CP0;
+		u32 sa;
+		u32 IsDelaySlot;
+		u32 pc;
+		u32 code;
+		PERFregs PERF;
+		u32 eCycle[32];
+		u32 sCycle[32];
+		u32 cycle;
+		u32 interrupt;
+		int branch;
+		int opmode;
+		u32 tempcycles;
+	};
+	static_assert(sizeof(cpuRegisters_9A2C) == 984, "cpuRegisters at 0312e902 is 984 bytes");
+
+	// layout per upstream PCSX2 7e939b75, pcsx2/R5900.h (cycle/writeback fields
+	// moved in-struct at 0x9A31, still 32-bit).
+	struct cpuRegisters_9A34
+	{
+		GPRregs GPR;
+		GPR_reg HI;
+		GPR_reg LO;
+		CP0regs CP0;
+		u32 sa;
+		u32 IsDelaySlot;
+		u32 pc;
+		u32 code;
+		PERFregs PERF;
+		u32 eCycle[32];
+		u32 sCycle[32];
+		u32 cycle;
+		u32 interrupt;
+		int branch;
+		int opmode;
+		u32 tempcycles;
+		u32 dmastall;
+		u32 pcWriteback;
+		u32 nextEventCycle;
+		u32 lastEventCycle;
+		u32 lastCOP0Cycle;
+		u32 lastPERFCycle[2];
+	};
+	static_assert(sizeof(cpuRegisters_9A34) == 1008, "cpuRegisters at 7e939b75 is 1008 bytes");
+
+	// The newer layout only appends, so the older one reads as a prefix of it
+	// and both eras normalize onto the newer shape by copying that prefix.
+	// Copying it means copying exactly this many bytes and no more: the older
+	// struct is four bytes longer than its last field, and the newer one puts
+	// dmastall in that padding, so a sizeof()-sized copy would land padding in
+	// a live field.
+	static constexpr size_t CPUREGS_SHARED_BYTES = offsetof(cpuRegisters_9A2C, tempcycles) + sizeof(cpuRegisters_9A2C::tempcycles);
+	static_assert(offsetof(cpuRegisters_9A2C, tempcycles) == offsetof(cpuRegisters_9A34, tempcycles),
+		"cpuRegisters at 7e939b75 appends to 0312e902's layout without moving a field");
+	static_assert(offsetof(cpuRegisters_9A34, dmastall) == CPUREGS_SHARED_BYTES,
+		"the fields 7e939b75 appends start where 0312e902's last field ends");
+
+	// layout per upstream PCSX2 0312e902, pcsx2/R3000A.h — plus one extra u32
+	// observed in every AetherSX2-written 0x9A2C state (796 bytes on file, not
+	// upstream's 792), sitting exactly where upstream later placed pcWriteback
+	// (fd194124a9). Named accordingly; its value is not used.
+	struct psxRegisters_9A2C
+	{
+		GPRRegs GPR;
+		CP0Regs CP0;
+		CP2Data CP2D;
+		CP2Ctrl CP2C;
+		u32 pc;
+		u32 code;
+		u32 cycle;
+		u32 interrupt;
+		u32 pcWriteback;
+		u32 sCycle[32];
+		s32 eCycle[32];
+	};
+	static_assert(sizeof(psxRegisters_9A2C) == 796, "psxRegisters as written by AetherSX2 0x9A2C states is 796 bytes");
+
+	// layout per upstream PCSX2 7e939b75, pcsx2/R3000A.h.
+	struct psxRegisters_9A34
+	{
+		GPRRegs GPR;
+		CP0Regs CP0;
+		CP2Data CP2D;
+		CP2Ctrl CP2C;
+		u32 pc;
+		u32 code;
+		u32 cycle;
+		u32 interrupt;
+		u32 pcWriteback;
+		u32 iopNextEventCycle;
+		s32 iopBreak;
+		s32 iopCycleEE;
+		u32 sCycle[32];
+		s32 eCycle[32];
+	};
+	static_assert(sizeof(psxRegisters_9A34) == 808, "psxRegisters at 7e939b75 is 808 bytes");
+	// Here the newer layout inserts rather than appends, so only the head up to
+	// the cycle arrays is shared; the arrays are copied separately.
+	static_assert(offsetof(psxRegisters_9A2C, sCycle) == offsetof(psxRegisters_9A34, iopNextEventCycle),
+		"psxRegisters at 7e939b75 inserts its new fields after the shared head");
+	static_assert(sizeof(psxRegisters_9A2C::sCycle) == sizeof(psxRegisters_9A34::sCycle) &&
+					  sizeof(psxRegisters_9A2C::eCycle) == sizeof(psxRegisters_9A34::eCycle),
+		"the IOP cycle arrays did not change shape between the two eras");
+
+	// layout per upstream PCSX2 0312e902, pcsx2/SaveState.cpp "Cycles" block.
+	// The COP0/PERF last-cycle area is 8 bytes in every AetherSX2-written file
+	// where stock upstream writes 12 (s_iLastCOP0Cycle + s_iLastPERFCycle[2]);
+	// byte-proven via the duplicated nextCounter/nextsCounter pair that
+	// rcntFreeze rewrites later in the same blob. The area is discarded on
+	// load (the mapped state resyncs those cycles to the load point).
+	struct CyclesBlock_9A2C
+	{
+		s32 EEsCycle;
+		u32 EEoCycle;
+		s32 iopCycleEE;
+		s32 iopBreak;
+		u32 g_nextEventCycle;
+		u32 g_iopNextEventCycle;
+		u32 cop0PerfCycleArea[2];
+		s32 nextCounter;
+		u32 nextsCounter;
+		u32 psxNextsCounter;
+		s32 psxNextCounter;
+	};
+	static_assert(sizeof(CyclesBlock_9A2C) == 48, "Cycles block in AetherSX2 0x9A2C states is 48 bytes");
+
+	// layout per upstream PCSX2 7e939b75, pcsx2/SaveState.cpp "Cycles" block
+	// (the moved fields live in the CPU structs at this vintage).
+	struct CyclesBlock_9A34
+	{
+		s32 EEsCycle;
+		u32 EEoCycle;
+		s32 nextCounter;
+		u32 nextsCounter;
+		u32 psxNextsCounter;
+		s32 psxNextCounter;
+	};
+	static_assert(sizeof(CyclesBlock_9A34) == 24, "Cycles block at 7e939b75 is 24 bytes");
+
+	// layout per upstream PCSX2 0312e902, pcsx2/R5900.h struct tlbs: the four
+	// raw registers followed by eight derived caches (recomputed today).
+	struct tlbs_9A2C
+	{
+		u32 PageMask, EntryHi;
+		u32 EntryLo0, EntryLo1;
+		u32 Mask, nMask;
+		u32 G;
+		u32 ASID;
+		u32 VPN2;
+		u32 PFN0;
+		u32 PFN1;
+		u32 S;
+	};
+	static_assert(sizeof(tlbs_9A2C) == 48, "tlbs at 0312e902 is 48 bytes per entry");
+
+	// layout per upstream PCSX2 0312e902, pcsx2/Counters.h.
+	struct Counter_9A2C
+	{
+		u32 count;
+		u32 modeval;
+		u32 target, hold;
+		u32 rate, interrupt;
+		u32 sCycleT;
+	};
+	static_assert(sizeof(Counter_9A2C) == 28, "Counter at 0312e902 is 28 bytes");
+
+	struct SyncCounter_9A2C
+	{
+		u32 Mode;
+		u32 sCycle;
+		s32 CycleT;
+	};
+	static_assert(sizeof(SyncCounter_9A2C) == 12, "SyncCounter at 0312e902 is 12 bytes");
+
+	// layout per upstream PCSX2 0312e902, pcsx2/IopCounters.h.
+	struct psxCounter_9A2C
+	{
+		u64 count, target;
+		u32 mode;
+		u32 rate, interrupt;
+		u32 sCycleT;
+		s32 CycleT;
+	};
+	static_assert(sizeof(psxCounter_9A2C) == 40, "psxCounter at 0312e902 is 40 bytes");
+
+	// Internal mode bits of the legacy psxCounter.mode word that do not map
+	// positionally into today's psxCounterMode bitfield (which mirrors the
+	// hardware register bits 0-14 exactly).
+	static constexpr u32 PSXCNT_STOPPED_9A2C = 0x10000000u; // IOPCNT_STOPPED at 0312e902
+	static constexpr u32 PSXCNT_HW_MODE_MASK = 0x7FFFu; // bits 0-14: hw register incl. flag + prescale bits
+
+	// layout per upstream PCSX2 0312e902, pcsx2/VU.h (32-bit pipe cycles).
+	struct fmacPipe_9A2C
+	{
+		u32 regupper;
+		u32 reglower;
+		int flagreg;
+		u32 xyzwupper;
+		u32 xyzwlower;
+		u32 sCycle;
+		u32 Cycle;
+		u32 macflag;
+		u32 statusflag;
+		u32 clipflag;
+	};
+	static_assert(sizeof(fmacPipe_9A2C) == 40, "fmacPipe at 0312e902 is 40 bytes");
+
+	struct fdivPipe_9A2C
+	{
+		int enable;
+		REG_VI reg;
+		u32 sCycle;
+		u32 Cycle;
+		u32 statusflag;
+	};
+	static_assert(sizeof(fdivPipe_9A2C) == 32, "fdivPipe at 0312e902 is 32 bytes");
+
+	struct efuPipe_9A2C
+	{
+		int enable;
+		REG_VI reg;
+		u32 sCycle;
+		u32 Cycle;
+	};
+	static_assert(sizeof(efuPipe_9A2C) == 28, "efuPipe at 0312e902 is 28 bytes");
+
+	struct ialuPipe_9A2C
+	{
+		int reg;
+		u32 sCycle;
+		u32 Cycle;
+	};
+	static_assert(sizeof(ialuPipe_9A2C) == 12, "ialuPipe at 0312e902 is 12 bytes");
+
+	// layout per upstream PCSX2 0312e902, pcsx2/Vif_Dma.h. Same total size as
+	// today's vifStruct, but the interior differs: today a TRXPOS register sits
+	// inside the transfer-register union, shifting everything after BITBLTBUF.
+	struct vifStruct_9A2C
+	{
+		alignas(16) u128 MaskRow;
+		alignas(16) u128 MaskCol;
+
+		struct
+		{
+			vifCode tag;
+			int cmd;
+			int pass;
+			int cl;
+			u8 usn;
+			u8 start_aligned;
+			u8 StructEnd;
+		};
+
+		int irq;
+
+		bool done;
+		tVIF_CTRL vifstalled;
+		bool stallontag;
+		bool waitforvu;
+		int unpackcalls;
+		tBITBLTBUF BITBLTBUF;
+		tTRXREG TRXREG;
+		u32 GSLastDownloadSize;
+
+		tVIF_CTRL irqoffset;
+		u32 vifpacketsize;
+		u8 inprogress;
+		u8 dmamode;
+
+		bool queued_program;
+		u32 queued_pc;
+		bool queued_gif_wait;
+	};
+	static_assert(sizeof(vifStruct_9A2C) == 144, "vifStruct at 0312e902 is 144 bytes");
+
+	// layout per upstream PCSX2 0312e902, pcsx2/CDVD/CDVD.h. Field-for-field
+	// the same order as today's cdvdStruct under older names; RTCcount was an
+	// int and RotSpeed did not exist yet.
+	struct cdvdStruct_9A2C
+	{
+		u8 nCommand;
+		u8 Ready;
+		u8 Error;
+		u8 IntrStat;
+		u8 Status;
+		u8 StatusSticky;
+		u8 Type;
+		u8 sCommand;
+		u8 sDataIn;
+		u8 sDataOut;
+		u8 HowTo;
+
+		u8 NCMDParam[16];
+		u8 SCMDParam[16];
+		u8 SCMDResult[16];
+
+		u8 NCMDParamC;
+		u8 NCMDParamP;
+		u8 SCMDParamC;
+		u8 SCMDParamP;
+		u8 SCMDResultC;
+		u8 SCMDResultP;
+
+		u8 CBlockIndex;
+		u8 COffset;
+		u8 CReadWrite;
+		u8 CNumBlocks;
+
+		int RTCcount;
+		cdvdRTC RTC;
+
+		u32 Sector;
+		int nSectors;
+		int Readed;
+		int Reading;
+		int WaitingDMA;
+		int ReadMode;
+		int BlockSize;
+		int Speed;
+		int RetryCnt;
+		int RetryCntP;
+		int RErr;
+		int SpindlCtrl;
+
+		u8 Key[16];
+		u8 KeyXor;
+		u8 decSet;
+
+		u8 mg_buffer[65536];
+		int mg_size;
+		int mg_maxsize;
+		int mg_datatype;
+		u8 mg_kbit[16];
+		u8 mg_kcon[16];
+
+		u8 TrayTimeout;
+		u8 Action;
+		u32 SeekToSector;
+		u32 MaxSector;
+		u32 ReadTime;
+		bool Spinning;
+		cdvdTrayTimer Tray;
+		u8 nextSectorsBuffered;
+		bool AbortRequested;
+	};
+	static_assert(sizeof(cdvdStruct_9A2C) == 65764, "cdvdStruct at 0312e902 is 65764 bytes");
+
+	// SIO-era blob sizes; the payloads are discarded (SIO is reset to its
+	// transfer-quiescent boot state on load), only the memcard CRCs matter.
+	// layout per upstream PCSX2 0312e902, pcsx2/Sio.h + Sio.cpp sioFreeze /
+	// pcsx2/IopSio2.h + IopSio2.cpp sio2Freeze.
+	static constexpr int SIO_BLOB_9A2C = 540;
+	static constexpr int SIO2_BLOB_9A2C = 8640;
+	// layout per upstream PCSX2 7e939b75, pcsx2/Sio.h sioFreeze/sio2Freeze
+	// (class Sio0 / class Sio2 raw dumps + two FreezeDeque<u8> fifos + CRCs).
+	static constexpr int SIO0_BLOB_9A34 = 32;
+	static constexpr int SIO2_BLOB_9A34 = 176;
+
+	// vuJITFreeze payload: microVU's lpState (microRegInfo), whose size is
+	// static_asserted at each vintage. Discarded on load — PreLoadPrep's
+	// ClearCPUExecutionCaches already reset the VU recs to a zero lpState.
+	static constexpr int MICROREGINFO_9A2C = 176; // 0312e902:pcsx2/x86/microVU_IR.h
+	static constexpr int MICROREGINFO_9A34 = 160; // 7e939b75:pcsx2/x86/microVU_IR.h
+
+	// Sizes of CURRENT types that the legacy byte layout pins, because the
+	// reader either freezes them directly or reaches them through a freeze
+	// function shared with the current format. They are era-invariant today;
+	// if one ever changes upstream, the legacy blob desyncs mid-stream, so
+	// pin them here to fail the build instead of the load.
+	static_assert(sizeof(fpuRegisters) == 264, "fpuRegs block is 264 bytes in every era");
+	static_assert(sizeof(VECTOR) == 16 && sizeof(REG_VI) == 16, "VU register views are 128-bit in every era");
+	static_assert(sizeof(ipu_fifo) == 288 && sizeof(g_BP) == 48 && sizeof(decoder) == 3028 && sizeof(ipu_cmd) == 32,
+		"IPU block payload is era-invariant");
+	static_assert(sizeof(g_ipu_vqclut) == 32 && sizeof(g_ipu_thresh) == 4 && sizeof(coded_block_pattern) == 4,
+		"IPU block payload is era-invariant");
+	static_assert(sizeof(gifUnit.stat) == 4 && sizeof(gifUnit.gsSIGNAL) == 12 && sizeof(gifUnit.lastTranType) == 4,
+		"Gif Unit block head is era-invariant apart from GS_FINISH");
+	static_assert(sizeof(Gif_Path) - sizeof(Gif_Path_MTVU) == 120, "gifPathFreeze writes a 120-byte struct head in every era");
+	static_assert(sizeof(sif0) == 580, "SIFdma block is era-invariant");
+	static_assert(sizeof(gif) == 28 && sizeof(gif_fifo) == 260, "GIFdma block is era-invariant");
+	static_assert(sizeof(cdr) == 39352, "cdrom block is era-invariant");
+	static_assert(sizeof(iopMem->Sif) == 256, "IOP-Subsystems SIF window is era-invariant");
+	static_assert(sizeof(gsVideoMode) == 4 && sizeof(gsIsInterlaced) == 1, "video mode fields are era-invariant");
+} // namespace OldState
+
+using SaveStateLegacy::WidenCycle;
+
+// Staged EE/IOP register state: blocks 1 (cpuRegs) and 2 (Cycles) interlock
+// (fields moved between them at 0x9A31), so both are read before either is
+// committed to the live registers.
+namespace
+{
+	struct StagedRegs
+	{
+		// normalized (version-independent) view of the legacy data
+		OldState::cpuRegisters_9A34 cpu; // 9A2C loads leave the tail fields unset
+		OldState::psxRegisters_9A34 psx;
+		fpuRegisters fpu;
+		OldState::tlbs_9A2C tlb[48];
+		bool allowParams1, allowParams2;
+		u32 elfCRC;
+		char discSerial[256];
+
+		s32 EEsCycle;
+		u32 EEoCycle;
+	};
+} // namespace
+
+// Verifies the identity fields the legacy format embeds in the cpuRegs block
+// against the running VM. A state from a different disc corrupts emulation,
+// so a mismatch is a hard failure.
+static bool CheckLegacyIdentity(const StagedRegs& st, Error* error)
+{
+	const std::string current_serial = VMManager::GetDiscSerial();
+	const u32 current_crc = VMManager::GetCurrentCRC();
+
+	if (current_serial.empty())
+	{
+		Console.Warning("(LegacyState) No disc serial available to verify state identity against.");
+		return true;
+	}
+
+	if (current_serial != st.discSerial)
+	{
+		Error::SetStringFmt(error, TRANSLATE_FS("SaveState", "This AetherSX2 save state is for '{0}', but '{1}' is running."),
+			st.discSerial, current_serial);
+		return false;
+	}
+
+	if (st.elfCRC != current_crc)
+	{
+		Error::SetStringFmt(error, TRANSLATE_FS("SaveState", "This AetherSX2 save state is for CRC {0:08X}, but the running game is CRC {1:08X}."),
+			st.elfCRC, current_crc);
+		return false;
+	}
+
+	return true;
+}
+
+bool SaveStateBase::FreezeInternalsLegacy(Error* error)
+{
+	pxAssert(IsLoading());
+	const u32 major = m_version >> 16;
+
+	// Legacy states are always 32MB-EE-RAM states; memFreeze (which carries
+	// the flag today) does not exist in them.
+	if (Ps2MemSize::ExposedRam != Ps2MemSize::MainRam)
+	{
+		Error::SetString(error, "Legacy save states require 32MB memory mode, but the VM is using extra memory.");
+		return false;
+	}
+
+	// ---------------------------------------------------------------- Block 1+2
+	StagedRegs st = {};
+
+	if (!FreezeTag("cpuRegs"))
+		return false;
+
+	if (major == 0x9A2C)
+	{
+		OldState::cpuRegisters_9A2C cpu;
+		OldState::psxRegisters_9A2C psx;
+		Freeze(cpu);
+		Freeze(psx);
+		std::memcpy(&st.cpu, &cpu, OldState::CPUREGS_SHARED_BYTES);
+		std::memcpy(&st.psx, &psx, offsetof(OldState::psxRegisters_9A2C, sCycle));
+		std::memcpy(st.psx.sCycle, psx.sCycle, sizeof(psx.sCycle));
+		std::memcpy(st.psx.eCycle, psx.eCycle, sizeof(psx.eCycle));
+	}
+	else
+	{
+		Freeze(st.cpu);
+		Freeze(st.psx);
+	}
+
+	Freeze(st.fpu);
+	Freeze(st.tlb);
+	Freeze(st.allowParams1);
+	Freeze(st.allowParams2);
+	FreezeSkip(2); // g_GameStarted, g_GameLoading — identity lives in the running VM
+	Freeze(st.elfCRC);
+	Freeze(st.discSerial);
+	st.discSerial[sizeof(st.discSerial) - 1] = 0;
+
+	if (!FreezeTag("Cycles"))
+		return false;
+
+	// The counter deadlines this block also carries are ignored: rcntFreeze and
+	// the iopCounters block write the same four values later in the same blob,
+	// which is what makes them a landmark for pinning the block's size.
+	if (major == 0x9A2C)
+	{
+		OldState::CyclesBlock_9A2C cyc;
+		Freeze(cyc);
+		st.EEsCycle = cyc.EEsCycle;
+		st.EEoCycle = cyc.EEoCycle;
+		// fields that moved into the CPU structs at 0x9A31:
+		st.psx.iopCycleEE = cyc.iopCycleEE;
+		st.psx.iopBreak = cyc.iopBreak;
+		st.cpu.nextEventCycle = cyc.g_nextEventCycle;
+		st.psx.iopNextEventCycle = cyc.g_iopNextEventCycle;
+		// cyc.cop0PerfCycleArea is discarded; COP0/PERF resync to the load point.
+		st.cpu.lastCOP0Cycle = st.cpu.cycle;
+		st.cpu.lastPERFCycle[0] = st.cpu.cycle;
+		st.cpu.lastPERFCycle[1] = st.cpu.cycle;
+	}
+	else
+	{
+		OldState::CyclesBlock_9A34 cyc;
+		Freeze(cyc);
+		st.EEsCycle = cyc.EEsCycle;
+		st.EEoCycle = cyc.EEoCycle;
+	}
+
+	if (!IsOkay())
+		return false;
+
+	if (!CheckLegacyIdentity(st, error))
+		return false;
+
+	// Commit. Domain bases for cycle widening: the old EE/IOP cycle values,
+	// zero-extended (the absolute epoch is arbitrary; consistency is what
+	// matters).
+	const u32 ee_base = st.cpu.cycle;
+	const u64 ee_new = static_cast<u64>(st.cpu.cycle);
+	const u32 iop_base = st.psx.cycle;
+	const u64 iop_new = static_cast<u64>(st.psx.cycle);
+	const auto widen_ee = [&](u32 v) { return WidenCycle(v, ee_base, ee_new); };
+	const auto widen_iop = [&](u32 v) { return WidenCycle(v, iop_base, iop_new); };
+
+	cpuRegs.GPR = st.cpu.GPR;
+	cpuRegs.HI = st.cpu.HI;
+	cpuRegs.LO = st.cpu.LO;
+	cpuRegs.CP0 = st.cpu.CP0;
+	cpuRegs.sa = st.cpu.sa;
+	cpuRegs.IsDelaySlot = st.cpu.IsDelaySlot;
+	cpuRegs.pc = st.cpu.pc;
+	cpuRegs.code = st.cpu.code;
+	cpuRegs.PERF = st.cpu.PERF;
+	std::memcpy(cpuRegs.eCycle, st.cpu.eCycle, sizeof(cpuRegs.eCycle));
+	for (int i = 0; i < 32; i++)
+		cpuRegs.sCycle[i] = widen_ee(st.cpu.sCycle[i]);
+	cpuRegs.cycle = ee_new;
+	cpuRegs.interrupt = st.cpu.interrupt;
+	cpuRegs.branch = st.cpu.branch;
+	cpuRegs.opmode = st.cpu.opmode;
+	cpuRegs.tempcycles = st.cpu.tempcycles;
+	cpuRegs.dmastall = st.cpu.dmastall; // zero for 0x9A2C, which has no such field
+	cpuRegs.pcWriteback = 0;
+	cpuRegs.nextEventCycle = widen_ee(st.cpu.nextEventCycle);
+	cpuRegs.lastEventCycle = ee_new;
+	cpuRegs.lastCOP0Cycle = widen_ee(st.cpu.lastCOP0Cycle);
+	cpuRegs.lastPERFCycle[0] = widen_ee(st.cpu.lastPERFCycle[0]);
+	cpuRegs.lastPERFCycle[1] = widen_ee(st.cpu.lastPERFCycle[1]);
+
+	psxRegs.GPR = st.psx.GPR;
+	psxRegs.CP0 = st.psx.CP0;
+	psxRegs.CP2D = st.psx.CP2D;
+	psxRegs.CP2C = st.psx.CP2C;
+	psxRegs.pc = st.psx.pc;
+	psxRegs.code = st.psx.code;
+	psxRegs.cycle = iop_new;
+	psxRegs.interrupt = st.psx.interrupt;
+	psxRegs.pcWriteback = 0;
+	psxRegs.iopNextEventCycle = widen_iop(st.psx.iopNextEventCycle);
+	psxRegs.iopBreak = st.psx.iopBreak;
+	psxRegs.iopCycleEE = st.psx.iopCycleEE;
+	psxRegs.iopCycleEECarry = 0;
+	for (int i = 0; i < 32; i++)
+		psxRegs.sCycle[i] = widen_iop(st.psx.sCycle[i]);
+	std::memcpy(psxRegs.eCycle, st.psx.eCycle, sizeof(psxRegs.eCycle));
+
+	fpuRegs = st.fpu;
+
+	for (int i = 0; i < 48; i++)
+	{
+		tlb[i].PageMask.UL = st.tlb[i].PageMask;
+		tlb[i].EntryHi.UL = st.tlb[i].EntryHi;
+		tlb[i].EntryLo0.UL = st.tlb[i].EntryLo0;
+		tlb[i].EntryLo1.UL = st.tlb[i].EntryLo1;
+	}
+	// cachedTlbs is deliberately untouched: PostLoadPrep diffs tlb[] against
+	// the pre-load backup and Unmap/MapTLB maintain the cache incrementally,
+	// exactly as for an in-session TLB rewrite.
+
+	AllowParams1 = st.allowParams1;
+	AllowParams2 = st.allowParams2;
+
+	EEsCycle = st.EEsCycle;
+	EEoCycle = widen_ee(st.EEoCycle);
+
+	// ------------------------------------------------------- EE-Subsystems
+	if (!FreezeTag("EE-Subsystems"))
+		return false;
+
+	// rcnt (untagged). vSyncInfo and the legacy `gates` word are discarded:
+	// both are recomputed (UpdateVSyncRate(true) in PostLoadPrep, cpuRcntSet
+	// here).
+	{
+		OldState::Counter_9A2C oc[4];
+		OldState::SyncCounter_9A2C oh, ov;
+		s32 nc;
+		u32 nsc;
+		Freeze(oc);
+		Freeze(oh);
+		Freeze(ov);
+		Freeze(nc);
+		Freeze(nsc);
+		FreezeSkip(40); // vSyncTimingInfo
+		Freeze(gsVideoMode); // enum layout is unchanged since 0312e902
+		Freeze(gsIsInterlaced);
+		FreezeSkip(4); // gates
+		if (!IsOkay())
+			return false;
+
+		for (int i = 0; i < 4; i++)
+		{
+			counters[i].count = oc[i].count;
+			counters[i].modeval = oc[i].modeval;
+			counters[i].target = oc[i].target;
+			counters[i].hold = oc[i].hold;
+			counters[i].rate = oc[i].rate;
+			counters[i].interrupt = oc[i].interrupt;
+			counters[i].startCycle = widen_ee(oc[i].sCycleT);
+		}
+		hsyncCounter.Mode = oh.Mode;
+		hsyncCounter.startCycle = widen_ee(oh.sCycle);
+		hsyncCounter.deltaCycles = oh.CycleT;
+		vsyncCounter.Mode = ov.Mode;
+		vsyncCounter.startCycle = widen_ee(ov.sCycle);
+		vsyncCounter.deltaCycles = ov.CycleT;
+		nextDeltaCounter = nc;
+		nextStartCounter = widen_ee(nsc);
+		// Rescheduling (cpuRcntSet) happens in PostLoadPrep via
+		// UpdateVSyncRate(true), which also rebuilds vSyncInfo.
+	}
+
+	if (!gsFreeze())
+		return false;
+
+	// vuMicro (tagged): field-by-field in both eras; identical legacy layout
+	// for 0x9A2C and 0x9A34. blockhasmbit was removed upstream and is
+	// discarded; the 32-bit VU cycles widen in the EE domain (VUs are
+	// scheduled against cpuRegs.cycle).
+	if (!FreezeTag("vuMicroRegs"))
+		return false;
+
+	const auto legacyVuPipes = [&](VURegs& vu) {
+		OldState::fmacPipe_9A2C fmac[4];
+		OldState::fdivPipe_9A2C fdiv;
+		OldState::efuPipe_9A2C efu;
+		OldState::ialuPipe_9A2C ialu[4];
+		Freeze(fmac);
+		Freeze(vu.fmacreadpos);
+		Freeze(vu.fmacwritepos);
+		Freeze(vu.fmaccount);
+		Freeze(fdiv);
+		Freeze(efu);
+		Freeze(ialu);
+		Freeze(vu.ialureadpos);
+		Freeze(vu.ialuwritepos);
+		Freeze(vu.ialucount);
+
+		for (int i = 0; i < 4; i++)
+		{
+			vu.fmac[i].regupper = fmac[i].regupper;
+			vu.fmac[i].reglower = fmac[i].reglower;
+			vu.fmac[i].flagreg = fmac[i].flagreg;
+			vu.fmac[i].xyzwupper = fmac[i].xyzwupper;
+			vu.fmac[i].xyzwlower = fmac[i].xyzwlower;
+			vu.fmac[i].sCycle = widen_ee(fmac[i].sCycle);
+			vu.fmac[i].Cycle = fmac[i].Cycle;
+			vu.fmac[i].macflag = fmac[i].macflag;
+			vu.fmac[i].statusflag = fmac[i].statusflag;
+			vu.fmac[i].clipflag = fmac[i].clipflag;
+
+			vu.ialu[i].reg = ialu[i].reg;
+			vu.ialu[i].sCycle = widen_ee(ialu[i].sCycle);
+			vu.ialu[i].Cycle = ialu[i].Cycle;
+		}
+		vu.fdiv.enable = fdiv.enable;
+		vu.fdiv.reg = fdiv.reg;
+		vu.fdiv.sCycle = widen_ee(fdiv.sCycle);
+		vu.fdiv.Cycle = fdiv.Cycle;
+		vu.fdiv.statusflag = fdiv.statusflag;
+		vu.efu.enable = efu.enable;
+		vu.efu.reg = efu.reg;
+		vu.efu.sCycle = widen_ee(efu.sCycle);
+		vu.efu.Cycle = efu.Cycle;
+	};
+
+	const auto legacyVuMid = [&](VURegs& vu) {
+		u32 cycle;
+		s32 nextBlockCycles;
+		Freeze(cycle);
+		Freeze(vu.flags);
+		Freeze(vu.code);
+		Freeze(vu.start_pc);
+		Freeze(vu.branch);
+		Freeze(vu.branchpc);
+		Freeze(vu.delaybranchpc);
+		Freeze(vu.takedelaybranch);
+		Freeze(vu.ebit);
+		Freeze(vu.pending_q);
+		Freeze(vu.pending_p);
+		FreezeSkip(4); // blockhasmbit — removed upstream
+		Freeze(vu.micro_macflags);
+		Freeze(vu.micro_clipflags);
+		Freeze(vu.micro_statusflags);
+		Freeze(vu.macflag);
+		Freeze(vu.statusflag);
+		Freeze(vu.clipflag);
+		Freeze(nextBlockCycles);
+		vu.cycle = widen_ee(cycle);
+		vu.nextBlockCycles = nextBlockCycles;
+	};
+
+	const auto legacyVuTail = [&](VURegs& vu) {
+		Freeze(vu.VIBackupCycles);
+		Freeze(vu.VIOldValue);
+		Freeze(vu.VIRegNumber);
+		legacyVuPipes(vu);
+	};
+
+	Freeze(VU0.ACC);
+	Freeze(VU0.VF);
+	Freeze(VU0.VI);
+	Freeze(VU0.q);
+	legacyVuMid(VU0);
+	legacyVuTail(VU0);
+
+	Freeze(VU1.ACC);
+	Freeze(VU1.VF);
+	Freeze(VU1.VI);
+	Freeze(VU1.q);
+	Freeze(VU1.p);
+	legacyVuMid(VU1);
+	{
+		u32 xgkicklastcycle;
+		Freeze(VU1.xgkickaddr);
+		Freeze(VU1.xgkickdiff);
+		Freeze(VU1.xgkicksizeremaining);
+		Freeze(xgkicklastcycle);
+		Freeze(VU1.xgkickcyclecount);
+		Freeze(VU1.xgkickenable);
+		Freeze(VU1.xgkickendpacket);
+		VU1.xgkicklastcycle = widen_ee(xgkicklastcycle);
+	}
+	legacyVuTail(VU1);
+	if (!IsOkay())
+		return false;
+
+	// vuJIT (untagged): the era's microRegInfo pair. PreLoadPrep's
+	// ClearCPUExecutionCaches already reset the VU recompilers (which zeroes
+	// lpState), so the payload is skipped.
+	FreezeSkip(2 * ((major == 0x9A2C) ? OldState::MICROREGINFO_9A2C : OldState::MICROREGINFO_9A34));
+
+	// VIF: same block framing as today, but the vifStruct interior moved
+	// (TRXPOS union). Field remap; the unpack buffer is bounds-checked before
+	// the raw read.
+	const auto legacyVif = [&](int idx) {
+		if (!FreezeTag(idx ? "VIF1dma" : "VIF0dma"))
+			return false;
+
+		Freeze(idx ? g_vif1Cycles : g_vif0Cycles);
+
+		OldState::vifStruct_9A2C ov;
+		Freeze(ov);
+		if (!IsOkay())
+			return false;
+
+		vifStruct& vif = idx ? vif1 : vif0;
+		vif.MaskRow = ov.MaskRow;
+		vif.MaskCol = ov.MaskCol;
+		vif.tag = ov.tag;
+		vif.cmd = ov.cmd;
+		vif.pass = ov.pass;
+		vif.cl = ov.cl;
+		vif.usn = ov.usn;
+		vif.start_aligned = ov.start_aligned;
+		vif.irq = ov.irq;
+		vif.done = ov.done;
+		vif.vifstalled = ov.vifstalled;
+		vif.stallontag = ov.stallontag;
+		vif.waitforvu = ov.waitforvu;
+		vif.unpackcalls = ov.unpackcalls;
+		vif.BITBLTBUF = ov.BITBLTBUF;
+		vif.TRXPOS = {}; // did not exist at this vintage
+		vif.TRXREG = ov.TRXREG;
+		vif.GSLastDownloadSize = ov.GSLastDownloadSize;
+		vif.irqoffset = ov.irqoffset;
+		vif.vifpacketsize = ov.vifpacketsize;
+		vif.inprogress = ov.inprogress;
+		vif.dmamode = ov.dmamode;
+		vif.queued_program = ov.queued_program;
+		vif.queued_pc = ov.queued_pc;
+		vif.queued_gif_wait = ov.queued_gif_wait;
+
+		u32 bSize;
+		Freeze(bSize);
+		if (bSize > sizeof(nVif[idx].buffer))
+		{
+			Error::SetStringFmt(error, "Legacy VIF{} unpack buffer is implausibly large ({} bytes).", idx, bSize);
+			return false;
+		}
+		nVif[idx].bSize = bSize;
+		FreezeMem(nVif[idx].buffer, bSize);
+		return IsOkay();
+	};
+
+	if (!legacyVif(0) || !legacyVif(1))
+		return false;
+
+	if (!sifFreeze()) // byte-identical since 0312e902
+		return false;
+
+	// IPU: the register/decoder payload is byte-identical; IPUCoreStatus
+	// (today appended to this block) is synthesized from the legacy IPUdma
+	// status below.
+	if (!FreezeTag("IPU"))
+		return false;
+	Freeze(ipu_fifo);
+	Freeze(g_BP);
+	Freeze(g_ipu_vqclut);
+	Freeze(g_ipu_thresh);
+	Freeze(coded_block_pattern);
+	Freeze(decoder);
+	Freeze(ipu_cmd);
+
+	if (!FreezeTag("IPUdma"))
+		return false;
+	{
+		// layout per upstream PCSX2 0312e902, pcsx2/IPU/IPUdma.h struct
+		// IPUStatus {InProgress, DMAFinished, DataRequested}.
+		bool inProgress = false, dmaFinished = false, dataRequested = false;
+		Freeze(inProgress);
+		Freeze(dmaFinished);
+		Freeze(dataRequested);
+		if (major == 0x9A34)
+			FreezeSkip(1); // CommandExecuteQueued (added 0x9A2D, gone today)
+		if (!IsOkay())
+			return false;
+
+		IPU1Status.InProgress = inProgress;
+		IPU1Status.DMAFinished = dmaFinished;
+		IPUCoreStatus.DataRequested = dataRequested;
+		IPUCoreStatus.WaitingOnIPUFrom = false;
+		IPUCoreStatus.WaitingOnIPUTo = false;
+	}
+
+	// Gif Unit: head remap (GS_FINISH grew a second flag), then the per-path
+	// freeze is unchanged since 0312e902 and handles the serialized host
+	// buffer pointer itself.
+	{
+		bool mtvuMode = false;
+		if (!FreezeTag("Gif Unit"))
+			return false;
+		Freeze(mtvuMode);
+		Freeze(gifUnit.stat);
+		Freeze(gifUnit.gsSIGNAL);
+		u8 finishFired = 0; // layout per 0312e902:pcsx2/Gif_Unit.h GS_FINISH {bool}
+		Freeze(finishFired);
+		gifUnit.gsFINISH.gsFINISHFired = (finishFired != 0);
+		gifUnit.gsFINISH.gsFINISHPending = false;
+		Freeze(gifUnit.lastTranType);
+		if (!gifPathFreeze(GIF_PATH_1) || !gifPathFreeze(GIF_PATH_2) || !gifPathFreeze(GIF_PATH_3))
+			return false;
+		if (mtvuMode != THREAD_VU1)
+			DevCon.Warning("gifUnit: MTVU Mode has switched between save/load state");
+	}
+
+	if (!gifDmaFreeze() || !sprFreeze() || !mtvuFreeze()) // all byte-identical since 0312e902
+		return false;
+
+	// ------------------------------------------------------ IOP-Subsystems
+	if (!FreezeTag("IOP-Subsystems"))
+		return false;
+
+	FreezeMem(iopMem->Sif, sizeof(iopMem->Sif));
+
+	// iopCounters: widen + mode-word translation. Today's psxCounterMode
+	// bitfield mirrors the hardware register bits 0-14 positionally, so the
+	// legacy word maps by masking; the legacy internal stopped bit moves to
+	// the new bitfield's `stopped`. The legacy blank-gate bytes are dropped —
+	// hBlanking/vBlanking resync at the next blank edge.
+	if (!FreezeTag("iopCounters"))
+		return false;
+	{
+		OldState::psxCounter_9A2C oc[8];
+		s32 pnc;
+		u32 pnsc;
+		Freeze(oc);
+		Freeze(pnc);
+		Freeze(pnsc);
+		FreezeSkip(2); // psxvblankgate, psxhblankgate
+		if (!IsOkay())
+			return false;
+
+		for (int i = 0; i < 8; i++)
+		{
+			psxCounters[i].count = oc[i].count;
+			psxCounters[i].target = oc[i].target;
+			psxCounters[i].rate = oc[i].rate;
+			psxCounters[i].interrupt = oc[i].interrupt;
+			psxCounters[i].startCycle = widen_iop(oc[i].sCycleT);
+			psxCounters[i].deltaCycles = oc[i].CycleT;
+			psxCounters[i].mode.modeval = oc[i].mode & OldState::PSXCNT_HW_MODE_MASK;
+			psxCounters[i].mode.stopped = (oc[i].mode & OldState::PSXCNT_STOPPED_9A2C) ? 1 : 0;
+			psxCounters[i].currentIrqMode.repeatInterrupt = psxCounters[i].mode.repeatIntr;
+			psxCounters[i].currentIrqMode.toggleInterrupt = psxCounters[i].mode.toggleIntr;
+		}
+		psxNextDeltaCounter = pnc;
+		psxNextStartCounter = widen_iop(pnsc);
+		psxRcntUpdate();
+	}
+
+	// SIO: the legacy transfer-engine blobs are discarded — savestates are
+	// only taken at transfer-quiescent points, so the boot/reset state is
+	// correct — but the memcard CRCs are honored so unchanged cards are not
+	// spuriously ejected (mirrors Sio2::DoState).
+	{
+		u64 mcdCrcs[2][4] = {};
+		if (major == 0x9A2C)
+		{
+			if (!FreezeTag("sio"))
+				return false;
+			FreezeSkip(OldState::SIO_BLOB_9A2C);
+			u64 crcs[2][8];
+			Freeze(crcs);
+			for (int port = 0; port < 2; port++)
+			{
+				for (int slot = 0; slot < 4; slot++)
+					mcdCrcs[port][slot] = crcs[port][slot];
+			}
+			if (!FreezeTag("sio2"))
+				return false;
+			FreezeSkip(OldState::SIO2_BLOB_9A2C);
+		}
+		else
+		{
+			if (!FreezeTag("sio0"))
+				return false;
+			FreezeSkip(OldState::SIO0_BLOB_9A34);
+			if (!FreezeTag("sio2"))
+				return false;
+			FreezeSkip(OldState::SIO2_BLOB_9A34);
+			for (int i = 0; i < 2; i++) // FreezeDeque<u8> fifoIn/fifoOut
+			{
+				u32 count = 0;
+				Freeze(count);
+				if (count > 0x10000)
+				{
+					Error::SetStringFmt(error, "Legacy SIO2 fifo is implausibly large ({} bytes).", count);
+					return false;
+				}
+				FreezeSkip(static_cast<int>(count));
+			}
+			Freeze(mcdCrcs);
+		}
+		if (!IsOkay())
+			return false;
+
+		bool ejected = false;
+		for (u32 port = 0; port < SIO::PORTS && !ejected; port++)
+		{
+			for (u32 slot = 0; slot < SIO::SLOTS; slot++)
+			{
+				if (mcdCrcs[port][slot] != mcds[port][slot].GetChecksum())
+				{
+					AutoEject::SetAll();
+					ejected = true;
+					break;
+				}
+			}
+		}
+
+		g_Sio0.SoftReset();
+		g_Sio2.SoftReset();
+		g_MultitapArr.at(0).FullReset();
+		g_MultitapArr.at(1).FullReset();
+	}
+
+	if (!cdrFreeze()) // byte-identical since 0312e902
+		return false;
+
+	// cdvd: same field order under older names; RTCcount widened to double,
+	// RotSpeed recomputed for the current disc/speed.
+	if (!FreezeTag("cdvd"))
+		return false;
+	{
+		auto ov = std::make_unique<OldState::cdvdStruct_9A2C>();
+		Freeze(*ov);
+		if (!IsOkay())
+			return false;
+
+		cdvd.nCommand = ov->nCommand;
+		cdvd.Ready = ov->Ready;
+		cdvd.Error = ov->Error;
+		cdvd.IntrStat = ov->IntrStat;
+		cdvd.Status = ov->Status;
+		cdvd.StatusSticky = ov->StatusSticky;
+		cdvd.DiscType = ov->Type;
+		cdvd.sCommand = ov->sCommand;
+		cdvd.sDataIn = ov->sDataIn;
+		cdvd.sDataOut = ov->sDataOut;
+		cdvd.HowTo = ov->HowTo;
+		std::memcpy(cdvd.NCMDParamBuff, ov->NCMDParam, sizeof(cdvd.NCMDParamBuff));
+		std::memcpy(cdvd.SCMDParamBuff, ov->SCMDParam, sizeof(cdvd.SCMDParamBuff));
+		std::memcpy(cdvd.SCMDResultBuff, ov->SCMDResult, sizeof(cdvd.SCMDResultBuff));
+		cdvd.NCMDParamCnt = ov->NCMDParamC;
+		cdvd.NCMDParamPos = ov->NCMDParamP;
+		cdvd.SCMDParamCnt = ov->SCMDParamC;
+		cdvd.SCMDParamPos = ov->SCMDParamP;
+		cdvd.SCMDResultCnt = ov->SCMDResultC;
+		cdvd.SCMDResultPos = ov->SCMDResultP;
+		cdvd.CBlockIndex = ov->CBlockIndex;
+		cdvd.COffset = ov->COffset;
+		cdvd.CReadWrite = ov->CReadWrite;
+		cdvd.CNumBlocks = ov->CNumBlocks;
+		cdvd.RTCcount = static_cast<double>(ov->RTCcount);
+		cdvd.RTC = ov->RTC;
+		cdvd.CurrentSector = ov->Sector;
+		cdvd.SectorCnt = ov->nSectors;
+		cdvd.SeekCompleted = ov->Readed;
+		cdvd.Reading = ov->Reading;
+		cdvd.WaitingDMA = ov->WaitingDMA;
+		cdvd.ReadMode = ov->ReadMode;
+		cdvd.BlockSize = ov->BlockSize;
+		cdvd.Speed = ov->Speed;
+		cdvd.RetryCntMax = ov->RetryCnt;
+		cdvd.CurrentRetryCnt = ov->RetryCntP;
+		cdvd.ReadErr = ov->RErr;
+		cdvd.SpindlCtrl = ov->SpindlCtrl;
+		std::memcpy(cdvd.Key, ov->Key, sizeof(cdvd.Key));
+		cdvd.KeyXor = ov->KeyXor;
+		cdvd.decSet = ov->decSet;
+		std::memcpy(cdvd.mg_buffer, ov->mg_buffer, sizeof(cdvd.mg_buffer));
+		cdvd.mg_size = ov->mg_size;
+		cdvd.mg_maxsize = ov->mg_maxsize;
+		cdvd.mg_datatype = ov->mg_datatype;
+		std::memcpy(cdvd.mg_kbit, ov->mg_kbit, sizeof(cdvd.mg_kbit));
+		std::memcpy(cdvd.mg_kcon, ov->mg_kcon, sizeof(cdvd.mg_kcon));
+		cdvd.TrayTimeout = ov->TrayTimeout;
+		cdvd.Action = ov->Action;
+		cdvd.SeekToSector = ov->SeekToSector;
+		cdvd.MaxSector = ov->MaxSector;
+		cdvd.ReadTime = ov->ReadTime;
+		cdvd.Spinning = ov->Spinning;
+		cdvd.Tray = ov->Tray;
+		cdvd.nextSectorsBuffered = ov->nextSectorsBuffered;
+		cdvd.AbortRequested = ov->AbortRequested;
+
+		cdvdRecalculateRotSpeed();
+
+		// Same post-load behavior as cdvdFreeze: make sure the source has the
+		// expected track buffered (a seek may be in progress).
+		if (cdvd.Reading)
+			cdvd.ReadErr = DoCDVDreadTrack(cdvd.SeekCompleted ? cdvd.CurrentSector : cdvd.SeekToSector, cdvd.ReadMode);
+	}
+
+	if (!deci2Freeze()) // byte-identical since 0312e902
+		return false;
+
+	// Tail: 0x9A2C-era builds compile input recording out, so their blob ends
+	// after deci2; 0x9A34 (NetherSX2 4248) carries the InputRecording block.
+	// Neither has hostHandles — mirror handleFreeze's load-side reset.
+	if (major == 0x9A34)
+	{
+		if (!InputRecordingFreeze())
+			return false;
+	}
+
+	if (EmuConfig.HostFs)
+		R3000A::ioman::reset();
+
+	// The legacy layouts are fully accounted; any residue means the blob was
+	// not what the version id claimed, and the half-applied load is unwound
+	// by the caller (VMManager::Reset).
+	if (m_idx != static_cast<int>(m_memory.size()))
+	{
+		Error::SetStringFmt(error, "Legacy save state has {} unexpected trailing bytes (version {:x}).",
+			static_cast<int>(m_memory.size()) - m_idx, m_version);
+		return false;
+	}
+
+	return IsOkay();
+}

--- a/pcsx2/SaveStateLegacy.cpp
+++ b/pcsx2/SaveStateLegacy.cpp
@@ -505,7 +505,11 @@ static bool CheckLegacyIdentity(const StagedRegs& st, Error* error)
 		return false;
 	}
 
-	if (st.elfCRC != current_crc)
+	// The ELF CRC only means anything once the VM has actually booted an ELF.
+	// Loading a state at startup resets the VM first, which clears the CRC, so
+	// an unknown CRC here is the normal case and is not a mismatch — the disc
+	// serial checked above is what identifies the game.
+	if (current_crc != 0 && st.elfCRC != current_crc)
 	{
 		Error::SetStringFmt(error, TRANSLATE_FS("SaveState", "This AetherSX2 save state is for CRC {0:08X}, but the running game is CRC {1:08X}."),
 			st.elfCRC, current_crc);

--- a/pcsx2/SaveStateLegacy.h
+++ b/pcsx2/SaveStateLegacy.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 yaps2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include "common/Pcsx2Types.h"
+
+// Loader for legacy-format savestates: upstream-PCSX2 formats of the
+// AetherSX2/NetherSX2 era. The container (zip entry set) is unchanged across
+// eras; what differs is the layout of the versioned blobs. The supported
+// legacy majors and the blob reader live in SaveStateLegacy.cpp; the per-entry
+// legacy handling (GS/SPU2/PAD) hangs off SaveState_UnzipFromZip.
+namespace SaveStateLegacy
+{
+	// The legacy savestate majors the in-engine reader understands:
+	//   0x9A2C — upstream PCSX2 at 0312e902 (the AetherSX2 v1.5-era format)
+	//   0x9A34 — upstream PCSX2 at 7e939b75 (the NetherSX2 v2.1 format)
+	bool IsSupportedVersion(u32 savever);
+
+	// Widens a wrapping 32-bit cycle counter to 64 bits relative to a domain
+	// base: the signed 32-bit delta to the old base is preserved against the
+	// new base. Correct across u32 wraps, which zero-extension is not.
+	__fi u64 WidenCycle(u32 old_value, u32 old_base, u64 new_base)
+	{
+		return new_base + static_cast<s64>(static_cast<s32>(old_value - old_base));
+	}
+} // namespace SaveStateLegacy

--- a/pcsx2/SaveStateLegacy.h
+++ b/pcsx2/SaveStateLegacy.h
@@ -20,7 +20,7 @@ namespace SaveStateLegacy
 	// Widens a wrapping 32-bit cycle counter to 64 bits relative to a domain
 	// base: the signed 32-bit delta to the old base is preserved against the
 	// new base. Correct across u32 wraps, which zero-extension is not.
-	__fi u64 WidenCycle(u32 old_value, u32 old_base, u64 new_base)
+	inline constexpr u64 WidenCycle(u32 old_value, u32 old_base, u64 new_base)
 	{
 		return new_base + static_cast<s64>(static_cast<s32>(old_value - old_base));
 	}

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -310,6 +310,7 @@
     <ClCompile Include="SPU2\wavedump_wav.cpp" />
     <ClCompile Include="SPU2\RegTable.cpp" />
     <ClCompile Include="SPU2\spu2freeze.cpp" />
+    <ClCompile Include="SPU2\spu2freeze-legacy.cpp" />
     <ClCompile Include="SPU2\spu2sys.cpp" />
     <ClCompile Include="SPU2\ADSR.cpp" />
     <ClCompile Include="SPU2\Mixer.cpp" />

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -421,6 +421,7 @@
     <ClCompile Include="windows\Optimus.cpp" />
     <ClCompile Include="Pcsx2Config.cpp" />
     <ClCompile Include="SaveState.cpp" />
+    <ClCompile Include="SaveStateLegacy.cpp" />
     <ClCompile Include="SourceLog.cpp" />
     <ClCompile Include="Elfheader.cpp" />
     <ClCompile Include="CDVD\InputIsoFile.cpp" />
@@ -884,6 +885,7 @@
     <ClInclude Include="Common.h" />
     <ClInclude Include="Config.h" />
     <ClInclude Include="SaveState.h" />
+    <ClInclude Include="SaveStateLegacy.h" />
     <ClInclude Include="Counters.h" />
     <ClInclude Include="Dmac.h" />
     <ClInclude Include="Hardware.h" />

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -425,6 +425,9 @@
     <ClCompile Include="SaveState.cpp">
       <Filter>System</Filter>
     </ClCompile>
+    <ClCompile Include="SaveStateLegacy.cpp">
+      <Filter>System</Filter>
+    </ClCompile>
     <ClCompile Include="SourceLog.cpp">
       <Filter>System</Filter>
     </ClCompile>
@@ -1491,6 +1494,9 @@
       <Filter>System\Include</Filter>
     </ClInclude>
     <ClInclude Include="SaveState.h">
+      <Filter>System\Include</Filter>
+    </ClInclude>
+    <ClInclude Include="SaveStateLegacy.h">
       <Filter>System\Include</Filter>
     </ClInclude>
     <ClInclude Include="Dmac.h">

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -812,6 +812,9 @@
     <ClCompile Include="SPU2\spu2freeze.cpp">
       <Filter>System\Ps2\SPU2</Filter>
     </ClCompile>
+    <ClCompile Include="SPU2\spu2freeze-legacy.cpp">
+      <Filter>System\Ps2\SPU2</Filter>
+    </ClCompile>
     <ClCompile Include="SPU2\spu2sys.cpp">
       <Filter>System\Ps2\SPU2</Filter>
     </ClCompile>

--- a/tests/ctest/core/CMakeLists.txt
+++ b/tests/ctest/core/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_pcsx2_test(core_test
 	patch_tests.cpp
+	savestate_legacy_tests.cpp
 	MockMemoryInterface.h
 	StubHost.cpp
 )

--- a/tests/ctest/core/savestate_legacy_tests.cpp
+++ b/tests/ctest/core/savestate_legacy_tests.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 yaps2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "SaveStateLegacy.h"
+
+#include <gtest/gtest.h>
+
+// The legacy save state formats count cycles in 32 bits, which wrap roughly
+// every 14.6 seconds of emulated time; today's counters are 64-bit. Widening
+// has to preserve the signed distance to the domain's own cycle counter, since
+// that distance — not the absolute value — is what schedules events.
+
+TEST(SaveStateLegacyWidenCycle, ValueAtTheBaseLandsOnTheNewBase)
+{
+	EXPECT_EQ(SaveStateLegacy::WidenCycle(0x1000, 0x1000, 0x1000), 0x1000u);
+	EXPECT_EQ(SaveStateLegacy::WidenCycle(0x1000, 0x1000, 0x1'0000'0000ull), 0x1'0000'0000ull);
+}
+
+TEST(SaveStateLegacyWidenCycle, PreservesDistanceToTheBase)
+{
+	// Ahead of the base (an event scheduled in the future).
+	EXPECT_EQ(SaveStateLegacy::WidenCycle(0x1064, 0x1000, 0x5000), 0x5064u);
+	// Behind the base (an event whose deadline has passed).
+	EXPECT_EQ(SaveStateLegacy::WidenCycle(0x0F9C, 0x1000, 0x5000), 0x4F9Cu);
+}
+
+TEST(SaveStateLegacyWidenCycle, SurvivesAWrapAheadOfTheBase)
+{
+	// The base is just short of the 32-bit wrap and the event is just past it,
+	// so the raw values are 4 billion apart while the real distance is 200.
+	// Zero-extension would schedule the event an eternity away.
+	constexpr u32 base = 0xFFFF'FF9Cu;
+	constexpr u32 value = 0x0000'0064u; // base + 200, wrapped
+	EXPECT_EQ(SaveStateLegacy::WidenCycle(value, base, 0x1'0000'0000ull), 0x1'0000'00C8ull);
+}
+
+TEST(SaveStateLegacyWidenCycle, SurvivesAWrapBehindTheBase)
+{
+	// Mirror image: the base has wrapped past zero and the event has not, so
+	// the event is 200 cycles in the past.
+	constexpr u32 base = 0x0000'0064u;
+	constexpr u32 value = 0xFFFF'FF9Cu; // base - 200, wrapped
+	EXPECT_EQ(SaveStateLegacy::WidenCycle(value, base, 0x1'0000'0064ull), 0xFFFF'FF9Cull);
+}
+
+TEST(SaveStateLegacyWidenCycle, IsUsableAtCompileTime)
+{
+	// The mappers widen in bulk, so this has to fold rather than call.
+	static_assert(SaveStateLegacy::WidenCycle(0x1064, 0x1000, 0x5000) == 0x5064u);
+	static_assert(SaveStateLegacy::WidenCycle(0x64, 0xFFFF'FF9Cu, 0x1'0000'0000ull) == 0x1'0000'00C8ull);
+	SUCCEED();
+}
+
+TEST(SaveStateLegacyVersion, AcceptsOnlyTheTwoFormatsSeenInTheWild)
+{
+	// 0x9A2C is the AetherSX2 v1.5-era format, 0x9A34 NetherSX2 v2.1's.
+	EXPECT_TRUE(SaveStateLegacy::IsSupportedVersion(0x9A2C0000));
+	EXPECT_TRUE(SaveStateLegacy::IsSupportedVersion(0x9A340000));
+
+	// Minor revisions within an accepted major share its blob layout.
+	EXPECT_TRUE(SaveStateLegacy::IsSupportedVersion(0x9A2C0001));
+
+	// Neighbouring majors are different layouts we have never seen a file of,
+	// and the current major goes through the normal reader.
+	EXPECT_FALSE(SaveStateLegacy::IsSupportedVersion(0x9A2B0000));
+	EXPECT_FALSE(SaveStateLegacy::IsSupportedVersion(0x9A350000));
+	EXPECT_FALSE(SaveStateLegacy::IsSupportedVersion(0x9A590000));
+	EXPECT_FALSE(SaveStateLegacy::IsSupportedVersion(0));
+}


### PR DESCRIPTION
Load AetherSX2 and NetherSX2 save states directly, so people arriving from those
emulators keep their libraries instead of starting every game over. Conversion
falls out for free: once a legacy state loads, saving writes a current-format
one.

## How it works

Both emulators kept upstream PCSX2's savestate format and version numbers
verbatim, so there is nothing exotic in the container — the zip entry set is
unchanged and the whole problem is versioned struct layouts. Two majors exist in
the wild:

| Major | Written by | Upstream layout |
|---|---|---|
| `0x9A2C` | AetherSX2 v1.5-era (3606/3668) | PCSX2 at `0312e902` |
| `0x9A34` | NetherSX2 v2.1 (4248) | PCSX2 at `7e939b75` |

`SaveStateLegacy.cpp` reads those layouts field-by-field straight into live
emulator state. Old structs are declared inline, each cited to the upstream sha
its layout came from and guarded by a `static_assert` on its byte-exact size.
Where a block never changed shape the existing freeze function is reused
unmodified; everything else is remapped. **Every layout fact here comes from
upstream PCSX2's own git history plus byte inspection of real state files** —
the shas are in the source so any claim can be checked with `git show`.

The one piece of real arithmetic is cycle widening. The old formats count cycles
in 32 bits, wrapping about every 14.6 seconds of emulated time, where ours are
64-bit. Zero-extension is wrong across a wrap, so counters widen by their signed
distance to their own domain's cycle count. That is the unit-tested part; getting
it wrong presents as "the game just hangs sometimes".

## What does not carry across

Controllers, USB and achievements predate the `StateWrapper` streams that read
them today, so those keep whatever the running VM booted with and the entries are
not required to be present. Memory cards are honoured through their CRCs — an
unchanged card is not spuriously ejected, a changed one triggers the normal
reconnect. Per-voice position inside the current 28-sample decode block does not
survive (a sub-millisecond hiccup, once). The player gets one OSD line saying the
state was imported and that saving converts it.

Everything else is restored, including the SPU2 mixer, voices and in-flight DMA —
see the last commit for why a partial SPU2 restore turns out not to be viable.

## Verification

- **Format**: a byte-exact walker over a 29-file corpus of both majors, every tag
  found at its computed offset and every byte accounted for, terminating exactly
  at EOF. That gate ran before any of this C++ existed.
- **Games**: Ratchet & Clank: Up Your Arsenal resumes from both formats — the
  0x9A2C path exercises all three of that era's deviations from stock upstream.
  EE, IOP and GS all run on from the restored state, and it has been played by
  hand with sound.
- **Audio**: graded headless by spectral flatness against known-good and
  known-bad captures.
- **Tests**: 92 core, 1714 recompiler, green.

Native save states are untouched by all of this — the legacy path only engages
when the version word says so.

## Not yet verified

Only two titles have been booted; the rest of the corpus (SotC, Jak II, Rogue
Galaxy, Katamari, Black) has not. Pads and memory cards have not been exercised
by hand, nor the MTVU on/off matrix, nor the round trip of re-saving a converted
state and reloading it.

## Worth an opinion

- **Hard-failing on a disc-serial mismatch.** A state from a different game will
  corrupt emulation, so this refuses rather than warns. The ELF CRC is only
  compared when the VM actually has one, since loading at startup resets the VM
  and clears it.
- **Legacy states require 32MB EE mode**, because the block predates the flag
  that records it. Currently a clean refusal.
- **Two new virtuals on `BaseSavestateEntry`** (`SupportsLegacy`,
  `FreezeInLegacy`) rather than special-casing entry names in the loader.
- **The era's SPU2 mapping lives in its own translation unit** so `spu2freeze.cpp`
  stays byte-identical to upstream's and future merges of it stay clean. Same
  reasoning as keeping the reader out of `SaveState.cpp`.
- **Adding a third major later** means one entry in a whitelist plus its layout
  structs; nothing else is version-aware.
