### PR TITLE
iOS: fix the Default preset and stop resets moving your Frame Pacing

### DIFF
--- a/platforms/ios/app/src/main/cpp/CMakeLists.txt
+++ b/platforms/ios/app/src/main/cpp/CMakeLists.txt
@@ -363,7 +363,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
 	# stale for the same reason. Upstream still writes it at configure time up in
 	# write_svnrev_h; this only refreshes it, and produces identical bytes.
 	add_custom_target(armsx2_svnrev ALL
-		BYPRODUCTS "${CMAKE_BINARY_DIR}/common/include/svnrev.h"
 		COMMAND ${CMAKE_COMMAND}
 			-DGIT_WORKING_DIR=${PROJECT_SOURCE_DIR}
 			-DOUTPUT_FILE=${CMAKE_BINARY_DIR}/common/include/svnrev.h

--- a/platforms/ios/app/src/main/swift/Models/Setting.swift
+++ b/platforms/ios/app/src/main/swift/Models/Setting.swift
@@ -6,11 +6,13 @@ import Foundation
 /// Configuration-only: holds the INI section/key/writer for a setting. The
 /// @Observable macro owns the stored property; didSet consults this config.
 ///
-/// `onSet` runs from each property's `didSet`. Swift suppresses property
-/// observers during `init()`, so `onSet` is not reached while
-/// `SettingsStore.init()` is running; the graphics-pipeline closures still go
-/// through `requestGraphicsApplyGuarded()` (which no-ops while INI is loading)
-/// as a guard, should that ever change.
+/// `onSet` runs from each property's `didSet`, including during
+/// `SettingsStore.init()`. Swift only suppresses observers on stored
+/// properties, and @Observable rewrites these into computed ones, so the
+/// setter body runs on every assignment. `suppressible` settings bail on the
+/// guard while the INI loads; the 88 that are not suppressible reach `onSet`
+/// mid-init, and `requestGraphicsApplyGuarded()` no-opping while INI is
+/// loading is what actually keeps that harmless.
 ///
 /// Every `EmuCore/GS` setting gets that apply hook by default. Opting in per
 /// setting is how the sprite hacks, the user hacks and the OSD flags ended up

--- a/platforms/ios/app/src/main/swift/Models/SettingsPresetCatalog.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsPresetCatalog.swift
@@ -104,6 +104,8 @@ enum BuiltInSettingsPreset: String, CaseIterable, Identifiable {
     private var configuration: Configuration {
         switch self {
         case .defaultPreset:
+            // Only isActive reads this; apply() short-circuits into resetAllDefaults. So it has to
+            // describe what that reset actually leaves behind, and it had drifted on two counts.
             return Configuration(
                 fastBoot: false,
                 enableCheats: false,
@@ -111,10 +113,11 @@ enum BuiltInSettingsPreset: String, CaseIterable, Identifiable {
                 fastCDVD: false,
                 fxaa: false,
                 casSharpening: false,
-                vsyncQueueSize: 8,
+                vsyncQueueSize: 4,
                 upscaleMultiplier: 1,
                 ophFlagHack: false,
-                emulationOnlyMode: false
+                emulationOnlyMode: false,
+                showBackgroundInSettings: true
             )
         case .ultraQuality:
             var configuration = qualityConfiguration(upscaleMultiplier: 2)

--- a/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
@@ -381,7 +381,7 @@ final class SettingsStore {
     var frameLimiterEnabled: Bool {
         didSet {
             applyFrameLimiterSettings()
-            markFramePacingCustom()
+            if frameLimiterEnabled != oldValue { markFramePacingCustom() }
         }
     }
     var fastForwardRuntimeEnabled = false
@@ -394,7 +394,9 @@ final class SettingsStore {
                 return
             }
             applyFrameLimiterSettings()
-            markFramePacingCustom()
+            // Compare against the clamped old value: this didSet re-enters after clamping, so
+            // oldValue is the unclamped intermediate, and clampedTargetFPS rounds.
+            if abs(targetFPS - Self.clampedTargetFPS(oldValue)) > 0.001 { markFramePacingCustom() }
         }
     }
     // clamps to 1.25...10.0
@@ -438,7 +440,7 @@ final class SettingsStore {
         guard !(_audioBufferMsConfig.suppressible && suppressINIWrites) else { return }
         _audioBufferMsConfig.writer(_audioBufferMsConfig.section, _audioBufferMsConfig.key, audioBufferMs)
         _audioBufferMsConfig.onSet?(audioBufferMs)
-        markFramePacingCustom()
+        if audioBufferMs != oldValue { markFramePacingCustom() }
     }}
     let _audioOutputLatencyMsConfig = Setting<Int>(
         section: "SPU2/Output", key: "OutputLatencyMS", default: 20,
@@ -447,7 +449,7 @@ final class SettingsStore {
         guard !(_audioOutputLatencyMsConfig.suppressible && suppressINIWrites) else { return }
         _audioOutputLatencyMsConfig.writer(_audioOutputLatencyMsConfig.section, _audioOutputLatencyMsConfig.key, audioOutputLatencyMs)
         _audioOutputLatencyMsConfig.onSet?(audioOutputLatencyMs)
-        markFramePacingCustom()
+        if audioOutputLatencyMs != oldValue { markFramePacingCustom() }
     }}
     let _audioFastForwardVolumeConfig = Setting<Int>(
         section: "SPU2/Output", key: "FastForwardVolume", default: 100,
@@ -676,7 +678,7 @@ final class SettingsStore {
         guard !(_vsyncQueueSizeConfig.suppressible && suppressINIWrites) else { return }
         _vsyncQueueSizeConfig.writer(_vsyncQueueSizeConfig.section, _vsyncQueueSizeConfig.key, vsyncQueueSize)
         _vsyncQueueSizeConfig.onSet?(vsyncQueueSize)
-        markFramePacingCustom()
+        if vsyncQueueSize != oldValue { markFramePacingCustom() }
     }}
     let _textureFilteringConfig = Setting<Int>(
         section: "EmuCore/GS", key: "filter", default: 2,
@@ -1202,7 +1204,7 @@ final class SettingsStore {
         guard !(_syncToHostRefreshConfig.suppressible && suppressINIWrites) else { return }
         _syncToHostRefreshConfig.writer(_syncToHostRefreshConfig.section, _syncToHostRefreshConfig.key, syncToHostRefresh)
         _syncToHostRefreshConfig.onSet?(syncToHostRefresh)
-        markFramePacingCustom()
+        if syncToHostRefresh != oldValue { markFramePacingCustom() }
     }}
     let _integerScalingConfig = Setting<Bool>(
         section: "EmuCore/GS", key: "IntegerScaling", default: false,

--- a/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
@@ -2704,8 +2704,6 @@ final class SettingsStore {
         fastForwardScalar = Self.defaultFastForwardScalar
         emulatorVolumePercent = Self.defaultEmulatorVolumePercent
         audioTimeStretch = true
-        audioBufferMs = 50
-        audioOutputLatencyMs = 20
         audioFastForwardVolume = 100
         audioSwapChannels = false
         ntscFramerate = 59.94
@@ -2768,7 +2766,6 @@ final class SettingsStore {
         ARMSX2Bridge.setINIInt("EmuCore/GS", key: "UserHackOverrides", value: 0)
         renderer = 17           // Metal
         upscaleMultiplier = 1.0 // Native PS2
-        vsyncQueueSize = 8
         textureFiltering = 2    // Bilinear (PS2)
         backThreadMode = 0            // Disabled
         hardwareMipmapping = true
@@ -2812,7 +2809,6 @@ final class SettingsStore {
         pcrtcAntiBlur = true
         disableInterlaceOffset = false
         skipDuplicateFrames = true
-        syncToHostRefresh = false
         integerScaling = false
         shadeBoost = false
         shadeBoostBrightness = 50
@@ -2840,6 +2836,10 @@ final class SettingsStore {
         dumpDirectTextures = true
         dumpPaletteTextures = true
 
+        // The graphics and emulator resets no longer touch the pacing keys, so this is the only
+        // thing restoring them. Apply the values first, the way the Frame Pacing screen's own
+        // reset does, rather than leaning on the preset's didSet to do it.
+        applyFramePacingPreset(.optimal)
         framePacingPreset = .optimal
         adaptiveResolutionEnabled = false
 

--- a/platforms/ios/app/src/main/swift/Views/HelpView.swift
+++ b/platforms/ios/app/src/main/swift/Views/HelpView.swift
@@ -75,7 +75,7 @@ private let helpData: [HelpSection] = [
         ),
         HelpItem(
             question: "VSync Queue Size",
-            answer: "Number of pre-rendered frames. Higher values reduce frame drops but increase input latency. Default: 8."
+            answer: "Number of pre-rendered frames. Higher values reduce frame drops but increase input latency. Default: 4."
         ),
     ]),
     HelpSection(title: "Overlay", icon: "speedometer", items: [

--- a/platforms/ios/app/src/main/swift/Views/PerGameSettingsPanel.swift
+++ b/platforms/ios/app/src/main/swift/Views/PerGameSettingsPanel.swift
@@ -539,7 +539,7 @@ struct PerGameSettingsPanel: View {
                     } label: {
                         HStack(spacing: 10) {
                             Image(systemName: category.systemImage)
-                                .frame(width: 22)
+                                .frame(width: OverlayTheme.rowIconWidth)
                                 .foregroundStyle(selected ? OverlayTheme.accent : OverlayTheme.textSecondary)
                             Text(settings.localized(category.titleKey))
                                 .font(.callout)
@@ -768,68 +768,25 @@ struct PerGameSettingsPanel: View {
 
     private var rootForm: some View {
         Form {
-            identitySection
-            overridesSection
+            PerGameIdentitySection(
+                enabled: enabled,
+                displayName: displayName,
+                hasPendingChanges: hasPendingChanges,
+                savesToRunningGame: savesToRunningGame,
+                game: game,
+                settings: settings
+            )
+            PerGameOverridesSection(
+                enabled: $enabled,
+                showResetAllConfirmation: $showResetAllConfirmation,
+                hasGameSettingsIdentity: hasGameSettingsIdentity,
+                savesToRunningGame: savesToRunningGame,
+                settings: settings
+            )
             categoryLinksSection
-            statusSection
+            PerGameStatusSection(statusMessage: statusMessage, settings: settings)
         }
         .scrollContentBackground(.hidden)
-    }
-
-    @ViewBuilder
-    private var identitySection: some View {
-        Section {
-            HStack(spacing: 12) {
-                Image(systemName: enabled ? "slider.horizontal.3" : "power")
-                    .font(.title3)
-                    .foregroundStyle(enabled ? Color.accentColor : Color.secondary)
-                    .frame(width: 32, height: 32)
-                    .background(Color.accentColor.opacity(enabled ? 0.14 : 0), in: Circle())
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(displayName)
-                        .font(.headline)
-                        .lineLimit(2)
-                    if let serial = game.metadata["serial"], !serial.isEmpty {
-                        Text("\(serial)  ·  CRC \(PadLayoutGameIdentity.normalizedCRC(game.metadata["crc"] ?? ""))")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .textSelection(.enabled)
-                    }
-                    Text(hasPendingChanges
-                         ? (savesToRunningGame
-                            ? settings.localized("Unsaved changes — tap Save to apply now.")
-                            : settings.localized("Unsaved changes — Save to apply on next boot."))
-                         : settings.localized("No pending changes."))
-                        .font(.caption)
-                        .foregroundStyle(hasPendingChanges ? Color.accentColor : Color.secondary)
-                }
-            }
-            .padding(.vertical, 4)
-        }
-    }
-
-    @ViewBuilder
-    private var overridesSection: some View {
-        Section {
-            Toggle(settings.localized("Use Per-Game Overrides"), isOn: $enabled)
-            Text(settings.localized(savesToRunningGame
-                ? "Overrides are saved for this game only and apply when you save, while the game runs."
-                : "Overrides are saved for this game only and apply on the next boot of this title."))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            if !hasGameSettingsIdentity {
-                Text(settings.localized("Start this game once before saving its settings."))
-                    .font(.caption)
-                    .foregroundStyle(OverlayTheme.warm)
-            }
-            Button(role: .destructive) {
-                showResetAllConfirmation = true
-            } label: {
-                Label(settings.localized("Reset All Overrides"), systemImage: "arrow.counterclockwise")
-            }
-            .disabled(!hasGameSettingsIdentity)
-        }
     }
 
     @ViewBuilder
@@ -874,17 +831,6 @@ struct PerGameSettingsPanel: View {
                 retroAchievementsTab
             } label: {
                 Label(settings.localized("RetroAchievements"), systemImage: "trophy")
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var statusSection: some View {
-        if let statusMessage {
-            Section {
-                Text(statusMessage)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
         }
     }

--- a/platforms/ios/app/src/main/swift/Views/Settings/PerGame/AudioTab.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/PerGame/AudioTab.swift
@@ -67,17 +67,17 @@ struct AudioTab: View {
 
                 Picker(settings.localized("Fast-Forward Volume"), selection: $perGameFastForwardVolume) {
                     Text(settings.localized("Use Global")).tag(-1)
-                    ForEach([0, 50, 100, 150, 200], id: \.self) { Text("\($0)%").tag($0) }
+                    ForEach(SettingsOptions.fastForwardVolume, id: \.self) { Text("\($0)%").tag($0) }
                 }
                 .disabled(!enabled)
                 Picker(settings.localized("Buffer Size"), selection: $perGameBufferMS) {
                     Text(settings.localized("Use Global")).tag(-1)
-                    ForEach([10, 25, 50, 75, 100, 150, 200], id: \.self) { Text("\($0) ms").tag($0) }
+                    ForEach(SettingsOptions.audioBufferMs, id: \.self) { Text("\($0) ms").tag($0) }
                 }
                 .disabled(!enabled)
                 Picker(settings.localized("Output Latency"), selection: $perGameOutputLatencyMS) {
                     Text(settings.localized("Use Global")).tag(-1)
-                    ForEach([5, 10, 20, 30, 50, 100, 200], id: \.self) { Text("\($0) ms").tag($0) }
+                    ForEach(SettingsOptions.audioOutputLatencyMs, id: \.self) { Text("\($0) ms").tag($0) }
                 }
                 .disabled(!enabled)
             }

--- a/platforms/ios/app/src/main/swift/Views/Settings/PerGame/FixesTab.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/PerGame/FixesTab.swift
@@ -35,10 +35,9 @@ struct FixesTab: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Picker(settings.localized("Texture Inside RT"), selection: $perGameTextureInsideRt) {
-                    Text(settings.localized("Use Global")).tag(-1)
-                    Text(settings.localized("Off")).tag(0)
-                    Text(settings.localized("Inside Targets")).tag(1)
-                    Text(settings.localized("Merge Targets")).tag(2)
+                    ForEach(SettingsOptions.withUseGlobal(SettingsOptions.textureInsideRT), id: \.id) { option in
+                        Text(settings.localized(option.title)).tag(option.id)
+                    }
                 }
                 .disabled(!enabled)
                 Text(settings.localized("Fixes games that render into areas of the framebuffer they later read back as textures (common half-screen or garbled-graphics fixes). " + (savesToRunningGame ? "Applies when you save." : "Applies on next boot.")))

--- a/platforms/ios/app/src/main/swift/Views/Settings/PerGame/FramePacingTab.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/PerGame/FramePacingTab.swift
@@ -55,13 +55,13 @@ struct FramePacingTab: View {
 
                 Picker(settings.localized("FPS Target"), selection: $perGameTargetFPS) {
                     Text(settings.localized("Use Global")).tag(-1)
-                    ForEach([30, 45, 60, 90, 120], id: \.self) { Text("\($0)").tag($0) }
+                    ForEach(SettingsOptions.targetFPS, id: \.self) { Text("\($0)").tag($0) }
                 }
                 .disabled(perGameFrameLimiter == 0 || !enabled)
 
                 Picker(settings.localized("VSync Queue Size"), selection: $perGameVsyncQueue) {
                     Text(settings.localized("Use Global")).tag(-1)
-                    ForEach([2, 3, 4, 5, 6, 8, 10, 12, 16], id: \.self) { Text("\($0)").tag($0) }
+                    ForEach(SettingsOptions.vsyncQueue, id: \.self) { Text("\($0)").tag($0) }
                 }
                 .disabled(!enabled)
 
@@ -77,13 +77,13 @@ struct FramePacingTab: View {
 
                 Picker(settings.localized("Buffer Size"), selection: $perGameBufferMS) {
                     Text(settings.localized("Use Global")).tag(-1)
-                    ForEach([10, 25, 50, 75, 100, 150, 200], id: \.self) { Text("\($0) ms").tag($0) }
+                    ForEach(SettingsOptions.audioBufferMs, id: \.self) { Text("\($0) ms").tag($0) }
                 }
                 .disabled(!enabled)
 
                 Picker(settings.localized("Output Latency"), selection: $perGameOutputLatencyMS) {
                     Text(settings.localized("Use Global")).tag(-1)
-                    ForEach([5, 10, 20, 30, 50, 100, 200], id: \.self) { Text("\($0) ms").tag($0) }
+                    ForEach(SettingsOptions.audioOutputLatencyMs, id: \.self) { Text("\($0) ms").tag($0) }
                 }
                 .disabled(!enabled)
             } header: {

--- a/platforms/ios/app/src/main/swift/Views/Settings/PerGame/GeneralTab.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/PerGame/GeneralTab.swift
@@ -3,6 +3,9 @@
 
 import SwiftUI
 
+/// Landscape shows these three sections as their own category; portrait puts them at the
+/// top of the panel's root form above the category links. Same content either way, so the
+/// sections live here once. They used to be written out twice and had already drifted.
 struct GeneralTab: View {
     @Binding var enabled: Bool
     @Binding var hasGameSettingsIdentity: Bool
@@ -17,14 +20,35 @@ struct GeneralTab: View {
 
     var body: some View {
         PerGameTab(title: settings.localized("General")) {
-            identitySection
-            overridesSection
-            statusSection
+            PerGameIdentitySection(
+                enabled: enabled,
+                displayName: displayName,
+                hasPendingChanges: hasPendingChanges,
+                savesToRunningGame: savesToRunningGame,
+                game: game,
+                settings: settings
+            )
+            PerGameOverridesSection(
+                enabled: $enabled,
+                showResetAllConfirmation: $showResetAllConfirmation,
+                hasGameSettingsIdentity: hasGameSettingsIdentity,
+                savesToRunningGame: savesToRunningGame,
+                settings: settings
+            )
+            PerGameStatusSection(statusMessage: statusMessage, settings: settings)
         }
     }
+}
 
-    @ViewBuilder
-    private var identitySection: some View {
+struct PerGameIdentitySection: View {
+    let enabled: Bool
+    let displayName: String
+    let hasPendingChanges: Bool
+    let savesToRunningGame: Bool
+    let game: ISOEntry
+    let settings: SettingsStore
+
+    var body: some View {
         Section {
             HStack(spacing: 12) {
                 Image(systemName: enabled ? "slider.horizontal.3" : "power")
@@ -43,11 +67,7 @@ struct GeneralTab: View {
                             .foregroundStyle(.secondary)
                             .textSelection(.enabled)
                     }
-                    Text(hasPendingChanges
-                         ? (savesToRunningGame
-                            ? settings.localized("Unsaved changes — tap Save to apply now.")
-                            : settings.localized("Unsaved changes — Save to apply on next boot."))
-                         : settings.localized("No pending changes."))
+                    Text(pendingChangesCaption)
                         .font(.caption)
                         .foregroundStyle(hasPendingChanges ? Color.accentColor : Color.secondary)
                 }
@@ -56,8 +76,23 @@ struct GeneralTab: View {
         }
     }
 
-    @ViewBuilder
-    private var overridesSection: some View {
+    private var pendingChangesCaption: String {
+        guard hasPendingChanges else { return settings.localized("No pending changes.") }
+        return savesToRunningGame
+            ? settings.localized("Unsaved changes — tap Save to apply now.")
+            : settings.localized("Unsaved changes — Save to apply on next boot.")
+    }
+}
+
+struct PerGameOverridesSection: View {
+    @Binding var enabled: Bool
+    @Binding var showResetAllConfirmation: Bool
+
+    let hasGameSettingsIdentity: Bool
+    let savesToRunningGame: Bool
+    let settings: SettingsStore
+
+    var body: some View {
         Section {
             Toggle(settings.localized("Use Per-Game Overrides"), isOn: $enabled)
             Text(settings.localized(savesToRunningGame
@@ -66,9 +101,9 @@ struct GeneralTab: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
             if !hasGameSettingsIdentity {
-                Text("Start this game once before saving its settings.")
+                Text(settings.localized("Start this game once before saving its settings."))
                     .font(.caption)
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(OverlayTheme.warm)
             }
             Button(role: .destructive) {
                 showResetAllConfirmation = true
@@ -78,9 +113,13 @@ struct GeneralTab: View {
             .disabled(!hasGameSettingsIdentity)
         }
     }
+}
 
-    @ViewBuilder
-    private var statusSection: some View {
+struct PerGameStatusSection: View {
+    let statusMessage: String?
+    let settings: SettingsStore
+
+    var body: some View {
         if let statusMessage {
             Section {
                 Text(statusMessage)

--- a/platforms/ios/app/src/main/swift/Views/Settings/PerGame/GraphicsTab.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/PerGame/GraphicsTab.swift
@@ -158,12 +158,9 @@ struct GraphicsTab: View {
             }
             .disabled(!enabled)
 
-            Picker(settings.localized("Deinterlace"), selection: $interlaceMode) {
-                ForEach(SettingsOptions.withUseGlobal(SettingsOptions.deinterlace), id: \.id) { option in
-                    Text(settings.localized(option.title)).tag(option.id)
-                }
-            }
-            .disabled(!enabled)
+            sharedPicker("Deinterlace", selection: $interlaceMode,
+                         SettingsOptions.withUseGlobal(SettingsOptions.deinterlace))
+                .disabled(!enabled)
 
             Picker(settings.localized("FXAA"), selection: $perGameFXAA) {
                 Text(settings.localized("Use Global")).tag(-1)
@@ -194,12 +191,9 @@ struct GraphicsTab: View {
             }
             .disabled(!enabled)
 
-            Picker(settings.localized("TV/CRT Shader"), selection: $perGameTVShader) {
-                ForEach(SettingsOptions.withUseGlobal(SettingsOptions.tvShader), id: \.id) { option in
-                    Text(settings.localized(option.title)).tag(option.id)
-                }
-            }
-            .disabled(!enabled)
+            sharedPicker("TV/CRT Shader", selection: $perGameTVShader,
+                         SettingsOptions.withUseGlobal(SettingsOptions.tvShader))
+                .disabled(!enabled)
             Text(settings.localized("Scanline and CRT effects are subtle on high-resolution displays and are more visible at a lower Internal Resolution."))
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -211,15 +205,9 @@ struct GraphicsTab: View {
             }
             .disabled(!enabled)
 
-            Picker(settings.localized("Max Anisotropy"), selection: $perGameMaxAnisotropy) {
-                Text(settings.localized("Use Global")).tag(-1)
-                Text(settings.localized("Off")).tag(0)
-                Text("2x").tag(2)
-                Text("4x").tag(4)
-                Text("8x").tag(8)
-                Text("16x").tag(16)
-            }
-            .disabled(!enabled)
+            sharedPicker("Max Anisotropy", selection: $perGameMaxAnisotropy,
+                         SettingsOptions.withUseGlobal(SettingsOptions.maxAnisotropy))
+                .disabled(!enabled)
 
             Picker(settings.localized("CAS Sharpness"), selection: $perGameCASSharpness) {
                 Text(settings.localized("Use Global")).tag(-1)
@@ -285,12 +273,9 @@ struct GraphicsTab: View {
                     .foregroundStyle(.orange)
             }
 
-            Picker(settings.localized("Trilinear Filtering"), selection: $trilinearFiltering) {
-                ForEach(Self.trilinearFilteringOptions, id: \.id) { option in
-                    Text(settings.localized(option.title)).tag(option.id)
-                }
-            }
-            .disabled(!enabled)
+            sharedPicker("Trilinear Filtering", selection: $trilinearFiltering,
+                         Self.trilinearFilteringOptions)
+                .disabled(!enabled)
 
             if trilinearFiltering != trilinearUseGlobalSentinel && trilinearFiltering != -1 {
                 Text(settings.localized("Non-automatic trilinear filtering may break textures in some games."))
@@ -298,19 +283,13 @@ struct GraphicsTab: View {
                     .foregroundStyle(.orange)
             }
 
-            Picker(settings.localized("Half-pixel Offset"), selection: $halfPixelOffset) {
-                ForEach(Self.halfPixelOffsetOptions, id: \.id) { option in
-                    Text(settings.localized(option.title)).tag(option.id)
-                }
-            }
-            .disabled(!manualAdvancedHacksEnabled)
+            sharedPicker("Half-pixel Offset", selection: $halfPixelOffset,
+                         Self.halfPixelOffsetOptions)
+                .disabled(!manualAdvancedHacksEnabled)
 
-            Picker(settings.localized("Round Sprite"), selection: $roundSprite) {
-                ForEach(Self.roundSpriteOptions, id: \.id) { option in
-                    Text(settings.localized(option.title)).tag(option.id)
-                }
-            }
-            .disabled(!manualAdvancedHacksEnabled)
+            sharedPicker("Round Sprite", selection: $roundSprite,
+                         Self.roundSpriteOptions)
+                .disabled(!manualAdvancedHacksEnabled)
 
             Toggle(settings.localized("Override Align Sprite"), isOn: $alignSpriteOverride)
                 .disabled(!manualAdvancedHacksEnabled)
@@ -364,32 +343,18 @@ struct GraphicsTab: View {
         }
 
         Section(settings.localized("Hardware Fixes & Display")) {
-            Picker(settings.localized("Hardware Download Mode"), selection: $perGameHWDownloadMode) {
-                Text(settings.localized("Use Global")).tag(-1)
-                Text(settings.localized("Enabled")).tag(0)
-                Text(settings.localized("Force Full")).tag(1)
-                Text(settings.localized("No Readbacks")).tag(2)
-                Text(settings.localized("Unsynchronized")).tag(3)
-                Text(settings.localized("Disabled")).tag(4)
-            }
-            .disabled(!enabled)
-            Picker(settings.localized("CPU CLUT Render"), selection: $perGameCPUCLUT) {
-                Text(settings.localized("Use Global")).tag(-1)
-                Text(settings.localized("Disabled")).tag(0)
-                Text(settings.localized("Normal")).tag(1)
-                Text(settings.localized("Aggressive")).tag(2)
-            }
-            .disabled(!enabled)
-            Picker(settings.localized("GPU Target CLUT"), selection: $perGameGPUTargetCLUT) {
-                Text(settings.localized("Use Global")).tag(-1)
-                Text(settings.localized("Off")).tag(0)
-                Text(settings.localized("Enabled (Exact)")).tag(1)
-                Text(settings.localized("Enabled (Inside Target)")).tag(2)
-            }
-            .disabled(!enabled)
+            sharedPicker("Hardware Download Mode", selection: $perGameHWDownloadMode,
+                         SettingsOptions.withUseGlobal(SettingsOptions.hardwareDownloadMode))
+                .disabled(!enabled)
+            sharedPicker("CPU CLUT Render", selection: $perGameCPUCLUT,
+                         SettingsOptions.withUseGlobal(SettingsOptions.cpuClutRender))
+                .disabled(!enabled)
+            sharedPicker("GPU Target CLUT", selection: $perGameGPUTargetCLUT,
+                         SettingsOptions.withUseGlobal(SettingsOptions.gpuTargetClut))
+                .disabled(!enabled)
             Picker(settings.localized("VSync Queue Size"), selection: $perGameVsyncQueue) {
                 Text(settings.localized("Use Global")).tag(-1)
-                ForEach([2, 3, 4, 5, 6, 8, 10, 12, 16], id: \.self) { Text("\($0)").tag($0) }
+                ForEach(SettingsOptions.vsyncQueue, id: \.self) { Text("\($0)").tag($0) }
             }
             .disabled(!enabled)
             Picker(settings.localized("Sync to Host Refresh"), selection: $perGameSyncToHostRefresh) {
@@ -425,6 +390,17 @@ struct GraphicsTab: View {
             Text(settings.localized("Texture replacement needs a restart to take effect."))
                 .font(.caption)
                 .foregroundStyle(.secondary)
+        }
+    }
+
+    /// Picker over a shared option table, localized the way the global screen's own
+    /// helper does. The caller adds `.disabled(...)`, since the gate differs per row.
+    private func sharedPicker(_ title: String, selection: Binding<Int>,
+                              _ options: [(id: Int, title: String)]) -> some View {
+        Picker(settings.localized(title), selection: selection) {
+            ForEach(options, id: \.id) { option in
+                Text(settings.localized(option.title)).tag(option.id)
+            }
         }
     }
 

--- a/platforms/ios/app/src/main/swift/Views/Settings/SettingsOptions.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/SettingsOptions.swift
@@ -79,4 +79,13 @@ enum SettingsOptions {
     static let roundSprite: [(id: Int, title: String)] = [
         (0, "Off"), (1, "Half"), (2, "Full")
     ]
+
+    /// Numeric steps for the pacing and audio pickers. Plain values, since the call sites
+    /// format them differently (bare, " ms", "%"). The global screens offer the same
+    /// settings as steppers over a continuous range, so these are the per-game lists only.
+    static let vsyncQueue = [2, 3, 4, 5, 6, 8, 10, 12, 16]
+    static let targetFPS = [30, 45, 60, 90, 120]
+    static let audioBufferMs = [10, 25, 50, 75, 100, 150, 200]
+    static let audioOutputLatencyMs = [5, 10, 20, 30, 50, 100, 200]
+    static let fastForwardVolume = [0, 50, 100, 150, 200]
 }


### PR DESCRIPTION
## What changed

* Fixed the Default preset never showing a checkmark, including immediately after you apply it.
* Fixed Reset Graphics and Reset Emulator quietly moving your Frame Pacing preset to Custom.
* Fixed the 60 FPS button, the quick FPS buttons and the Audio screen's own reset buttons doing the same thing when the value was already what they set.
* Fixed a build failure where reconfiguring cmake and then building hit a dependency cycle in Xcode.
* Fixed the General tab in landscape showing an untranslated warning in a different orange to the same warning in portrait.
* Per game Max Anisotropy, Hardware Download Mode, CPU CLUT Render, GPU Target CLUT and Texture Inside RT now read the same option lists the global screens read.
* Corrected the Help entry for VSync Queue Size, which still gave the old default of 8.

## The Default preset

Settings, then Presets, then Default runs a full reset, and afterwards the Default row still read as inactive. Not usually. Under any settings the app can reach.

That row's checkmark comes from an `isActive` check that compares eleven values against a hand written list of what Default is supposed to leave behind. Only the checkmark reads that list, because applying Default short circuits into `resetAllDefaults` and never looks at it, so the two had no reason to stay in step and had drifted on two counts.

It claimed a queue size of 8, while the reset ends by applying the Optimal pacing preset and leaves 4. And `showBackgroundInSettings` is a member with a default that the Default entry never passed, so it claimed the background in Settings was off while the reset turns it on. The other nine already agreed.

## Resets and Frame Pacing

Six settings switch the Frame Pacing preset to Custom when you change them, which is what you want when you actually change them. They were doing it on any write at all. The settings store is `@Observable`, so writing a value it already holds still runs the setter, and the preset moved even though the pacing had not.

Each one now compares against the old value first. The INI write and the limiter apply stay unconditional, so only the marking is gated.

`targetFPS` needed the awkward version. Its observer re enters after clamping, so the old value it sees is the unclamped intermediate rather than your previous setting, and the clamp rounds. Comparing against the clamped old value stops 59.94 landing on an existing 60 from counting as a change.

Separately, the resets were reaching outside their own screens. Reset Graphics restored VSync Queue Size and Sync to Host Refresh, which appear nowhere on the Graphics screen and live only on Frame Pacing. Reset Emulator restored the audio buffer and output latency, which live on Audio. So both were writing settings they do not show, and dragging the preset to Custom on the way.

The queue value Reset Graphics restored was 8, which is the upstream PCSX2 default we keep around as a migration comparator rather than ours. Ours has been 4 since the Optimal migration, so that reset left you on Custom holding a queue size matching no preset the Graphics screen owns.

Frame limiter and FPS target stay in the emulator reset, since that screen does have controls for them. All four removed values are still restorable from Reset Frame Pacing, any preset row, the two per row resets on the Audio screen, or a full reset. The full reset now applies the Optimal values explicitly before setting the preset, the way the Frame Pacing screen already does, rather than relying on the preset's observer to be the only thing restoring them.

This is not being claimed as a rule the file follows. The emulator reset still restores volume, time stretch, fast forward volume and channel swap, which are Audio screen settings too. They do not touch the pacing preset, so they are not part of this and have been left alone.

## The build cycle

Reconfiguring and then building failed with a cycle: `PCSX2_LTO` needs `armsx2_svnrev`, which needs `ZERO_CHECK`, which needs `PCSX2_LTO`.

This came in with the build time git revision work and went unnoticed because it only appears after a regeneration. A build directory that has already settled keeps working, which is why nobody hit it.

The `BYPRODUCTS` on that target was the cause. `svnrev.h` lives in `common/include`, which is on the include path of most of the core, so Xcode inferred a producer edge from every consumer of that header and routed it back through the regeneration target. The target is `ALL` and always runs its command, and PCSX2 already depends on it explicitly, so the declaration was buying nothing. The other header keeps its `BYPRODUCTS`, since it sits in its own target's binary directory and only the app reads it.

## Finishing the shared option lists

The shared option tables landed last time but only about half the call sites moved over, so several pickers were still carrying their own copy of a list that already existed. GPU Target CLUT had already drifted off the back of that: the global screen calls option 1 "Enabled (Exact Match)" and the per game tab called it "Enabled (Exact)".

The numeric steps moved across too, since VSync Queue Size, Buffer Size and Output Latency each had two per game copies spread between the graphics, frame pacing and audio tabs.

## One copy of the general sections

Portrait puts the game identity, the overrides toggle and the status line at the top of the panel's root form. Landscape shows the same three as their own General category. They were written out twice and had drifted, so the landscape copy never picked up the localized warning or the theme colour.

## Testing

Built for device against every commit, including the reconfigure then build sequence that used to fail.

The behaviour here needs a device, since the simulator cannot boot a game without a BIOS. Worth checking:

* On Optimal, press Reset Emulator. The preset should stay Optimal.
* Tap the 60 FPS button while already at 60, and Audio's Buffer reset while already at 50. The preset should stay put. Then drag the FPS slider and confirm it does go to Custom, so the marking still works.
* Set Frame Pacing to Low Latency, then press Reset Graphics. Queue size should stay 2 and the preset should stay Low Latency.
* Presets, then Default. Queue 4, latency 15, buffer 50, sync off, limiter on, 60 fps, and the preset reads Optimal.
* The green checkmark should appear on the Default row as the confirmation dialog dismisses, without leaving the screen and coming back. `isActive` is evaluated in the view body across two stores, so a correct check can still fail to redraw. If it only shows up after navigating away and back, the check is right but the observation is not.
* Open each global graphics screen beside its per game tab and confirm the option lists still match.
