### PR TITLE
iOS: say when a graphics setting needs a restart, and hold two ranges

### DIFF
--- a/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
@@ -209,9 +209,7 @@ final class SettingsStore {
     static let defaultEmulatorVolumePercent = 100
     static let textureOffsetRange = -4096...4096
     static let skipDrawRange = 0...5000
-    // Named so the stepper and the per-game panel agree about the bounds. Neither
-    // this one nor casSharpnessRange is on its global descriptor's codec, so a
-    // hand-edited INI still gets through. A gap rather than a decision.
+    // Named so the stepper, the per-game panel and the global codec all agree.
     static let vsyncQueueRange = 2...16
     static let audioBufferMsRange = 10...200
     static let audioOutputLatencyMsRange = 5...200
@@ -660,7 +658,7 @@ final class SettingsStore {
     let _vsyncQueueSizeConfig = Setting<Int>(
         section: "EmuCore/GS", key: "VsyncQueueSize", default: 8,
         suppressible: false,
-        codec: .int)
+        codec: .int(in: SettingsStore.vsyncQueueRange))
     var vsyncQueueSize: Int = 8 { didSet {
         commit(_vsyncQueueSizeConfig, vsyncQueueSize)
         if vsyncQueueSize != oldValue { markFramePacingCustom() }
@@ -697,7 +695,7 @@ final class SettingsStore {
     let _casSharpnessConfig = Setting<Int>(
         section: "EmuCore/GS", key: "CASSharpness", default: 50,
         suppressible: false,
-        codec: .int)
+        codec: .int(in: SettingsStore.casSharpnessRange))
     var casSharpness: Int = 50 { didSet { commit(_casSharpnessConfig, casSharpness) } }
     let _interlaceModeConfig = Setting<Int>(
         section: "EmuCore/GS", key: "deinterlace_mode", default: 0,

--- a/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
@@ -670,9 +670,13 @@ final class SettingsStore {
         suppressible: false,
         codec: .int)
     var textureFiltering: Int = 2 { didSet { commit(_textureFilteringConfig, textureFiltering) } }
+    // Boot-only for the same reason as the renderer above: the core counts this in
+    // RestartOptionsAreEqual, so applying it live goes down GSreopen and tears the
+    // Metal device down under the running game. The picker says "Requires restart".
     let _backThreadModeConfig = Setting<Int>(
         section: "EmuCore/GS", key: "GSBackThreadMode", default: 0,
         suppressible: false,
+        bootOnly: true,
         codec: .int)
     var backThreadMode: Int = 0 { didSet { commit(_backThreadModeConfig, backThreadMode) } }
     let _hardwareMipmappingConfig = Setting<Bool>(

--- a/platforms/ios/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
@@ -109,7 +109,7 @@ struct GraphicsSettingsView: View {
             } header: {
                 Text(settings.localized("Performance"))
             } footer: {
-                Text(settings.localized("Pipelined splits GS emulation across two threads on multi-core systems and competes for cores with EE/VU threads. The debug modes are much slower — do not use them for play."))
+                Text(settings.localized("Pipelined splits GS emulation across two threads on multi-core systems and competes for cores with EE/VU threads. The debug modes are much slower — do not use them for play. Requires restart."))
             }
 
             Section(settings.localized("Renderer")) {


### PR DESCRIPTION
Two small fixes from the settings audits. Neither is a refactor and neither changes what any setting does for someone already inside the supported ranges.

## What changed

* GS Back Thread now says "Requires restart." in its caption, the same way the renderer right below it does. Before this you changed it, nothing happened, and nothing on screen told you why.
* GS Back Thread is boot only now. The core counts GSBackThreadMode in RestartOptionsAreEqual, so applying it while a VM is live goes down GSreopen and tears the Metal device down under the running game. That is exactly why the renderer is boot only. Nobody can reach it today, because the graphics apply is a no op without a live VM and the only way out of a game is Stop Emulation, but it costs a line to close.
* Queue Size and CAS Sharpness are held to the ranges that were already named for them. vsyncQueueRange and casSharpnessRange were used by the stepper and by the per game panel, but neither was on its global descriptor, so a hand edited file could push a value straight through. The core does not clamp either one.

## What I checked

Picked Pipelined on the simulator, confirmed the key landed in the file, quit, relaunched, and the picker came back on Pipelined. That is the thing boot only must not break: it only takes away the nudge to the running VM, it does not touch the write.

Wrote VsyncQueueSize = 99 and CASSharpness = 500 into the file by hand and launched. The rows read 16 and 100%. The file still says 99 and 500 afterwards, because nothing rewrites it on launch, so someone's settings are only corrected once they change something themselves rather than behind their back.

Both ini gates stay empty on the same container, populated and fresh install, since 8 and 50 are already inside their ranges and all four frame pacing presets write 2, 4 or 8. Debug build clean and the twelve source checks still pass.

## No translations

The whole GS Back Thread section already falls back to English in every language, picker label and all four option labels included. Translating one caption while the label above it stays English reads worse than leaving it. localized falls back to the key, so nothing breaks. Translating that section is its own commit.
