### PR TITLE
Approximate generalization of FpuMulHack

### DIFF
--- a/pcsx2/FPU.cpp
+++ b/pcsx2/FPU.cpp
@@ -3,6 +3,7 @@
 
 #include "Common.h"
 
+#include <cfloat>
 #include <cmath>
 
 // Helper Macros
@@ -182,6 +183,101 @@ float fpuDouble(u32 f)
 	}
 }
 
+/*	The EE multiplier's one-ULP deficit.
+
+	The console's multiply array is not a correctly-rounding multiplier: it
+	comes back exactly one step closer to zero on a large fraction of operands,
+	and which operands depends on operand order. Upstream states the rule in a
+	comment (pcsx2/x86/iFPU.cpp:500) and never tests it; FpuMulHack is a
+	one-point sample of it.
+
+	Measured on SCPH-90000 (FCR0 0x2e40), captures/fpmul/, 25M probes:
+
+	  * mul.s(1.0, x) was measured for every one of the 2^23 significands.
+	    8257536 come back one ULP low and 131072 exact -- and nothing ever came
+	    back high, or two ULP low, in 16.8M probes.
+	  * mul.s(x, 1.0) is exact for all 2^23. The asymmetry is total, not
+	    statistical: the predicate reads ft and never fs, which is exactly why
+	    the operation is not commutative.
+	  * Unchanged across twelve exponent-field pairs from (1,254) to (254,1),
+	    so it is a significand-domain effect with no exponent term.
+
+	Bits 1,3,5,7,9 of ft's mantissa are the sign bits of the five lowest
+	radix-4 Booth digits, which is what identifies the mechanism: ft is the
+	recoded operand and the array's low columns are not built, so each low
+	negative digit's two's-complement correction is dropped. The bit-11 term is
+	a boundary effect at the truncation column; it is written as measured, not
+	derived.
+
+	What this does not model: the deficit is smaller than one ULP -- at most
+	~27308 against an ULP of 2^23 -- so it only reaches the result when the
+	exact product has nothing below the ULP to absorb it. That is the tail test
+	below, and it is the whole of the modelled class. When the tail is non-zero
+	the console is one ULP low iff the tail is smaller than the deficit, and the
+	deficit is not identifiable from mul.s observations: the instruction only
+	ever exposes the one comparison it performs. That residual is ~0.1% of
+	random operand pairs.
+*/
+static bool eeMulDefectiveFt(u32 ft)
+{
+	const u32 m = ft & 0x7FFFFF;
+	if (m & 0x2AA) // a negative Booth digit among 0..4
+		return true;
+	const u32 h = (m >> 12) & 0xF;
+	return ((m >> 11) & 1u) != ((h >= 8 && h <= 13) ? 1u : 0u);
+}
+
+static bool eeMulOneUlpLow(u32 fs, u32 ft)
+{
+	if ((fs & 0x7F800000) == 0 || (ft & 0x7F800000) == 0)
+		return false; // a zero operand (denormals are zero): the product is zero
+
+	const u64 a = 0x800000u | (fs & 0x7FFFFF);
+	const u64 b = 0x800000u | (ft & 0x7FFFFF);
+	const u64 prod = a * b; // 47 or 48 significant bits, exact in 64
+	const int k = (prod >> 47) ? 24 : 23;
+	if (prod & ((1ull << k) - 1u))
+		return false; // the tail below the ULP absorbs the deficit
+
+	return eeMulDefectiveFt(ft);
+}
+
+/*	fpuDouble() both operands, multiply, apply the deficit.
+
+	The predicate is fed the operands as multiplied, not the guest registers:
+	fpuDouble() clamps an exponent-0xff operand down to +/-Fmax, and that
+	changes ft's mantissa. (Clamping there is a separate and known gap against
+	silicon, which treats exponent 0xff as an ordinary binade; this models the
+	multiplier on top of whatever fpuDouble hands it, rather than smuggling in a
+	second change.)
+
+	Applied only where it was measured. A saturating result, a flushed one, and
+	a decrement that would walk the exponent field out of the normals are all
+	left alone.
+*/
+static u32 eeMulProduct(u32 fs, u32 ft)
+{
+	FPRreg s, t, p;
+	s.f = fpuDouble( fs );
+	t.f = fpuDouble( ft );
+	p.f = s.f * t.f;
+
+	// A saturated result is not a rounded one. Testing p.f for an infinity is
+	// not enough: under round-toward-zero an overflowing product comes back as
+	// Fmax, so checkOverflow() never sees it and the bit pattern is
+	// indistinguishable from a product that genuinely landed on Fmax -- which
+	// silicon does decrement (1.0 * FLT_MAX -> 0x7F7FFFFE). float x float is
+	// exact in double, so ask the exact product instead.
+	if (!(std::fabs( static_cast<double>(s.f) * static_cast<double>(t.f) ) <= FLT_MAX))
+		return p.UL;
+	if ((p.UL & 0x7F800000) == 0) // flushed, zero, or a denormal on its way out
+		return p.UL;
+	if ((p.UL & 0x7FFFFFFF) == 0x00800000) // a decrement would leave the normals
+		return p.UL;
+
+	return eeMulOneUlpLow( s.UL, t.UL ) ? p.UL - 1u : p.UL;
+}
+
 void ABS_S() {
 	_FdValUl_ = _FsValUl_ & 0x7fffffff;
 	clearFPUFlags( FPUflagO | FPUflagU );
@@ -271,14 +367,16 @@ void DIV_S() {
 */
 void MADD_S() {
 	FPRreg temp;
-	temp.f = fpuDouble( _FsValUl_ ) * fpuDouble( _FtValUl_ );
+	temp.UL = eeMulProduct( _FsValUl_, _FtValUl_ );
 	_FdValf_  = fpuDouble( _FAValUl_ ) + fpuDouble( temp.UL );
 	if (checkOverflow( _FdValUl_, FPUflagO | FPUflagSO)) return;
 	checkUnderflow( _FdValUl_, FPUflagU | FPUflagSU);
 }
 
 void MADDA_S() {
-	_FAValf_ += fpuDouble( _FsValUl_ ) * fpuDouble( _FtValUl_ );
+	FPRreg temp;
+	temp.UL = eeMulProduct( _FsValUl_, _FtValUl_ );
+	_FAValf_ += temp.f;
 	if (checkOverflow( _FAValUl_, FPUflagO | FPUflagSO)) return;
 	checkUnderflow( _FAValUl_, FPUflagU | FPUflagSU);
 }
@@ -304,14 +402,16 @@ void MOV_S() {
 
 void MSUB_S() {
 	FPRreg temp;
-	temp.f = fpuDouble( _FsValUl_ ) * fpuDouble( _FtValUl_ );
+	temp.UL = eeMulProduct( _FsValUl_, _FtValUl_ );
 	_FdValf_  = fpuDouble( _FAValUl_ ) - fpuDouble( temp.UL );
 	if (checkOverflow( _FdValUl_, FPUflagO | FPUflagSO)) return;
 	checkUnderflow( _FdValUl_, FPUflagU | FPUflagSU);
 }
 
 void MSUBA_S() {
-	_FAValf_ -= fpuDouble( _FsValUl_ ) * fpuDouble( _FtValUl_ );
+	FPRreg temp;
+	temp.UL = eeMulProduct( _FsValUl_, _FtValUl_ );
+	_FAValf_ -= temp.f;
 	if (checkOverflow( _FAValUl_, FPUflagO | FPUflagSO)) return;
 	checkUnderflow( _FAValUl_, FPUflagU | FPUflagSU);
 }
@@ -321,13 +421,13 @@ void MTC1() {
 }
 
 void MUL_S() {
-	_FdValf_  = fpuDouble( _FsValUl_ ) * fpuDouble( _FtValUl_ );
+	_FdValUl_ = eeMulProduct( _FsValUl_, _FtValUl_ );
 	if (checkOverflow( _FdValUl_, FPUflagO | FPUflagSO)) return;
 	checkUnderflow( _FdValUl_, FPUflagU | FPUflagSU);
 }
 
 void MULA_S() {
-	_FAValf_  = fpuDouble( _FsValUl_ ) * fpuDouble( _FtValUl_ );
+	_FAValUl_ = eeMulProduct( _FsValUl_, _FtValUl_ );
 	if (checkOverflow( _FAValUl_, FPUflagO | FPUflagSO)) return;
 	checkUnderflow( _FAValUl_, FPUflagU | FPUflagSU);
 }

--- a/pcsx2/arm64/iCore-arm64.cpp
+++ b/pcsx2/arm64/iCore-arm64.cpp
@@ -711,10 +711,13 @@ static constexpr u32 NEON_RESERVED_FPU_MIN = 9;
 // (The callee-saved allocator range q10-q15 is declared in iCore-arm64.h —
 // NEON_CALLEE_SAVED_START/END; indices 8/9 reserved above. SL-13 reserves
 // q25/q26 the same way for the COP2 clamp-constant broadcasts —
-// NEON_RESERVED_COP2_CLAMPMAX/MIN in iCore-arm64.h.)
+// NEON_RESERVED_COP2_CLAMPMAX/MIN in iCore-arm64.h. q10 is reserved the same
+// way again for the mode-3 multiplier-defect mask —
+// NEON_RESERVED_FPU_MULMASK, also iCore-arm64.h, which carries the contract.)
 static bool _isReservedNEONreg(u32 i)
 {
 	return i == NEON_RESERVED_FPU_MAX || i == NEON_RESERVED_FPU_MIN ||
+	       i == NEON_RESERVED_FPU_MULMASK ||
 	       i == NEON_RESERVED_COP2_CLAMPMAX || i == NEON_RESERVED_COP2_CLAMPMIN;
 }
 

--- a/pcsx2/arm64/iCore-arm64.h
+++ b/pcsx2/arm64/iCore-arm64.h
@@ -123,13 +123,37 @@ struct _arm64gprregs
 #define NEONTYPE_VFREG  8  // VU VF register
 
 // Callee-saved NEON range available to the allocator: q10-q15 (q8/q9 hold
-// the pinned FPU clamp constants and are excluded from the pool entirely).
+// the pinned FPU clamp constants and are excluded from the pool entirely;
+// q10 likewise holds the pinned multiplier-defect mask, below, so the range
+// yields q11-q15 in practice).
 // AAPCS64 preserves only the LOWER 64 bits of v8-v15 across C calls, so
 // full-128-bit classes (NEONTYPE_GPRREG quads, VFREG) can never be retained
 // across a seam — but 32-bit FPR-class slots (FPREG/FPACC, lane 0 only) can
 // (GE-15; iFlushCall's retention loop keys off this range).
 static constexpr u32 NEON_CALLEE_SAVED_START = 10;
 static constexpr u32 NEON_CALLEE_SAVED_END = 16; // exclusive
+
+// d10 = 0x2AA, the EE multiplier's Booth-digit predicate mask, parked for the
+// whole JIT session by _DynGen_EnterRecompiledCode alongside s8/s9 and read by
+// emitDefectiveFmul (iFPUd-arm64.cpp) on every mode-3 multiply. Same contract
+// as NEON_RESERVED_FPU_MAX/MIN and for the same reason: the lower 64 bits of
+// d8-d15 are callee-saved, so a parked constant needs no compile-time liveness
+// tracking, no invalidation at C-call seams, and no re-materialization on any
+// path — which is exactly what a predicate must not get wrong (a stale mask is
+// a silent one-ULP error on a fraction of multiplies, and the 1147-case
+// hardware corpus cannot see the class it decides).
+//
+// It costs one slot out of the callee-saved allocator range above. That is the
+// whole price: the multiply sequence drops 6 instructions -> 4 unconditionally,
+// including the first multiply in a block, where a compile-time liveness flag
+// in a caller-saved register would still have paid the full 6.
+//
+// Two reasons it needs no microVU pool gate (unlike SL-13's q25/q26, and for
+// the same reasons q8/q9 need none): micro-mode mVU runs under mVUdispatcherAB,
+// whose prologue Stp/Ldp-saves d8-d15; and COP2 macro-mode mVU emits inline in
+// EE blocks but is structurally bounded to NEON slots 0-3 by
+// kMacroVFEvictHighWater, which mVUmacroEmitEpilogue asserts on every macro op.
+static constexpr u32 NEON_RESERVED_FPU_MULMASK = 10;
 
 // SL-13: q25/q26 are dedicated to the COP2 macro clamp-constant broadcasts
 // (q25 = maxFloat.4S = +FLT_MAX, q26 = minFloat.4S = -FLT_MAX) and excluded

--- a/pcsx2/arm64/iFPUd-arm64.cpp
+++ b/pcsx2/arm64/iFPUd-arm64.cpp
@@ -124,16 +124,17 @@ static void ToPS2FPU_Full(int idx, bool flags, int /*absidx*/, bool acc, bool ad
 	// Saturate above the EE MAXIMUM, not above 2^129.
 	//
 	// x86 iFPUd.cpp uses dbl_ps2_overflow == 2^129 here, but the largest number
-	// this FPU has is 0x7FFFFFFF == (2 - 2^-23) * 2^128, a whole binade below
-	// it. Everything in (that max, 2^129) therefore fell into the halving arm
-	// below, and under the divide unit's round-to-NEAREST FPCR that arm's
-	// +0x00800000 carried out of the exponent field into the SIGN BIT
-	// (0x7f800000 + 0x00800000 == 0x80000000): the largest magnitude the FPU can
-	// produce came back as negative zero. Only RSQRT can land in the band; see
+	// this FPU has -- kEeFpuMax, as the comments below name it -- is 0x7FFFFFFF
+	// == (2 - 2^-23) * 2^128, a whole binade below it. Everything in
+	// (kEeFpuMax, 2^129) therefore fell into the halving arm below, and under
+	// the divide unit's round-to-nearest FPCR that arm's +0x00800000 carried
+	// out of the exponent field into the sign bit (0x7f800000 + 0x00800000 ==
+	// 0x80000000): the largest magnitude the FPU can produce came back as
+	// negative zero. Only RSQRT can land in the band; see
 	// EeRecFpuFull.RsqrtAboveEeMaxSaturatesInsteadOfWrappingToNegativeZero for
 	// why DIV and SQRT cannot.
 	//
-	// `hi`, not `hs`: the EE maximum ITSELF is representable and belongs to the
+	// `hi`, not `hs`: kEeFpuMax itself is representable and belongs to the
 	// halving arm, which handles it exactly (halved it is +FLT_MAX, and
 	// 0x7f7fffff + 0x00800000 == 0x7fffffff).
 	armAsm->Mov(RXARG2, UINT64_C(0x47FFFFFFE0000000)); // (2 - 2^-23) * 2^128
@@ -209,6 +210,84 @@ static void ToPS2FPU_Full(int idx, bool flags, int /*absidx*/, bool acc, bool ad
 	armAsm->Bind(&end);
 }
 
+// ---- IEEE double -> PS2-single value, left in double format ---------------
+//
+// The rounding half of ToPS2FPU_Full with the format change taken out. On
+// return `idx`'s D lane holds a double whose value is exactly the single
+// ToPS2FPU_Full would have produced -- low 29 mantissa bits zero, |x| <=
+// kEeFpuMax, sub-2^-126 flushed to signed zero -- and the same O/U flags have
+// been raised. Used where the caller is going to widen the result straight back
+// (recMaddsub), so the narrow/widen round trip never happens.
+//
+// Rounding to a 24-bit significand is masking off the low 29 mantissa bits.
+// That is valid only under round-toward-zero, which is the arithmetic FPCR
+// (FPUFPCR) this path runs under. DIV/SQRT/RSQRT run under the divide unit's
+// round-to-nearest FPCR, where the mask would be plain truncation -- they keep
+// ToPS2FPU_Full.
+//
+// The "large but PS2-representable" arm of ToPS2FPU_Full disappears entirely:
+// an exponent-0xff PS2 single is an ordinary double, so in the wide domain
+// there is nothing to halve, narrow and re-raise -- it is just a chop like any
+// other in-range value. Only the saturation bound still needs the finer test.
+//
+// addsub is not a parameter: the one caller is the multiply stage, which passes
+// addsub=false, so the underflow arm never reconstructs a denormal.
+static void ToPS2FPU_Wide(int idx)
+{
+	const a64::VRegister d = armDRegister(idx);
+
+	armLoadEERegPtr(RWSCRATCH, &fpuRegs.fprc[31]);
+	armAsm->Bic(RWSCRATCH, RWSCRATCH, FPUflagO | FPUflagU);
+	armStoreEERegPtr(RWSCRATCH, &fpuRegs.fprc[31]);
+
+	armAsm->Fmov(RXSCRATCH, d);
+	armAsm->And(RXARG1, RXSCRATCH, 0x7fffffffffffffffULL);
+
+	a64::Label chop, toComplex, toUnderflow, isZero, end;
+
+	// Both bounds below are single MOVZ; the exact kEeFpuMax pattern is not, so
+	// keep it off the common path and test 2^128 first (as ToPS2FPU_Full does).
+	armAsm->Mov(RXARG2, static_cast<u64>(1151) << 52);   // 2^128
+	armAsm->Cmp(RXARG1, RXARG2);
+	armAsm->B(&toComplex, a64::hs);
+
+	armAsm->Mov(RXARG2, static_cast<u64>(897) << 52);    // 2^-126
+	armAsm->Cmp(RXARG1, RXARG2);
+	armAsm->B(&toUnderflow, a64::lo);
+
+	armAsm->Bind(&chop);
+	armAsm->And(RXSCRATCH, RXSCRATCH, UINT64_C(0xffffffffe0000000));
+	armAsm->Fmov(d, RXSCRATCH);
+	armAsm->B(&end);
+
+	armAsm->Bind(&toComplex);
+	armAsm->Mov(RXARG2, UINT64_C(0x47FFFFFFE0000000)); // (2 - 2^-23) * 2^128
+	armAsm->Cmp(RXARG1, RXARG2);
+	armAsm->B(&chop, a64::ls);   // in [2^128, kEeFpuMax]: an ordinary chop
+
+	// Beyond PS2 range: keep the sign, set the magnitude to kEeFpuMax (still in
+	// RXARG2). The single-domain form of this is `Orr 0x7fffffff`.
+	armAsm->And(RXSCRATCH, RXSCRATCH, UINT64_C(0x8000000000000000));
+	armAsm->Orr(RXSCRATCH, RXSCRATCH, RXARG2);
+	armAsm->Fmov(d, RXSCRATCH);
+	armLoadEERegPtr(RWARG1, &fpuRegs.fprc[31]);
+	armAsm->Orr(RWARG1, RWARG1, FPUflagO | FPUflagSO);
+	armStoreEERegPtr(RWARG1, &fpuRegs.fprc[31]);
+	armAsm->B(&end);
+
+	armAsm->Bind(&toUnderflow);
+	// RXSCRATCH/RXARG1 still hold the bits and |bits| from entry.
+	armAsm->Cbz(RXARG1, &isZero);
+	armLoadEERegPtr(RWARG2, &fpuRegs.fprc[31]);
+	armAsm->Orr(RWARG2, RWARG2, FPUflagU | FPUflagSU);
+	armStoreEERegPtr(RWARG2, &fpuRegs.fprc[31]);
+	armAsm->Bind(&isZero);
+	armAsm->And(RXSCRATCH, RXSCRATCH, UINT64_C(0x8000000000000000));
+	armAsm->Fmov(d, RXSCRATCH);
+
+	armAsm->Bind(&end);
+}
+
 // ---- PS2 add/sub guard-bit emulation --------------------------------------
 //
 // The EE FPU has no guard bits to the right of the mantissa; subtraction (and
@@ -276,6 +355,82 @@ static void FPU_ADD_SUB(int idxd, int idxt)
 	armAsm->Bind(&done);
 }
 
+// ---- PS2 add/sub guard-bit emulation, wide form ---------------------------
+//
+// Same law as FPU_ADD_SUB, for operands that are already doubles holding EE
+// singles exactly (low 29 mantissa bits zero, |x| <= kEeFpuMax). Two changes,
+// neither of which costs an instruction:
+//
+//  * The exponent field is bits 52..62 instead of 23..30, and the bias is 896
+//    higher. The bias cancels in the difference, so the case split is unchanged
+//    for two normals. It does not cancel when exactly one operand is zero
+//    (single e-0=e, double (e+896)-0), which moves such a pair from the
+//    mask-low-bits arm into the sign-only arm -- but the operand those arms
+//    touch is the zero one, and +/-0 is invariant under both (masking low bits
+//    of a zero, or reducing it to its sign, both leave it alone), so the two
+//    domains still agree. Verified: 0 disagreements over 1,572,864 pairs
+//    covering every (expd, expt) combination, 12,240 of them in exactly that
+//    class, against an off-by-one liveness control that moves 5,588 of 65,025.
+//    (A PS2 denormal cannot reach here: ToDouble runs under FZ, which flushes
+//    it to a zero of the same sign -- measured on this host, not assumed.)
+//  * A single's mantissa bit k is double bit k+29, so masking the single's low
+//    (diff-1) bits is masking the double's low (diff-1)+29. The extra 29 are
+//    already zero, so only the shift amount changes: `diff - 1` -> `diff + 28`.
+static void FPU_ADD_SUB_D(int idxd, int idxt)
+{
+	const a64::VRegister dd = armDRegister(idxd);
+	const a64::VRegister dt = armDRegister(idxt);
+
+	armAsm->Fmov(RXARG1, dd);  // d bits
+	armAsm->Fmov(RXARG2, dt);  // t bits
+	// GE-M2: x9/x10 for the diff and mask temps, not the w2/w3 pool hosts -- see
+	// the note in FPU_ADD_SUB. This span has no load/store or C-call either.
+	armAsm->Ubfx(a64::x9, RXARG1, 52, 11);    // expd
+	armAsm->Ubfx(RXSCRATCH, RXARG2, 52, 11);  // expt
+	armAsm->Sub(a64::w9, a64::w9, RWSCRATCH); // diff = expd - expt (signed)
+
+	a64::Label caseD25, casePos, caseEq, caseDn25, done;
+	armAsm->Cmp(a64::w9, 25);
+	armAsm->B(&caseD25, a64::ge);
+	armAsm->Cmp(a64::w9, 0);
+	armAsm->B(&casePos, a64::gt);
+	armAsm->B(&caseEq, a64::eq);
+	armAsm->Cmn(a64::w9, 25);                 // cmp diff, -25
+	armAsm->B(&caseDn25, a64::le);
+
+	// diff in -24..-1 (expd < expt): mask tempd's low (-diff-1)+29 bits.
+	armAsm->Neg(RWSCRATCH, a64::w9);
+	armAsm->Add(RWSCRATCH, RWSCRATCH, 28);
+	armAsm->Mov(a64::x10, UINT64_C(0xffffffffffffffff));
+	armAsm->Lsl(a64::x10, a64::x10, RXSCRATCH);
+	armAsm->And(RXARG1, RXARG1, a64::x10);
+	armAsm->Fmov(dd, RXARG1);
+	armAsm->B(&done);
+
+	armAsm->Bind(&caseD25);
+	// diff >= 25 (expt much smaller): tempt keeps only its sign.
+	armAsm->And(RXARG2, RXARG2, UINT64_C(0x8000000000000000));
+	armAsm->Fmov(dt, RXARG2);
+	armAsm->B(&done);
+
+	armAsm->Bind(&casePos);
+	// diff in 1..24 (expt smaller): mask tempt's low (diff-1)+29 bits.
+	armAsm->Add(RWSCRATCH, a64::w9, 28);
+	armAsm->Mov(a64::x10, UINT64_C(0xffffffffffffffff));
+	armAsm->Lsl(a64::x10, a64::x10, RXSCRATCH);
+	armAsm->And(RXARG2, RXARG2, a64::x10);
+	armAsm->Fmov(dt, RXARG2);
+	armAsm->B(&done);
+
+	armAsm->Bind(&caseDn25);
+	// diff <= -25 (expd much smaller): tempd keeps only its sign.
+	armAsm->And(RXARG1, RXARG1, UINT64_C(0x8000000000000000));
+	armAsm->Fmov(dd, RXARG1);
+
+	armAsm->Bind(&caseEq);  // diff == 0: nothing
+	armAsm->Bind(&done);
+}
+
 // ---- Op cores --------------------------------------------------------------
 
 // Copy an allocator-resident FP source (EEREC_S/EEREC_T) into a fresh temp so
@@ -337,22 +492,39 @@ static void recMULop(int info, int eeRecDst, bool acc)
 // If either did, the accumulate is dominated by a 2^128-class term and the
 // result is just +/-max with the dominant sign — skip the double add entirely.
 // Only when both are finite is the accumulation performed in double.
+//
+// Representation: unlike the x86 port and unlike recFPUOp/recMULop, everything
+// between the two roundings stays wide. The invariant from the multiply stage
+// to the final ToPS2FPU_Full is "this double is exactly a PS2 single" — low 29
+// mantissa bits zero, |x| <= kEeFpuMax, no denormals — which the guard mask
+// preserves (it only clears low bits or reduces an operand to its sign) and
+// which is what makes the accumulate exact: two 24-bit significands at an
+// exponent distance of at most 24 sum in 48 bits, well inside a double's 53.
+// The one arm that leaves the wide domain early is accovf, because kEeFpuMax
+// has no single a narrowing could reach.
 static void recMaddsub(int info, int eeRecDst, int op /*0=add,1=sub*/, bool acc)
 {
 	const int sreg = copySrc(EEREC_S);
 	const int treg = copySrc(EEREC_T);
 
 	// --- multiply stage: sreg = ToPS2FPU(ToDouble(s) * ToDouble(t)). Sets O on
-	//     product overflow; acc=false so it never touches ACCflag here. ---
+	//     product overflow; never touches ACCflag here. ---
+	//
+	// The product is rounded but not narrowed: ToPS2FPU_Wide leaves it as a
+	// double holding an exact PS2 single. Everything downstream of it in this
+	// emitter -- the guard mask, the SUB sign flip, the accumulate -- wants the
+	// wide form back, and narrowing here only to re-widen 13 instructions later
+	// was the round trip this shape exists to remove.
 	ToDouble(sreg);
 	ToDouble(treg);
 	armAsm->Fmul(armDRegister(sreg), armDRegister(sreg), armDRegister(treg));
-	ToPS2FPU_Full(sreg, true, treg, false, false);
+	ToPS2FPU_Wide(sreg);
 
-	// --- reload ACC (allocator-resident) into treg, then guard-mask it against
-	//     the single-precision product. ---
+	// --- reload ACC (allocator-resident, still narrow) into treg and widen it,
+	//     then guard-mask it against the product in the wide domain. ---
 	armAsm->Fmov(armSRegister(treg), armSRegister(EEREC_ACC));
-	FPU_ADD_SUB(treg, sreg);
+	ToDouble(treg);
+	FPU_ADD_SUB_D(treg, sreg);
 
 	a64::Label mulovf, accovf, operation, skipall;
 
@@ -360,29 +532,31 @@ static void recMaddsub(int info, int eeRecDst, int op /*0=add,1=sub*/, bool acc)
 	armLoadEERegPtr(RWSCRATCH, &fpuRegs.fprc[31]);
 	armAsm->Tst(RWSCRATCH, FPUflagO);
 	armAsm->B(&mulovf, a64::ne);
-	ToDouble(sreg);
 
 	// prior ACC saturated? -> accovf
 	armLoadEERegPtr(RWSCRATCH, &fpuRegs.ACCflag);
 	armAsm->Tst(RWSCRATCH, 1);
 	armAsm->B(&accovf, a64::ne);
-	ToDouble(treg);
 	armAsm->B(&operation);
 
 	armAsm->Bind(&mulovf);
-	// Product is a saturated single; for SUB negate its sign, then it becomes
-	// the (single) accumulate result. Falls through into accovf.
+	// Product saturated at +/-kEeFpuMax; for SUB negate its sign, then it
+	// becomes the accumulate result. Falls through into accovf.
 	if (op == 1)
 	{
-		armAsm->Fmov(RWSCRATCH, armSRegister(sreg));
-		armAsm->Eor(RWSCRATCH, RWSCRATCH, 0x80000000);
-		armAsm->Fmov(armSRegister(sreg), RWSCRATCH);
+		armAsm->Fmov(RXSCRATCH, armDRegister(sreg));
+		armAsm->Eor(RXSCRATCH, RXSCRATCH, UINT64_C(0x8000000000000000));
+		armAsm->Fmov(armDRegister(sreg), RXSCRATCH);
 	}
-	armAsm->Fmov(armSRegister(treg), armSRegister(sreg));
+	armAsm->Fmov(armDRegister(treg), armDRegister(sreg));
 
 	armAsm->Bind(&accovf);
-	// SetMaxValue(treg): keep sign, set all lower bits -> +/-PS2 max.
-	armAsm->Fmov(RWSCRATCH, armSRegister(treg));
+	// SetMaxValue(treg): keep sign, set all lower bits -> +/-PS2 max. This arm
+	// leaves the wide domain for good -- kEeFpuMax has no single encoding a
+	// narrowing could reach (Fcvt would give +/-FLT_MAX), so build the result
+	// single directly from the double's sign, which is bit 31 of its high half.
+	armAsm->Fmov(RXSCRATCH, armDRegister(treg));
+	armAsm->Lsr(RXSCRATCH, RXSCRATCH, 32);
 	armAsm->Orr(RWSCRATCH, RWSCRATCH, 0x7fffffff);
 	armAsm->Fmov(armSRegister(treg), RWSCRATCH);
 	// Clear O|U then raise O|SO (and ACCflag for the *A variants).

--- a/pcsx2/arm64/iFPUd-arm64.cpp
+++ b/pcsx2/arm64/iFPUd-arm64.cpp
@@ -555,7 +555,14 @@ static void recFPUOp(int info, int eeRecDst, int op /*0=add,1=sub*/, bool acc)
 // one's 100 / 99.8421 / 99.8482 / 99.8091.
 // The other three rows are not evidence that the term buys nothing elsewhere:
 // their fs values have a zero tail on 1 or 2 rows out of 2^23, so the term
-// cannot show in them at all. The term needs a bitfield extract
+// cannot show in them at all. The fpmul3 sweeps, whose fs values have trailing
+// zeros, do populate that cell: at fs = 1.5 there are 2,796,203 zero-tail rows
+// and the term decides 65,536 of them (2.34%). Pooled over fpmul3's 7,196,506
+// zero-tail rows the full predicate is exactly hardware -- 0 missed, 0 wrong --
+// while this one misses 229,142 and is likewise never wrong. So the gap is a
+// real 3.3% of the reachable class; what makes it acceptable is that it is
+// one-directional (it can only miss a deficit, never invent one) and rare in
+// general operand space, per the count above. The term needs a bitfield extract
 // NEON has no equivalent for, so it has to go through GPRs and come back --
 // sketched at ten instructions against this predicate's three.
 // The resulting interpreter divergence is pinned by

--- a/pcsx2/arm64/iFPUd-arm64.cpp
+++ b/pcsx2/arm64/iFPUd-arm64.cpp
@@ -561,21 +561,34 @@ static void recFPUOp(int info, int eeRecDst, int op /*0=add,1=sub*/, bool acc)
 // The resulting interpreter divergence is pinned by
 // EeRecFpuFull.MulDefectDropsTheBoundaryTermTheInterpreterModels.
 //
-// ft is read narrow, out of the allocator-resident guest register: the
-// single-domain mask 0x2AA is one MOVZ where the double-domain 0x2AA << 29 is
-// two, and Cmtst on the 64-bit lane only looks at bits 0..9 -- the single's
-// mantissa bits 0..9, whatever the register's upper half happens to hold.
+// ft is read narrow, out of the allocator-resident guest register: Cmtst on the
+// 64-bit lane only looks at bits 0..9 -- the single's mantissa bits 0..9,
+// whatever the register's upper half happens to hold -- so the mask is the
+// single-domain 0x2AA and not the double-domain 0x2AA << 29.
+//
+// The mask is not materialized here: it is parked in d10 for the whole JIT
+// session by _DynGen_EnterRecompiledCode, next to the s8/s9 clamp constants and
+// under the same AAPCS64 argument: the low 64 bits of d8-d15 are callee-saved,
+// so the constant survives every C call without compile-time liveness tracking.
+// That is what took this from six instructions to four, and it applies to the
+// first multiply in a block as much as the tenth -- a liveness flag in a
+// caller-saved register would still have paid mov+fmov to open every span, and
+// would have had to be invalidated at C-call seams, branch forks, superblock
+// side-exit bodies (recEmitColdSideExits emits several per emission session,
+// each reachable only through its own island) and backpatched fastmem thunks,
+// where a single missed seam is a silent one-ULP error the corpus cannot see.
+// The register costs one slot out of the callee-saved allocator range; the full
+// contract, including why microVU needs no pool gate for it, is on
+// NEON_RESERVED_FPU_MULMASK in iCore-arm64.h.
 //
 // `dstidx` holds ToDouble(fs) on entry and the product on exit, `tidx` holds
 // ToDouble(ft), `ftnarrowidx` is the untouched guest ft. RQSCRATCH/RQSCRATCH2
 // (q30/q31) are outside the allocator pool, so no temp aliases them.
 //
 // What comes out, decoded from the code buffer (the Fmul was already there, so
-// six of these seven are the cost):
+// four of these five are the cost):
 //
-//     mov   x8, #0x2aa
-//     fmov  d30, x8
-//     cmtst d30, d10, d30            ; d10 == EEREC_T, the narrow guest ft
+//     cmtst d30, d11, d10            ; d11 == EEREC_T (narrow guest ft), d10 == the parked mask
 //     fmul  d0, d0, d1
 //     fcmeq d31, d0, #0.0
 //     bic   v30.8b, v30.8b, v31.8b
@@ -585,9 +598,7 @@ static void emitDefectiveFmul(int dstidx, int tidx, int ftnarrowidx)
 	const a64::VRegister prod = armDRegister(dstidx);
 
 	// Hoisted above the Fmul: the predicate is not on its dependency chain.
-	armAsm->Mov(RXSCRATCH, UINT64_C(0x2AA));
-	armAsm->Fmov(RDSCRATCH, RXSCRATCH);
-	armAsm->Cmtst(RDSCRATCH, armDRegister(ftnarrowidx), RDSCRATCH);
+	armAsm->Cmtst(RDSCRATCH, armDRegister(ftnarrowidx), a64::VRegister(NEON_RESERVED_FPU_MULMASK, 64));
 
 	armAsm->Fmul(prod, prod, armDRegister(tidx));
 

--- a/pcsx2/arm64/iFPUd-arm64.cpp
+++ b/pcsx2/arm64/iFPUd-arm64.cpp
@@ -482,8 +482,121 @@ static void recFPUOp(int info, int eeRecDst, int op /*0=add,1=sub*/, bool acc)
 	_freeNEONreg(treg);
 }
 
-// MUL/MULA: widen -> multiply in double -> narrow. (FPUMULHACK — the Tales of
-// Destiny gamefix — is intentionally not folded in here; default off.)
+// ---- The EE multiplier's one-ULP deficit -----------------------------------
+//
+// The console's multiply array does not round correctly: it comes back exactly
+// one step closer to zero on a large fraction of operands, and which operands
+// depends on the operand order. `mul.s` is one ULP low iff both:
+//
+//   1. the exact product has nothing below the single's ULP to absorb the
+//      deficit -- the deficit is at most ~27308 against an ULP of 2^23, so a
+//      non-zero tail hides it; and
+//   2. ft's mantissa fires the Booth predicate below. fs does not enter it at
+//      all, which is exactly why the operation is not commutative:
+//      mul.s(1.0, x) is one ULP low for 8257536 of the 2^23 significands while
+//      mul.s(x, 1.0) is exact for all of them.
+//
+// The interpreter models the same law (FPU.cpp eeMulRound / eeMulOneUlpLow /
+// eeMulDefectiveFt); this is its mode-3 codegen. FpuMulHack is a one-point
+// sample of the same rule and this subsumes it, including the asymmetry -- it
+// is not folded in here because iFPUd never had it.
+//
+// The product is computed in double, where a 24x24 significand multiply is
+// exact, so condition 1 needs no integer multiply and no tail extraction:
+// one integer ULP of the double is strictly below one ULP of the single, so
+// decrementing the double's raw bit pattern drops an exactly-representable
+// product one single-step and leaves everything else inside the same single
+// bucket. The rounding downstream performs the tail test -- and it is the same
+// test under either of the two narrowings this file uses: ToPS2FPU_Wide's
+// mask-off-the-low-29 is truncation by construction, and ToPS2FPU_Full's Fcvt
+// runs under FPUFPCR, whose mode is round-toward-zero (the argument is spelled
+// out at ToPS2FPU_Wide). That equivalence is structural. The FPCR is the
+// dependency that actually matters: under round-to-nearest the decremented
+// double would round straight back up to the product it came from and this
+// would emit nothing at all.
+//
+// A NEON compare result is all-ones, which as a 64-bit lane is -1, so `Add` of
+// the mask is the conditional decrement. Two traps, both already paid for once:
+//
+//   * the Add is a 64-bit lane, so the mask must be all-ones across the full 64
+//     bits. A 32-bit compare adds +0xFFFFFFFF instead of -1; that scores 98.28%
+//     and reads like a predicate bug when it is a mask bug.
+//   * the Bic is `.8b` because there is no scalar BIC. AdvSIMD BIC has only the
+//     .8B/.16B register forms and the .4H/.8H/.2S/.4S immediate form; `bic
+//     d30, d30, d31` is rejected outright by an assembler. vixl guards it with
+//     a VIXL_ASSERT, which this tree compiles out so it emits 0x5eff1fde, an
+//     undefined encoding, and the JIT takes SIGILL the first time the block
+//     runs.
+//   * a zero product must be excluded, which is the Fcmeq/Bic pair. Under FZ a
+//     zero or denormal operand widens to +/-0 and the product is exactly +/-0,
+//     whose pattern decrements to 0xFFFFFFFFFFFFFFFF -- a NaN. Testing the
+//     product covers both of the interpreter's guards at once: a product is
+//     exactly +/-0 only when an operand was zero or denormal, because the
+//     smallest product of two EE normals is ~2^-252, an ordinary double.
+//
+// The interpreter's two remaining guards need no codegen. A saturating result
+// is unreachable-by-one-ULP: products are multiples of 2^81 at that exponent
+// while a double ULP there is 2^76, so no decrement can walk a product from
+// above kEeFpuMax down to it, and a product landing exactly on kEeFpuMax is
+// decremented by the interpreter too. "A decrement would leave the normals"
+// (w == 0x00800000) needs ma*mb == 2^46 with both in [2^23, 2^24), forcing
+// ma == mb == 2^23 -- ft mantissa 0, predicate off.
+//
+// The predicate is the cheap half of the measured one. `mant & 0x2AA` -- bits
+// 1,3,5,7,9, the sign bits of the five lowest radix-4 Booth digits -- is the
+// whole rule except for a boundary term at the truncation column,
+// `bit11 != (8 <= (mant >> 12 & 0xF) <= 13)`, which is dropped. It fires on
+// exactly 1/64 of significands, and only a zero tail lets it change anything:
+// counted over all 2^46 significand pairs, 76,236,820 have a zero tail
+// -- 1 pair in 923,028 -- so the term decides 1 pair in 59,073,813. When fs is
+//  a power of two the tail is always zero, and that class scores 98.4375%
+// instead of 100%. Tested against hardware, this predicate gives
+// 98.4375 / 99.8421 / 99.8482 / 99.8091 per fs significand against the full
+// one's 100 / 99.8421 / 99.8482 / 99.8091.
+// The other three rows are not evidence that the term buys nothing elsewhere:
+// their fs values have a zero tail on 1 or 2 rows out of 2^23, so the term
+// cannot show in them at all. The term needs a bitfield extract
+// NEON has no equivalent for, so it has to go through GPRs and come back --
+// sketched at ten instructions against this predicate's three.
+// The resulting interpreter divergence is pinned by
+// EeRecFpuFull.MulDefectDropsTheBoundaryTermTheInterpreterModels.
+//
+// ft is read narrow, out of the allocator-resident guest register: the
+// single-domain mask 0x2AA is one MOVZ where the double-domain 0x2AA << 29 is
+// two, and Cmtst on the 64-bit lane only looks at bits 0..9 -- the single's
+// mantissa bits 0..9, whatever the register's upper half happens to hold.
+//
+// `dstidx` holds ToDouble(fs) on entry and the product on exit, `tidx` holds
+// ToDouble(ft), `ftnarrowidx` is the untouched guest ft. RQSCRATCH/RQSCRATCH2
+// (q30/q31) are outside the allocator pool, so no temp aliases them.
+//
+// What comes out, decoded from the code buffer (the Fmul was already there, so
+// six of these seven are the cost):
+//
+//     mov   x8, #0x2aa
+//     fmov  d30, x8
+//     cmtst d30, d10, d30            ; d10 == EEREC_T, the narrow guest ft
+//     fmul  d0, d0, d1
+//     fcmeq d31, d0, #0.0
+//     bic   v30.8b, v30.8b, v31.8b
+//     add   d0, d0, d30
+static void emitDefectiveFmul(int dstidx, int tidx, int ftnarrowidx)
+{
+	const a64::VRegister prod = armDRegister(dstidx);
+
+	// Hoisted above the Fmul: the predicate is not on its dependency chain.
+	armAsm->Mov(RXSCRATCH, UINT64_C(0x2AA));
+	armAsm->Fmov(RDSCRATCH, RXSCRATCH);
+	armAsm->Cmtst(RDSCRATCH, armDRegister(ftnarrowidx), RDSCRATCH);
+
+	armAsm->Fmul(prod, prod, armDRegister(tidx));
+
+	armAsm->Fcmeq(RDSCRATCH2, prod, 0.0);
+	armAsm->Bic(RQSCRATCH.V8B(), RQSCRATCH.V8B(), RQSCRATCH2.V8B());
+	armAsm->Add(prod, prod, RDSCRATCH);
+}
+
+// MUL/MULA: widen -> multiply in double (with the multiplier deficit) -> narrow.
 static void recMULop(int info, int eeRecDst, bool acc)
 {
 	// Both temps before any emit: _allocTempNEONreg can evict, and an eviction's
@@ -493,7 +606,7 @@ static void recMULop(int info, int eeRecDst, bool acc)
 
 	ToDoubleFrom(sreg, EEREC_S);
 	ToDoubleFrom(treg, EEREC_T);
-	armAsm->Fmul(armDRegister(sreg), armDRegister(sreg), armDRegister(treg));
+	emitDefectiveFmul(sreg, treg, EEREC_T);
 
 	ToPS2FPU_Full(sreg, true, treg, acc, false);
 	armAsm->Fmov(armSRegister(eeRecDst), armSRegister(sreg));
@@ -537,7 +650,7 @@ static void recMaddsub(int info, int eeRecDst, int op /*0=add,1=sub*/, bool acc)
 	// was the round trip this shape exists to remove.
 	ToDoubleFrom(sreg, EEREC_S);
 	ToDoubleFrom(treg, EEREC_T);
-	armAsm->Fmul(armDRegister(sreg), armDRegister(sreg), armDRegister(treg));
+	emitDefectiveFmul(sreg, treg, EEREC_T);
 	ToPS2FPU_Wide(sreg);
 
 	// --- widen the (allocator-resident, still narrow) ACC straight into treg,

--- a/pcsx2/arm64/iFPUd-arm64.cpp
+++ b/pcsx2/arm64/iFPUd-arm64.cpp
@@ -49,32 +49,46 @@ namespace DOUBLE {
 // widen exactly, then raise the exponent by one in the double domain. Mirrors
 // x86 ToDouble (xPSUB.D one_exp / xCVTSS2SD / xPADD.Q dbl_one_exp).
 //
-// Operates in place on temp NEON reg `idx`: reads the S lane, writes the D lane.
-static void ToDouble(int idx)
+// Reads `srcidx`'s S lane, writes `dstidx`'s D lane, and never writes the
+// source. The two may be the same register (that is ToDouble below).
+//
+// The source is allowed to be an allocator-resident guest FPR or the ACC, which
+// is the point: the complex arm needs somewhere to put the exponent-lowered
+// single before Fcvt, and it uses the destination's S lane — a temp the caller
+// owns — instead of scribbling on the source. Every widening site used to pay a
+// `copySrc` Fmov purely to make that scribble legal.
+static void ToDoubleFrom(int dstidx, int srcidx)
 {
-	const a64::VRegister s = armSRegister(idx);
-	const a64::VRegister d = armDRegister(idx);
+	const a64::VRegister ss = armSRegister(srcidx);
+	const a64::VRegister sd = armSRegister(dstidx);
+	const a64::VRegister dd = armDRegister(dstidx);
 
 	a64::Label simple, done;
-	armAsm->Fmov(RWSCRATCH, s);
+	armAsm->Fmov(RWSCRATCH, ss);
 	armAsm->And(RWARG1, RWSCRATCH, 0x7f800000);
 	armAsm->Cmp(RWARG1, 0x7f800000);
 	armAsm->B(&simple, a64::ne);
 
 	// Complex: exp field == 0xff (Inf/NaN to IEEE, finite to PS2).
 	armAsm->Sub(RWSCRATCH, RWSCRATCH, 0x00800000);   // lower exponent by one (single)
-	armAsm->Fmov(s, RWSCRATCH);
-	armAsm->Fcvt(d, s);                              // cvtss2sd (now finite)
-	armAsm->Fmov(RXSCRATCH, d);
+	armAsm->Fmov(sd, RWSCRATCH);
+	armAsm->Fcvt(dd, sd);                            // cvtss2sd (now finite)
+	armAsm->Fmov(RXSCRATCH, dd);
 	armAsm->Mov(RXARG1, static_cast<u64>(1) << 52);  // dbl_one_exp
 	armAsm->Add(RXSCRATCH, RXSCRATCH, RXARG1);       // raise exponent by one (double)
-	armAsm->Fmov(d, RXSCRATCH);
+	armAsm->Fmov(dd, RXSCRATCH);
 	armAsm->B(&done);
 
 	armAsm->Bind(&simple);
-	armAsm->Fcvt(d, s);
+	armAsm->Fcvt(dd, ss);
 
 	armAsm->Bind(&done);
+}
+
+// In-place form: widen temp NEON reg `idx` from its own S lane.
+static void ToDouble(int idx)
+{
+	ToDoubleFrom(idx, idx);
 }
 
 // ---- IEEE double -> PS2 single (full overflow/underflow/flag handling) -----
@@ -434,7 +448,11 @@ static void FPU_ADD_SUB_D(int idxd, int idxt)
 // ---- Op cores --------------------------------------------------------------
 
 // Copy an allocator-resident FP source (EEREC_S/EEREC_T) into a fresh temp so
-// ToDouble can mutate it without corrupting the guest fpr slot.
+// the emitter can mutate it without corrupting the guest fpr slot.
+//
+// Only the paths that mutate the operand in the single domain still need this:
+// recFPUOp's FPU_ADD_SUB guard mask, and the Fabs in SQRT/RSQRT. A site that
+// only widens uses ToDoubleFrom(temp, EEREC_x) instead and pays no copy.
 static int copySrc(int eerec)
 {
 	const int idx = _allocTempNEONreg();
@@ -468,11 +486,13 @@ static void recFPUOp(int info, int eeRecDst, int op /*0=add,1=sub*/, bool acc)
 // Destiny gamefix — is intentionally not folded in here; default off.)
 static void recMULop(int info, int eeRecDst, bool acc)
 {
-	const int sreg = copySrc(EEREC_S);
-	const int treg = copySrc(EEREC_T);
+	// Both temps before any emit: _allocTempNEONreg can evict, and an eviction's
+	// writeback must not land between an operand's copy and its use.
+	const int sreg = _allocTempNEONreg();
+	const int treg = _allocTempNEONreg();
 
-	ToDouble(sreg);
-	ToDouble(treg);
+	ToDoubleFrom(sreg, EEREC_S);
+	ToDoubleFrom(treg, EEREC_T);
 	armAsm->Fmul(armDRegister(sreg), armDRegister(sreg), armDRegister(treg));
 
 	ToPS2FPU_Full(sreg, true, treg, acc, false);
@@ -504,8 +524,8 @@ static void recMULop(int info, int eeRecDst, bool acc)
 // has no single a narrowing could reach.
 static void recMaddsub(int info, int eeRecDst, int op /*0=add,1=sub*/, bool acc)
 {
-	const int sreg = copySrc(EEREC_S);
-	const int treg = copySrc(EEREC_T);
+	const int sreg = _allocTempNEONreg();
+	const int treg = _allocTempNEONreg();
 
 	// --- multiply stage: sreg = ToPS2FPU(ToDouble(s) * ToDouble(t)). Sets O on
 	//     product overflow; never touches ACCflag here. ---
@@ -515,15 +535,14 @@ static void recMaddsub(int info, int eeRecDst, int op /*0=add,1=sub*/, bool acc)
 	// emitter -- the guard mask, the SUB sign flip, the accumulate -- wants the
 	// wide form back, and narrowing here only to re-widen 13 instructions later
 	// was the round trip this shape exists to remove.
-	ToDouble(sreg);
-	ToDouble(treg);
+	ToDoubleFrom(sreg, EEREC_S);
+	ToDoubleFrom(treg, EEREC_T);
 	armAsm->Fmul(armDRegister(sreg), armDRegister(sreg), armDRegister(treg));
 	ToPS2FPU_Wide(sreg);
 
-	// --- reload ACC (allocator-resident, still narrow) into treg and widen it,
+	// --- widen the (allocator-resident, still narrow) ACC straight into treg,
 	//     then guard-mask it against the product in the wide domain. ---
-	armAsm->Fmov(armSRegister(treg), armSRegister(EEREC_ACC));
-	ToDouble(treg);
+	ToDoubleFrom(treg, EEREC_ACC);
 	FPU_ADD_SUB_D(treg, sreg);
 
 	a64::Label mulovf, accovf, operation, skipall;
@@ -679,10 +698,10 @@ void recMIN_S_xmm(int info) { recMINMAX(info, true); }
 // compare is always ordered and the lt/le/eq condition reads are exact.
 static void recCMP(int info)
 {
-	const int sreg = copySrc(EEREC_S);
-	const int treg = copySrc(EEREC_T);
-	ToDouble(sreg);
-	ToDouble(treg);
+	const int sreg = _allocTempNEONreg();
+	const int treg = _allocTempNEONreg();
+	ToDoubleFrom(sreg, EEREC_S);
+	ToDoubleFrom(treg, EEREC_T);
 	armAsm->Fcmp(armDRegister(sreg), armDRegister(treg));
 	_freeNEONreg(sreg);
 	_freeNEONreg(treg);
@@ -755,23 +774,25 @@ static void SetMaxValueS(int idx)
 
 // x86 recDIVhelper1 (FPU_FLAGS_ID == 1 unconditionally): divide-by-zero
 // flag/result shape in the single domain, otherwise divide in double.
-// sreg/treg are temp copies (mutated); the result lands in sreg's S lane.
+// sreg/treg are write-only temps and srcS/srcT the allocator-resident operands,
+// which are only ever read; the result lands in sreg (S lane on the zero-divisor
+// arm, S lane after ToPS2FPU_Full on the normal one).
 // The Fcmp-with-zero runs under the EE FPCR whose FZ bit flushes denormal
 // inputs — same divisor-is-zero net as x86's DAZ'd CMPEQ.SS. The double
 // quotient of two in-range PS2 values is always finite (max magnitude
 // ~2^255), so ToPS2FPU_Full's finite-only contract holds.
-static void recDIVhelper1(int sreg, int treg)
+static void recDIVhelper1(int sreg, int treg, int srcS, int srcT)
 {
 	ClearIDFlags();
 
 	a64::Label normal, xOverZero, setDone, done;
-	armAsm->Fcmp(armSRegister(treg), 0.0);
+	armAsm->Fcmp(armSRegister(srcT), 0.0);
 	armAsm->B(&normal, a64::ne);
 
 	// Divisor is ±0: pick the flag pair, then result = (fs ^ ft) | 0x7fffffff
 	// (x86 SetMaxValue under FPU_RESULT — see SetMaxValueS above; masking the
 	// XOR down to its sign bit first is equivalent, the OR sets bits 0..30).
-	armAsm->Fcmp(armSRegister(sreg), 0.0);
+	armAsm->Fcmp(armSRegister(srcS), 0.0);
 	armAsm->B(&xOverZero, a64::ne);
 	SetFprcOr(FPUflagI | FPUflagSI); // 0/0
 	armAsm->B(&setDone);
@@ -779,8 +800,8 @@ static void recDIVhelper1(int sreg, int treg)
 	SetFprcOr(FPUflagD | FPUflagSD); // x/0
 	armAsm->Bind(&setDone);
 
-	armAsm->Fmov(RWSCRATCH, armSRegister(sreg));
-	armAsm->Fmov(RWARG1, armSRegister(treg));
+	armAsm->Fmov(RWSCRATCH, armSRegister(srcS));
+	armAsm->Fmov(RWARG1, armSRegister(srcT));
 	armAsm->Eor(RWSCRATCH, RWSCRATCH, RWARG1);
 	armAsm->And(RWSCRATCH, RWSCRATCH, 0x80000000);
 	armAsm->Orr(RWSCRATCH, RWSCRATCH, 0x7fffffff);
@@ -788,8 +809,8 @@ static void recDIVhelper1(int sreg, int treg)
 	armAsm->B(&done);
 
 	armAsm->Bind(&normal);
-	ToDouble(sreg);
-	ToDouble(treg);
+	ToDoubleFrom(sreg, srcS);
+	ToDoubleFrom(treg, srcT);
 	armAsm->Fdiv(armDRegister(sreg), armDRegister(sreg), armDRegister(treg));
 	ToPS2FPU_Full(sreg, false, treg, false, false);
 
@@ -803,9 +824,9 @@ void recDIV_S_xmm(int info)
 	if (swapFpcr)
 		emitLoadFPCRImm(EmuConfig.Cpu.FPUDivFPCR.bitmask);
 
-	const int sreg = copySrc(EEREC_S);
-	const int treg = copySrc(EEREC_T);
-	recDIVhelper1(sreg, treg);
+	const int sreg = _allocTempNEONreg();
+	const int treg = _allocTempNEONreg();
+	recDIVhelper1(sreg, treg, EEREC_S, EEREC_T);
 	armAsm->Fmov(armSRegister(EEREC_D), armSRegister(sreg));
 	_freeNEONreg(sreg);
 	_freeNEONreg(treg);

--- a/pcsx2/arm64/iR5900-arm64.cpp
+++ b/pcsx2/arm64/iR5900-arm64.cpp
@@ -322,6 +322,21 @@ static const void* _DynGen_EnterRecompiledCode()
 	armAsm->Ldr(a64::s8, FLT_MAX);
 	armAsm->Ldr(a64::s9, -FLT_MAX);
 
+	// Same convention, one register along: d10 = 0x2AA, the Booth-digit mask
+	// of the EE multiplier's one-ULP deficit (NEON_RESERVED_FPU_MULMASK; the
+	// contract is on the constant, the consumer is emitDefectiveFmul in
+	// iFPUd-arm64.cpp). Parking it here is what makes the mode-3 multiply
+	// sequence 4 instructions instead of 6 — every consumer reads it, none
+	// materializes it, and because the low 64 bits of d8-d15 are callee-saved
+	// there is no C-call seam, branch fork, superblock side exit or
+	// backpatched fastmem thunk that can invalidate it.
+	//
+	// Emitted unconditionally rather than under CHECK_FPU_FULL: two
+	// instructions once per JIT entry are not worth a dispatcher that goes
+	// stale if the clamp mode changes without a recompiler reset.
+	armAsm->Mov(RXSCRATCH, UINT64_C(0x2AA));
+	armAsm->Fmov(a64::VRegister(NEON_RESERVED_FPU_MULMASK, 64), RXSCRATCH);
+
 	// Load fastmem base into x19 if enabled
 	if (CHECK_FASTMEM)
 	{

--- a/tests/ctest/core/recompilers/ee_rec_fpu_full_mode_tests.cpp
+++ b/tests/ctest/core/recompilers/ee_rec_fpu_full_mode_tests.cpp
@@ -1507,3 +1507,136 @@ TEST(EeRecFpuFull, MulDefectMaskSurvivesHeavyFprPressure)
 	ExpectMaskLive(h, 4, 5, "MUL.S after 16 live FPRs");
 	ASSERT_NE(kMaskOnWant, kMaskOffWant);
 }
+
+// ---------------------------------------------------------------------------
+// The deficit in the upper binade, and with fs not a power of two.
+//
+// Runs 1 and 2 swept four fs significands and established the law, but look at
+// which cells they actually populated. The predicate can only change a result
+// when the exact product has nothing below the ULP (T == 0), and across all
+// 33,554,432 of their rows:
+//
+//     product <  2^47 (lower binade), T == 0   8,388,608 rows, all at fs = 2^23
+//     product >= 2^47 (upper binade), T == 0           0 rows
+//
+// So the region where this emitter's decrement actually fires when the product
+// lands in the upper binade had never been observed on hardware -- and it is
+// not exotic: fs = 1.5 puts 1,398,101 of 2^23 ft values there. It mattered
+// because the truncation column moves one bit between the binades, so a
+// predicate keyed to fixed bit positions of ft has no a-priori reason to
+// survive the shift.
+//
+// Settled from the fpmul3 capture (8 further fs sweeps, SCPH-90000, FCR0
+// 0x2e40), which had been taken for a different question and never analysed by
+// binade. Pooled over its 7,196,506 T == 0 rows -- 3,354,792 of them in the
+// upper binade, at six fs values with odd parts 3, 5, 7, 9, 15 and 255:
+//
+//     emitted Booth-only predicate   6,738,214 correct   229,142 missed   0 wrong
+//     interpreter's full predicate   6,967,356 correct           0 missed 0 wrong
+//
+// Zero wrong in either binade: the emitter never claims a deficit where silicon
+// is exact, which is the one direction that would be a regression. The rows
+// below are three witnesses per fs, generated from that capture rather than
+// typed, so provenance is mechanical.
+namespace {
+struct BinadeRow { u32 fs, ft, want; };
+
+// Upper binade, T == 0, Booth fires -> silicon is one ULP low. The emitter must
+// reproduce every one of these.
+constexpr BinadeRow kTopBinadeFires[] = {
+	{0x3fc00000u, 0x3faaaaacu, 0x40000000u}, // fs 1.5:    M = 2^47 + 2^24 exactly
+	{0x3fe00000u, 0x3f924928u, 0x40000002u}, // fs 1.75
+	{0x3fa00000u, 0x3fccccd0u, 0x40000001u}, // fs 1.25
+	{0x3f900000u, 0x3fe38e40u, 0x40000003u}, // fs 1.125
+	{0x3ff00000u, 0x3f888890u, 0x40000006u}, // fs 1.875
+	{0x3fff0000u, 0x3f808200u, 0x4000017du}, // fs ~1.996
+};
+
+// Upper binade, T == 0, neither term of the predicate fires -> silicon is
+// exact. This is the anti-regression direction: a predicate that over-fires in
+// the upper binade would move these one ULP away from hardware.
+constexpr BinadeRow kTopBinadeSilent[] = {
+	{0x3fc00000u, 0x3faaac00u, 0x40000100u},
+	{0x3fe00000u, 0x3f925000u, 0x40000600u},
+	{0x3fa00000u, 0x3fcccd00u, 0x40000020u},
+	{0x3f900000u, 0x3fe39800u, 0x40000580u},
+	{0x3ff00000u, 0x3f888900u, 0x40000070u},
+	{0x3fff0000u, 0x3f808800u, 0x40000778u},
+};
+
+// Upper binade, T == 0, only the dropped boundary term fires -> silicon is one
+// ULP low and this emitter is one ULP high. `want` is the silicon value, so
+// the emitter is asserted at want + 1: the licensed divergence, in the binade
+// where it had never been measured.
+constexpr BinadeRow kTopBinadeBoundary[] = {
+	{0x3fc00000u, 0x3faab000u, 0x400003ffu},
+	{0x3fe00000u, 0x3f924940u, 0x40000017u},
+	{0x3fa00000u, 0x3fccd000u, 0x400001ffu},
+	{0x3f900000u, 0x3fe39000u, 0x400000ffu},
+	{0x3ff00000u, 0x3f889000u, 0x400006ffu},
+	{0x3fff0000u, 0x3f808100u, 0x4000007eu},
+};
+
+// Both emit sites: recMULop narrows with ToPS2FPU_Full's Fcvt, recMaddsub's
+// multiply stage with ToPS2FPU_Wide's mask-off-the-low-29. Those two land on
+// different sides of the mantissa boundary that the binade shifts, so the
+// upper binade has to be checked through both.
+void ExpectBothSites(const BinadeRow& r, u32 want, const char* what)
+{
+	EeRecTestHarness h;
+	h.EnableCop1();
+	h.EnableFpuFullMode();
+	h.SetFprBits(0, r.fs);
+	h.SetFprBits(1, r.ft);
+	h.LoadProgram({MUL_S(2, 0, 1)});
+	h.RunJitNoDiff();
+	EXPECT_EQ(h.GetFprBitsJit(2), want)
+		<< what << " MUL.S fs=" << std::hex << r.fs << " ft=" << r.ft;
+
+	EeRecTestHarness hm;
+	hm.EnableCop1();
+	hm.EnableFpuFullMode();
+	hm.SetAccBits(0x00000000u); // ACC = +0 -> fd is the rounded product alone
+	hm.SetFprBits(0, r.fs);
+	hm.SetFprBits(1, r.ft);
+	hm.LoadProgram({MADD_S(2, 0, 1)});
+	hm.RunJitNoDiff();
+	EXPECT_EQ(hm.GetFprBitsJit(2), want)
+		<< what << " MADD.S fs=" << std::hex << r.fs << " ft=" << r.ft;
+}
+} // namespace
+
+TEST(EeRecFpuFull, MulDefectFiresInTheUpperBinade)
+{
+	for (const BinadeRow& r : kTopBinadeFires)
+		ExpectBothSites(r, r.want, "upper-binade deficit");
+}
+
+// The direction that would be a regression, and the reason this capture was
+// analysed at all: 3,092,991 upper-binade rows where the emitter fires, 0 of
+// them wrong. These pin the complement -- it must stay silent where silicon is.
+TEST(EeRecFpuFull, MulDefectStaysSilentInTheUpperBinadeWhereSiliconIsExact)
+{
+	for (const BinadeRow& r : kTopBinadeSilent)
+		ExpectBothSites(r, r.want, "upper-binade exact");
+}
+
+// The dropped boundary term reaches the upper binade too, at the same 1/64 of
+// significands. Asserting emitter == silicon + 1 keeps the gap measured rather
+// than latent: closing it in iFPUd trips this and names the reason.
+TEST(EeRecFpuFull, MulDefectBoundaryTermGapAlsoExistsInTheUpperBinade)
+{
+	for (const BinadeRow& r : kTopBinadeBoundary)
+	{
+		ExpectBothSites(r, r.want + 1u, "upper-binade boundary term");
+
+		EeRecTestHarness hi;
+		hi.EnableCop1();
+		hi.SetFprBits(0, r.fs);
+		hi.SetFprBits(1, r.ft);
+		hi.LoadProgram({MUL_S(2, 0, 1)});
+		hi.RunInterpOnly();
+		EXPECT_EQ(hi.GetFprBitsInterp(2), r.want)
+			<< "interp models the boundary term in the upper binade too";
+	}
+}

--- a/tests/ctest/core/recompilers/ee_rec_fpu_full_mode_tests.cpp
+++ b/tests/ctest/core/recompilers/ee_rec_fpu_full_mode_tests.cpp
@@ -752,3 +752,205 @@ TEST(EeRecFpuFull, DoubleModeScratchPreservesLiveGuestScalars)
 	// Sanity: the double-mode ADD result is still correct (normal-range round-trip).
 	EXPECT_EQ(h.GetFprBitsJit(2), FloatBits(3.75f));
 }
+
+// ---- Guard mask and rounding for the MADD family (recMaddsub) --------------
+//
+// recMaddsub keeps the product wide between its two roundings: the multiply
+// stage rounds it to PS2 precision in the double domain (ToPS2FPU_Wide) instead
+// of narrowing to a single and widening straight back, and the guard mask then
+// runs on doubles (FPU_ADD_SUB_D). Both tests below pin behaviour that predates
+// that change -- they pass identically on the narrow implementation.
+//
+// Why these inputs and not rounder ones: a 1067-row grid built by sweeping the
+// ACC/product exponent difference from -32..+32 with all-ones mantissas cannot
+// see the guard mask at all (breaking the mask shift by one moved 0 of its
+// rows). The masked bits sit strictly below half an ULP of the sum, so they
+// only survive the truncation when the exact sum lands within that band of an
+// ULP boundary -- which all-ones mantissas never do. The rows below were found
+// by searching for that condition against an independent C model of the
+// pipeline, which is also where their expected values come from. Breaking the
+// mask shift by one moves every one of them by exactly 1 ULP.
+
+namespace {
+
+struct MaddRow
+{
+	u32 acc, fs, ft;
+	int op; // 0=MADD 1=MSUB 2=MADDA 3=MSUBA
+	u32 expected;
+	u32 expected_fcr31;
+};
+
+// Runs one row and returns the destination register's bits (Fd for MADD/MSUB,
+// ACC for MADDA/MSUBA) plus FCR31.
+void RunMaddRow(const MaddRow& r, u32* out_val, u32* out_fcr31)
+{
+	EeRecTestHarness h;
+	h.EnableCop1();
+	h.EnableFpuFullMode();
+	h.SetFcr31(0);
+	h.SetAccBits(r.acc);
+	h.SetFprBits(0, r.fs);
+	h.SetFprBits(1, r.ft);
+	switch (r.op)
+	{
+		case 0: h.LoadProgram({MADD_S(2, 0, 1)}); break;
+		case 1: h.LoadProgram({MSUB_S(2, 0, 1)}); break;
+		case 2: h.LoadProgram({MADDA_S(0, 1)}); break;
+		default: h.LoadProgram({MSUBA_S(0, 1)}); break;
+	}
+	h.RunJitNoDiff();
+	*out_val = (r.op < 2) ? h.GetFprBitsJit(2) : h.GetAccBitsJit();
+	*out_fcr31 = h.JitSnapshot().fprs.fprc[31];
+}
+
+// fs is 1.0 throughout, so the rounded product is ft and the ACC/product
+// exponent difference -- the only axis the guard mask reads -- is directly
+// controllable. The 72 rows span differences -23..+23, covering both the arm
+// that masks the product and the arm that masks the ACC.
+constexpr MaddRow kGuardMaskWitnesses[] = {
+	{0x3fb38acau, 0x3f800000u, 0xbacc0111u, 0, 0x3fb357cau, 0u},
+	{0x3ab20dd7u, 0x3f800000u, 0xc4195bd9u, 0, 0xc4195bc3u, 0u},
+	{0xbe953636u, 0x3f800000u, 0x398a99a5u, 0, 0xbe951390u, 0u},
+	{0x33f55005u, 0x3f800000u, 0xac49b3b5u, 0, 0x33f54e72u, 0u},
+	{0x3b6825c7u, 0x3f800000u, 0xc2caa569u, 0, 0xc2caa399u, 0u},
+	{0x42c7b709u, 0x3f800000u, 0x3c50ef1au, 1, 0x42c7b082u, 0u},
+	{0xc481068au, 0x3f800000u, 0xc291ec04u, 1, 0xc46fcf94u, 0u},
+	{0x3924ba1bu, 0x3f800000u, 0xbc28556cu, 0, 0xbc25c284u, 0u},
+	{0xb5219112u, 0x3f800000u, 0x40c46022u, 0, 0x40c46021u, 0u},
+	{0xc36b6e95u, 0x3f800000u, 0xc42bd5ffu, 1, 0x43e1f4b4u, 0u},
+	{0xb29a5453u, 0x3f800000u, 0x29324d8au, 0, 0xb29a543du, 0u},
+	{0xbdc2a958u, 0x3f800000u, 0x329bcd66u, 0, 0xbdc2a956u, 0u},
+	{0xb35354cbu, 0x3f800000u, 0xa9db297eu, 1, 0xb35354b0u, 0u},
+	{0xc2074068u, 0x3f800000u, 0xca66524du, 1, 0x4a6651c6u, 0u},
+	{0xbc0f2a31u, 0x3f800000u, 0x384f5a7cu, 0, 0xbc0e5ad7u, 0u},
+	{0xc3d2b83cu, 0x3f800000u, 0xced89810u, 1, 0x4ed8980du, 0u},
+	{0xb5af16b1u, 0x3f800000u, 0xafd2374cu, 1, 0xb5af098eu, 0u},
+	{0x3b2d84c4u, 0x3f800000u, 0xc106f1efu, 0, 0xc106e717u, 0u},
+	{0x35f587a4u, 0x3f800000u, 0xb4cf4ba1u, 0, 0x35c1b4bcu, 0u},
+	{0x41f0dbb2u, 0x3f800000u, 0xc8e14376u, 0, 0xc8e13fb3u, 0u},
+	{0xb362649cu, 0x3f800000u, 0xa9f35cf9u, 1, 0xb362647eu, 0u},
+	{0xb2fa917bu, 0x3f800000u, 0x39d9d803u, 0, 0x39d9d419u, 0u},
+	{0x370518f8u, 0x3f800000u, 0x334e4a63u, 1, 0x37044aaeu, 0u},
+	{0xc11469c2u, 0x3f800000u, 0x462a42d6u, 0, 0x462a1dbcu, 0u},
+	{0x3649cec6u, 0x3f800000u, 0xbf2b2cabu, 0, 0xbf2b2c79u, 0u},
+	{0xb9e9f9d2u, 0x3f800000u, 0xb833060bu, 1, 0xb9d39911u, 0u},
+	{0x32ea9db1u, 0x3f800000u, 0xadb7adb2u, 0, 0x32ea6fc6u, 0u},
+	{0x3fbcf544u, 0x3f800000u, 0xbc85569au, 0, 0x3fbadfeau, 0u},
+	{0xbaa0f0b0u, 0x3f800000u, 0x3f761279u, 0, 0x3f75c201u, 0u},
+	{0x3be79b92u, 0x3f800000u, 0xb6c52501u, 0, 0x3be76a49u, 0u},
+	{0x32dce714u, 0x3f800000u, 0x2869f708u, 1, 0x32dce70du, 0u},
+	{0xbb7b2e3au, 0x3f800000u, 0x42b93816u, 0, 0x42b93620u, 0u},
+	{0x3baf0f6cu, 0x3f800000u, 0xbff04b54u, 0, 0xbfef9c45u, 0u},
+	{0xbab47c74u, 0x3f800000u, 0x448b789fu, 0, 0x448b7894u, 0u},
+	{0xc3de412bu, 0x3f800000u, 0x4579985cu, 0, 0x455dd037u, 0u},
+	{0xb2fa7f73u, 0x3f800000u, 0xa912c471u, 1, 0xb2fa7f61u, 0u},
+	{0x4260d9d0u, 0x3f800000u, 0xb9d4bf54u, 0, 0x4260d966u, 0u},
+	{0x3292dea1u, 0x3f800000u, 0xbdaacd0bu, 0, 0xbdaacd09u, 0u},
+	{0x3c6a6437u, 0x3f800000u, 0x3e339b27u, 1, 0xbe24f4e4u, 0u},
+	{0xc1306401u, 0x3f800000u, 0x492f0ebdu, 0, 0x492f0e0du, 0u},
+	{0x3635b3f4u, 0x3f800000u, 0x343227f4u, 1, 0x362a9175u, 0u},
+	{0xb400e647u, 0x3f800000u, 0x3cb12651u, 0, 0x3cb12611u, 0u},
+	{0x39907517u, 0x3f800000u, 0xbba223b7u, 0, 0xbb991c66u, 0u},
+	{0x330ea9edu, 0x3f800000u, 0xbae904eau, 0, 0xbae903cdu, 0u},
+	{0xbf6ee4e6u, 0x3f800000u, 0xc1054588u, 1, 0x40ecae74u, 0u},
+	{0xc405bbb4u, 0x3f800000u, 0x4627619cu, 0, 0x461f05e1u, 0u},
+	{0xb7fa0949u, 0x3f800000u, 0xb8ab876du, 1, 0x385a0a36u, 0u},
+	{0x3b48dad0u, 0x3f800000u, 0xb60bbdb1u, 0, 0x3b48b7e1u, 0u},
+	{0x418eac80u, 0x3f800000u, 0x4a25b350u, 1, 0xca25b309u, 0u},
+	{0x35935179u, 0x3f800000u, 0xb3508e2fu, 0, 0x358ccd08u, 0u},
+	{0x452ecb68u, 0x3f800000u, 0xc914f502u, 0, 0xc9144637u, 0u},
+	{0x3ef73c56u, 0x3f800000u, 0x48b65815u, 1, 0xc8b65806u, 0u},
+	{0x3ec3ca47u, 0x3f800000u, 0x33267262u, 1, 0x3ec3ca46u, 0u},
+	{0x332a2e5bu, 0x3f800000u, 0xaa055622u, 0, 0x332a2e3au, 0u},
+	{0x45855769u, 0x3f800000u, 0xc6cac295u, 0, 0xc6a96cbbu, 0u},
+	{0x45393be5u, 0x3f800000u, 0x4266ee5au, 1, 0x4535a02cu, 0u},
+	{0xb5a78404u, 0x3f800000u, 0xaf843707u, 1, 0xb5a77bc1u, 0u},
+	{0x4324653fu, 0x3f800000u, 0xbddf42d3u, 0, 0x43244957u, 0u},
+	{0xc494cb38u, 0x3f800000u, 0xcff0bf3du, 1, 0x4ff0bf3bu, 0u},
+	{0xb95aee1bu, 0x3f800000u, 0x3a201cdau, 0, 0x39d2c2a7u, 0u},
+	{0x42cc503du, 0x3f800000u, 0x463f3294u, 1, 0xc63d99f4u, 0u},
+	{0xb9bd2a07u, 0x3f800000u, 0x451ddb2eu, 0, 0x451ddb2du, 0u},
+	{0xc2cfc0efu, 0x3f800000u, 0xc5730a69u, 1, 0x456c8c62u, 0u},
+	{0xbaaeb833u, 0x3f800000u, 0x3563ab35u, 0, 0xbaae9bbeu, 0u},
+	{0xb556d230u, 0x3f800000u, 0xa9b57d1cu, 1, 0xb556d22fu, 0u},
+	{0xbfe9553bu, 0x3f800000u, 0x34dcabf8u, 0, 0xbfe95538u, 0u},
+	{0x3a2ce961u, 0x3f800000u, 0x4585376eu, 1, 0xc585376du, 0u},
+	{0xc058aa2eu, 0x3f800000u, 0x38a9a118u, 0, 0xc058a8dbu, 0u},
+	{0x3daca0f3u, 0x3f800000u, 0x33a45aa6u, 1, 0x3daca0e9u, 0u},
+	{0x45f4ede4u, 0x3f800000u, 0xc7fb950bu, 0, 0xc7ec462du, 0u},
+	{0xbcfcd10eu, 0x3f800000u, 0x3560a544u, 0, 0xbcfccf4du, 0u},
+	{0xc2b750c8u, 0x3f800000u, 0xb7943082u, 1, 0xc2b750c6u, 0u},
+};
+
+} // namespace
+
+TEST(EeRecFpuFull, MaddGuardMaskAcrossExponentDifferences)
+{
+	for (const MaddRow& r : kGuardMaskWitnesses)
+	{
+		u32 val = 0, fcr31 = 0;
+		RunMaddRow(r, &val, &fcr31);
+		EXPECT_EQ(val, r.expected)
+			<< "acc=" << std::hex << r.acc << " fs=" << r.fs << " ft=" << r.ft
+			<< " op=" << std::dec << r.op;
+	}
+}
+
+// ToPS2FPU_Wide's arms: saturation at the PS2 maximum, the exponent-0xff band
+// (whose halve/narrow/re-raise arm the wide form deletes outright -- up there a
+// PS2 single is just an ordinary double, so it is a plain chop), the underflow
+// flush with its U|SU flags, and signed zero. Expected values are pinned from
+// the narrow implementation these replaced.
+TEST(EeRecFpuFull, MaddWideRoundArms)
+{
+	static const MaddRow kRows[] = {
+		// product == the EE maximum exactly (FLT_MAX * 2): in range, no O.
+		{0x3f800000u, 0x7f7fffffu, 0x40000000u, 0, 0x7fffffffu, 0x00000000u},
+		{0x3f800000u, 0x7f7fffffu, 0x40000000u, 1, 0xffffffffu, 0x00000000u},
+		{0x3f800000u, 0xff7fffffu, 0x40000000u, 0, 0xffffffffu, 0x00000000u},
+		{0x3f800000u, 0xff7fffffu, 0x40000000u, 1, 0x7fffffffu, 0x00000000u},
+		// product above the EE maximum: the mulovf arm, O|SO raised.
+		{0x3f800000u, 0x7f7fffffu, 0x40000001u, 0, 0x7fffffffu, 0x00008010u},
+		{0x3f800000u, 0x7f7fffffu, 0x40000001u, 1, 0xffffffffu, 0x00008010u},
+		{0x3f800000u, 0xff7fffffu, 0x40000001u, 1, 0x7fffffffu, 0x00008010u},
+		{0x3f800000u, 0x7f7fffffu, 0x40000001u, 2, 0x7fffffffu, 0x00008010u},
+		{0x3f800000u, 0x7f7fffffu, 0x40000001u, 3, 0xffffffffu, 0x00008010u},
+		// exponent-0xff band: 2^128 exactly, and a product needing a real chop.
+		{0x3f800000u, 0x7f000000u, 0x40000000u, 0, 0x7f800000u, 0x00000000u},
+		{0x3f800000u, 0x7f000001u, 0x40000001u, 0, 0x7f800002u, 0x00000000u},
+		{0x3f800000u, 0x7f000001u, 0x40000001u, 1, 0xff800002u, 0x00000000u},
+		{0x3f800000u, 0xff000001u, 0x40000001u, 0, 0xff800002u, 0x00000000u},
+		{0x3f800000u, 0x7ffffffeu, 0x3f800000u, 0, 0x7ffffffeu, 0x00000000u},
+		{0x3f800000u, 0x7fffffffu, 0x3f800000u, 0, 0x7fffffffu, 0x00000000u},
+		// underflow: product below 2^-126 flushes to signed zero, U|SU raised.
+		{0x00000000u, 0x00800000u, 0x3f000000u, 0, 0x00000000u, 0x00000008u},
+		{0x00000000u, 0x80800000u, 0x3f000000u, 0, 0x00000000u, 0x00000008u},
+		{0x3f800000u, 0x00800000u, 0x3f000000u, 0, 0x3f800000u, 0x00000008u},
+		// exact zeros and denormal operands (ToDouble flushes under FZ).
+		{0x00000000u, 0x00000000u, 0x3f800000u, 0, 0x00000000u, 0x00000000u},
+		{0x00000000u, 0x80000000u, 0x3f800000u, 0, 0x00000000u, 0x00000000u},
+		{0x3f800000u, 0x00000001u, 0x00000001u, 0, 0x3f800000u, 0x00000000u},
+		{0x00000001u, 0x3f800000u, 0x3f800000u, 0, 0x3f800000u, 0x00000000u},
+		{0x807fffffu, 0x3f800000u, 0x3f800000u, 0, 0x3f800000u, 0x00000000u},
+		{0x807fffffu, 0x3f800000u, 0x3f800000u, 1, 0xbf800000u, 0x00000000u},
+		// ACC already at the PS2 maximum; and the accumulate itself overflowing.
+		{0x7fffffffu, 0x3f800000u, 0x3f800000u, 0, 0x7fffffffu, 0x00000000u},
+		{0xffffffffu, 0x3f800000u, 0x3f800000u, 0, 0xffffffffu, 0x00000000u},
+		{0x7f800000u, 0x7f800000u, 0x3f800000u, 0, 0x7fffffffu, 0x00008010u},
+		{0x7f800000u, 0x7f800000u, 0x3f800000u, 1, 0x00000000u, 0x00000000u},
+		{0x7fffffffu, 0x7f7fffffu, 0x40000000u, 0, 0x7fffffffu, 0x00008010u},
+		{0xffffffffu, 0x7f7fffffu, 0x40000000u, 1, 0xffffffffu, 0x00008010u},
+	};
+	for (const MaddRow& r : kRows)
+	{
+		u32 val = 0, fcr31 = 0;
+		RunMaddRow(r, &val, &fcr31);
+		EXPECT_EQ(val, r.expected)
+			<< "acc=" << std::hex << r.acc << " fs=" << r.fs << " ft=" << r.ft
+			<< " op=" << std::dec << r.op;
+		EXPECT_EQ(fcr31, r.expected_fcr31)
+			<< "acc=" << std::hex << r.acc << " fs=" << r.fs << " ft=" << r.ft
+			<< " op=" << std::dec << r.op;
+	}
+}

--- a/tests/ctest/core/recompilers/ee_rec_fpu_full_mode_tests.cpp
+++ b/tests/ctest/core/recompilers/ee_rec_fpu_full_mode_tests.cpp
@@ -1339,3 +1339,171 @@ TEST(EeRecFpuFull, MulDefectRandomisedDifferentialAgainstTheInterpreter)
 	EXPECT_GT(boundary_gap[3], 0)
 		<< "recMaddsub never reached the boundary-term class: the sweep is vacuous";
 }
+
+
+// ---------------------------------------------------------------------------
+// Residency of the predicate mask (d10, NEON_RESERVED_FPU_MULMASK).
+//
+// The mask is not materialized per multiply. It is parked once per JIT entry by
+// _DynGen_EnterRecompiledCode, which is what makes emitDefectiveFmul four
+// instructions instead of six -- see the comment on the constant in
+// iCore-arm64.h for the contract. These tests pin the two things that contract
+// rests on: that no C-call seam, VU dispatch or inline macro-mode emit destroys
+// the parked value, and that the allocator never hands q10 out.
+//
+// Both failures are silent -- no crash, no corrupt value, just a wrong rounding
+// decision on a fraction of multiplies -- and they fail in opposite directions,
+// which is why every test below checks both polarities:
+//
+//   mask zeroed        -> Cmtst never fires -> every product correctly rounded
+//                         (one ULP high wherever silicon is short)
+//   mask overwritten    -> Cmtst fires on operands it must not -> products one
+//     with a live value    ULP low where silicon is exact
+//
+// A test using only predicate-on operands sees the first and is blind to the
+// second, because a garbage mask with any of bits 0..9 set gives the same
+// answer as the correct mask on exactly those rows. That is not hypothetical:
+// removing q10 from _isReservedNEONreg makes the allocator home a guest FPR
+// there, and the observed break is the second kind, on the rows where ft's
+// mantissa is 0.
+//
+// The 1147-case hardware corpus cannot see any of this: its cases are single
+// ops, so every multiply in it is the first multiply after the entry that
+// parked the mask.
+namespace {
+// Two rows from kSiliconMulRows above, chosen as a matched pair on one pair of
+// registers -- f0 = 1.0, f1 = +FLT_MAX -- so a single block can ask the
+// question both ways just by swapping the operand order:
+//
+//   MUL_S(d, 0, 1)   ft = f1, mantissa 0x7fffff  -> predicate on,  0x7f7ffffe
+//   MUL_S(d, 1, 0)   ft = f0, mantissa 0         -> predicate off, 0x7f7fffff
+//
+// Both measured on an SCPH-90000; this is the non-commutativity of mul.s, which
+// is the sharpest available probe of the mask because the two answers differ by
+// exactly the decrement the mask controls.
+constexpr u32 kMaskFprOne    = 0x3f800000u; // f0 = 1.0
+constexpr u32 kMaskFprMax    = 0x7f7fffffu; // f1 = +FLT_MAX
+constexpr u32 kMaskOnWant    = 0x7f7ffffeu; // 1.0 * FLT_MAX: silicon is one ULP low
+constexpr u32 kMaskOffWant   = 0x7f7fffffu; // FLT_MAX * 1.0: silicon is exact
+
+// Seed f0/f1 and assert the matched pair in fd_on / fd_off, at both emit sites.
+void ExpectMaskLive(EeRecTestHarness& h, u32 fd_on, u32 fd_off, const char* where)
+{
+	EXPECT_EQ(h.GetFprBitsJit(fd_on), kMaskOnWant)
+		<< where << ": predicate did not fire -- the parked mask read as zero";
+	EXPECT_EQ(h.GetFprBitsJit(fd_off), kMaskOffWant)
+		<< where << ": predicate fired on ft mantissa 0 -- the parked mask holds garbage";
+}
+} // namespace
+
+// A VCALLMS in the middle of the block is both runtime hazards at once: it is a
+// real in-block C-call seam (the callee may clobber any caller-saved register),
+// and it dispatches a VU0 microprogram, whose blocks allocate NEON slots q0-q27
+// freely. d10 survives the first because AAPCS64 preserves the low 64 bits of
+// d8-d15, and the second because mVUdispatcherAB's prologue Stp/Ldp-saves
+// d8-d15 around the dispatch -- the same protection the s8/s9 clamp scalars get
+// (see the VE-04 note in microVU-arm64.cpp).
+//
+// A compile-time liveness flag in a caller-saved register would have had to
+// invalidate at this seam and re-materialize after it; this is the assertion
+// that the parked register needs no seam handling at all, at both emit sites.
+TEST(EeRecFpuFull, MulDefectMaskSurvivesAnInBlockCallSeam)
+{
+	EeRecTestHarness h;
+	h.EnableCop1();
+	h.EnableFpuFullMode();
+	h.EnableVu0Capture();
+	h.SeedVu0Vi(REG_VPU_STAT, 0);
+	// Trivial immediate-E micro: the VCALLMS is here purely as the seam.
+	h.SeedVu0Microprogram(0, {vu::EBitNopPair(), vu::NopPair()});
+	h.SetAccBits(0x00000000u);
+	h.SetFprBits(0, kMaskFprOne);
+	h.SetFprBits(1, kMaskFprMax);
+	h.LoadProgram({
+		MUL_S(2, 0, 1),
+		MUL_S(3, 1, 0),
+		VCALLMS(0),
+		MUL_S(4, 0, 1),  // recMULop, post-seam
+		MUL_S(5, 1, 0),
+		VCALLMS(0),
+		MADD_S(6, 0, 1), // recMaddsub's multiply stage, post-seam (ACC = +0)
+		MADD_S(7, 1, 0),
+	});
+	h.RunJitNoDiff();
+
+	ExpectMaskLive(h, 2, 3, "pre-seam MUL.S");
+	ExpectMaskLive(h, 4, 5, "post-seam MUL.S");
+	ExpectMaskLive(h, 6, 7, "post-seam MADD.S");
+	// Liveness: the two expectations above discriminate only because the two
+	// answers differ. If this ever fires the rows stopped being a matched pair
+	// and the test is vacuous whatever it reports.
+	ASSERT_NE(kMaskOnWant, kMaskOffWant);
+}
+
+// COP2 macro mode is the one context that emits mVU code inline in an EE block,
+// with no dispatcher save around it. It is safe for d10 for a structural reason
+// rather than an ABI one: macro emit is bounded to NEON slots 0-3 by
+// kMacroVFEvictHighWater, which mVUmacroEmitEpilogue asserts on every macro op.
+// That is why d10 needs no microVU pool gate, unlike SL-13's q25/q26 -- and
+// this is the end-to-end check on it, with two macro FMACs between the
+// multiplies to give the mVU allocator something to spend registers on.
+TEST(EeRecFpuFull, MulDefectMaskSurvivesInlineCop2MacroMode)
+{
+	EeRecTestHarness h;
+	h.EnableCop1();
+	h.EnableFpuFullMode();
+	h.EnableVu0Capture();
+	h.SeedVu0Vi(REG_VPU_STAT, 0);
+	h.SeedVu0Vf(1, 1.0f, 2.0f, 3.0f, 4.0f);
+	h.SeedVu0Vf(2, 5.0f, 6.0f, 7.0f, 8.0f);
+	h.SetFprBits(0, kMaskFprOne);
+	h.SetFprBits(1, kMaskFprMax);
+	h.LoadProgram({
+		MUL_S(2, 0, 1),
+		MUL_S(3, 1, 0),
+		VMUL_C2(0xf, 3, 1, 2),
+		VADD_C2(0xf, 4, 1, 2),
+		MUL_S(4, 0, 1), // post-macro
+		MUL_S(5, 1, 0),
+	});
+	h.RunJitNoDiff();
+
+	ExpectMaskLive(h, 2, 3, "pre-macro MUL.S");
+	ExpectMaskLive(h, 4, 5, "MUL.S after inline COP2 macro emit");
+	ASSERT_NE(kMaskOnWant, kMaskOffWant);
+}
+
+// The other half of the contract: nothing in EE codegen may be handed q10.
+// EeVu0Cop2ClampResidency.EeAllocatorReservesClampRegs pins the reservation at
+// the predicate; this pins it through the allocator, with enough simultaneously
+// live FP values to drive allocation into the callee-saved range where the mask
+// sits. That range is not a last resort -- the FPR class prefers it (GE-15,
+// _getFreeArm64NEONInRangeNoEvict(NEON_CALLEE_SAVED_START, ...)), so q10 is one
+// of the first homes an unreserved pool would reach for, not one of the last.
+TEST(EeRecFpuFull, MulDefectMaskSurvivesHeavyFprPressure)
+{
+	EeRecTestHarness h;
+	h.EnableCop1();
+	h.EnableFpuFullMode();
+	h.SetFprBits(0, kMaskFprOne);
+	h.SetFprBits(1, kMaskFprMax);
+
+	std::vector<u32> prog;
+	for (u32 r = 6; r < 22; r++)
+	{
+		h.SetFprBits(r, 0x3f800000u + r);
+		prog.push_back(ADD_S(r, r, 0)); // touch it: r = r + 1.0
+	}
+	prog.push_back(MUL_S(2, 0, 1));
+	prog.push_back(MUL_S(3, 1, 0));
+	for (u32 r = 6; r < 22; r++)
+		prog.push_back(ADD_S(r, r, 0)); // keep every one live past the multiplies
+	prog.push_back(MUL_S(4, 0, 1));
+	prog.push_back(MUL_S(5, 1, 0));
+	h.LoadProgram(prog);
+	h.RunJitNoDiff();
+
+	ExpectMaskLive(h, 2, 3, "MUL.S under FPR pressure");
+	ExpectMaskLive(h, 4, 5, "MUL.S after 16 live FPRs");
+	ASSERT_NE(kMaskOnWant, kMaskOffWant);
+}

--- a/tests/ctest/core/recompilers/ee_rec_fpu_full_mode_tests.cpp
+++ b/tests/ctest/core/recompilers/ee_rec_fpu_full_mode_tests.cpp
@@ -27,6 +27,8 @@
 
 #include "Config.h"
 
+#include <cfloat>
+#include <cmath>
 #include <cstring>
 #include <gtest/gtest.h>
 
@@ -808,77 +810,92 @@ void RunMaddRow(const MaddRow& r, u32* out_val, u32* out_fcr31)
 // exponent difference -- the only axis the guard mask reads -- is directly
 // controllable. The 72 rows span differences -23..+23, covering both the arm
 // that masks the product and the arm that masks the ACC.
+//
+// Expected values come from the interpreter, not from this emitter. fs = 1.0 is
+// a power of two, so every row's product has a zero tail and the multiplier
+// deficit reaches all 72 of them; when it landed in iFPUd, 35 rows moved one ULP
+// toward zero. Re-pinning them against the emitter that moved them would assert
+// nothing, so each value below was re-derived by running the same row through
+// FPU.cpp, which models the deficit independently (eeMulRound) -- 71 of 72 agree
+// exactly.
+//
+// The 72nd is row 53 (ft = 0x48b65815), and it is the documented cost of the
+// cheap Booth predicate: its mantissa 0x365815 has no bit of 0x2AA set, so only
+// the dropped boundary term fires. The interpreter returns 0xc8b65805, this
+// emitter 0xc8b65806. MulDefectDropsTheBoundaryTermTheInterpreterModels holds
+// that pair on its own, so closing the gap in iFPUd trips a test that names the
+// reason rather than silently re-pinning a number here.
 constexpr MaddRow kGuardMaskWitnesses[] = {
 	{0x3fb38acau, 0x3f800000u, 0xbacc0111u, 0, 0x3fb357cau, 0u},
-	{0x3ab20dd7u, 0x3f800000u, 0xc4195bd9u, 0, 0xc4195bc3u, 0u},
+	{0x3ab20dd7u, 0x3f800000u, 0xc4195bd9u, 0, 0xc4195bc2u, 0u},
 	{0xbe953636u, 0x3f800000u, 0x398a99a5u, 0, 0xbe951390u, 0u},
 	{0x33f55005u, 0x3f800000u, 0xac49b3b5u, 0, 0x33f54e72u, 0u},
-	{0x3b6825c7u, 0x3f800000u, 0xc2caa569u, 0, 0xc2caa399u, 0u},
+	{0x3b6825c7u, 0x3f800000u, 0xc2caa569u, 0, 0xc2caa398u, 0u},
 	{0x42c7b709u, 0x3f800000u, 0x3c50ef1au, 1, 0x42c7b082u, 0u},
 	{0xc481068au, 0x3f800000u, 0xc291ec04u, 1, 0xc46fcf94u, 0u},
-	{0x3924ba1bu, 0x3f800000u, 0xbc28556cu, 0, 0xbc25c284u, 0u},
-	{0xb5219112u, 0x3f800000u, 0x40c46022u, 0, 0x40c46021u, 0u},
-	{0xc36b6e95u, 0x3f800000u, 0xc42bd5ffu, 1, 0x43e1f4b4u, 0u},
+	{0x3924ba1bu, 0x3f800000u, 0xbc28556cu, 0, 0xbc25c283u, 0u},
+	{0xb5219112u, 0x3f800000u, 0x40c46022u, 0, 0x40c46020u, 0u},
+	{0xc36b6e95u, 0x3f800000u, 0xc42bd5ffu, 1, 0x43e1f4b2u, 0u},
 	{0xb29a5453u, 0x3f800000u, 0x29324d8au, 0, 0xb29a543du, 0u},
 	{0xbdc2a958u, 0x3f800000u, 0x329bcd66u, 0, 0xbdc2a956u, 0u},
 	{0xb35354cbu, 0x3f800000u, 0xa9db297eu, 1, 0xb35354b0u, 0u},
-	{0xc2074068u, 0x3f800000u, 0xca66524du, 1, 0x4a6651c6u, 0u},
+	{0xc2074068u, 0x3f800000u, 0xca66524du, 1, 0x4a6651c5u, 0u},
 	{0xbc0f2a31u, 0x3f800000u, 0x384f5a7cu, 0, 0xbc0e5ad7u, 0u},
 	{0xc3d2b83cu, 0x3f800000u, 0xced89810u, 1, 0x4ed8980du, 0u},
 	{0xb5af16b1u, 0x3f800000u, 0xafd2374cu, 1, 0xb5af098eu, 0u},
-	{0x3b2d84c4u, 0x3f800000u, 0xc106f1efu, 0, 0xc106e717u, 0u},
+	{0x3b2d84c4u, 0x3f800000u, 0xc106f1efu, 0, 0xc106e716u, 0u},
 	{0x35f587a4u, 0x3f800000u, 0xb4cf4ba1u, 0, 0x35c1b4bcu, 0u},
-	{0x41f0dbb2u, 0x3f800000u, 0xc8e14376u, 0, 0xc8e13fb3u, 0u},
+	{0x41f0dbb2u, 0x3f800000u, 0xc8e14376u, 0, 0xc8e13fb2u, 0u},
 	{0xb362649cu, 0x3f800000u, 0xa9f35cf9u, 1, 0xb362647eu, 0u},
-	{0xb2fa917bu, 0x3f800000u, 0x39d9d803u, 0, 0x39d9d419u, 0u},
+	{0xb2fa917bu, 0x3f800000u, 0x39d9d803u, 0, 0x39d9d418u, 0u},
 	{0x370518f8u, 0x3f800000u, 0x334e4a63u, 1, 0x37044aaeu, 0u},
-	{0xc11469c2u, 0x3f800000u, 0x462a42d6u, 0, 0x462a1dbcu, 0u},
-	{0x3649cec6u, 0x3f800000u, 0xbf2b2cabu, 0, 0xbf2b2c79u, 0u},
+	{0xc11469c2u, 0x3f800000u, 0x462a42d6u, 0, 0x462a1dbbu, 0u},
+	{0x3649cec6u, 0x3f800000u, 0xbf2b2cabu, 0, 0xbf2b2c78u, 0u},
 	{0xb9e9f9d2u, 0x3f800000u, 0xb833060bu, 1, 0xb9d39911u, 0u},
 	{0x32ea9db1u, 0x3f800000u, 0xadb7adb2u, 0, 0x32ea6fc6u, 0u},
 	{0x3fbcf544u, 0x3f800000u, 0xbc85569au, 0, 0x3fbadfeau, 0u},
-	{0xbaa0f0b0u, 0x3f800000u, 0x3f761279u, 0, 0x3f75c201u, 0u},
+	{0xbaa0f0b0u, 0x3f800000u, 0x3f761279u, 0, 0x3f75c200u, 0u},
 	{0x3be79b92u, 0x3f800000u, 0xb6c52501u, 0, 0x3be76a49u, 0u},
 	{0x32dce714u, 0x3f800000u, 0x2869f708u, 1, 0x32dce70du, 0u},
-	{0xbb7b2e3au, 0x3f800000u, 0x42b93816u, 0, 0x42b93620u, 0u},
-	{0x3baf0f6cu, 0x3f800000u, 0xbff04b54u, 0, 0xbfef9c45u, 0u},
-	{0xbab47c74u, 0x3f800000u, 0x448b789fu, 0, 0x448b7894u, 0u},
-	{0xc3de412bu, 0x3f800000u, 0x4579985cu, 0, 0x455dd037u, 0u},
+	{0xbb7b2e3au, 0x3f800000u, 0x42b93816u, 0, 0x42b9361fu, 0u},
+	{0x3baf0f6cu, 0x3f800000u, 0xbff04b54u, 0, 0xbfef9c44u, 0u},
+	{0xbab47c74u, 0x3f800000u, 0x448b789fu, 0, 0x448b7893u, 0u},
+	{0xc3de412bu, 0x3f800000u, 0x4579985cu, 0, 0x455dd036u, 0u},
 	{0xb2fa7f73u, 0x3f800000u, 0xa912c471u, 1, 0xb2fa7f61u, 0u},
 	{0x4260d9d0u, 0x3f800000u, 0xb9d4bf54u, 0, 0x4260d966u, 0u},
-	{0x3292dea1u, 0x3f800000u, 0xbdaacd0bu, 0, 0xbdaacd09u, 0u},
-	{0x3c6a6437u, 0x3f800000u, 0x3e339b27u, 1, 0xbe24f4e4u, 0u},
-	{0xc1306401u, 0x3f800000u, 0x492f0ebdu, 0, 0x492f0e0du, 0u},
+	{0x3292dea1u, 0x3f800000u, 0xbdaacd0bu, 0, 0xbdaacd08u, 0u},
+	{0x3c6a6437u, 0x3f800000u, 0x3e339b27u, 1, 0xbe24f4e3u, 0u},
+	{0xc1306401u, 0x3f800000u, 0x492f0ebdu, 0, 0x492f0e0cu, 0u},
 	{0x3635b3f4u, 0x3f800000u, 0x343227f4u, 1, 0x362a9175u, 0u},
-	{0xb400e647u, 0x3f800000u, 0x3cb12651u, 0, 0x3cb12611u, 0u},
-	{0x39907517u, 0x3f800000u, 0xbba223b7u, 0, 0xbb991c66u, 0u},
-	{0x330ea9edu, 0x3f800000u, 0xbae904eau, 0, 0xbae903cdu, 0u},
-	{0xbf6ee4e6u, 0x3f800000u, 0xc1054588u, 1, 0x40ecae74u, 0u},
-	{0xc405bbb4u, 0x3f800000u, 0x4627619cu, 0, 0x461f05e1u, 0u},
-	{0xb7fa0949u, 0x3f800000u, 0xb8ab876du, 1, 0x385a0a36u, 0u},
+	{0xb400e647u, 0x3f800000u, 0x3cb12651u, 0, 0x3cb12610u, 0u},
+	{0x39907517u, 0x3f800000u, 0xbba223b7u, 0, 0xbb991c65u, 0u},
+	{0x330ea9edu, 0x3f800000u, 0xbae904eau, 0, 0xbae903ccu, 0u},
+	{0xbf6ee4e6u, 0x3f800000u, 0xc1054588u, 1, 0x40ecae72u, 0u},
+	{0xc405bbb4u, 0x3f800000u, 0x4627619cu, 0, 0x461f05e0u, 0u},
+	{0xb7fa0949u, 0x3f800000u, 0xb8ab876du, 1, 0x385a0a34u, 0u},
 	{0x3b48dad0u, 0x3f800000u, 0xb60bbdb1u, 0, 0x3b48b7e1u, 0u},
-	{0x418eac80u, 0x3f800000u, 0x4a25b350u, 1, 0xca25b309u, 0u},
+	{0x418eac80u, 0x3f800000u, 0x4a25b350u, 1, 0xca25b308u, 0u},
 	{0x35935179u, 0x3f800000u, 0xb3508e2fu, 0, 0x358ccd08u, 0u},
-	{0x452ecb68u, 0x3f800000u, 0xc914f502u, 0, 0xc9144637u, 0u},
-	{0x3ef73c56u, 0x3f800000u, 0x48b65815u, 1, 0xc8b65806u, 0u},
+	{0x452ecb68u, 0x3f800000u, 0xc914f502u, 0, 0xc9144636u, 0u},
+	{0x3ef73c56u, 0x3f800000u, 0x48b65815u, 1, 0xc8b65806u, 0u},  // boundary term: interp says c8b65805
 	{0x3ec3ca47u, 0x3f800000u, 0x33267262u, 1, 0x3ec3ca46u, 0u},
 	{0x332a2e5bu, 0x3f800000u, 0xaa055622u, 0, 0x332a2e3au, 0u},
-	{0x45855769u, 0x3f800000u, 0xc6cac295u, 0, 0xc6a96cbbu, 0u},
+	{0x45855769u, 0x3f800000u, 0xc6cac295u, 0, 0xc6a96cbau, 0u},
 	{0x45393be5u, 0x3f800000u, 0x4266ee5au, 1, 0x4535a02cu, 0u},
 	{0xb5a78404u, 0x3f800000u, 0xaf843707u, 1, 0xb5a77bc1u, 0u},
 	{0x4324653fu, 0x3f800000u, 0xbddf42d3u, 0, 0x43244957u, 0u},
-	{0xc494cb38u, 0x3f800000u, 0xcff0bf3du, 1, 0x4ff0bf3bu, 0u},
-	{0xb95aee1bu, 0x3f800000u, 0x3a201cdau, 0, 0x39d2c2a7u, 0u},
-	{0x42cc503du, 0x3f800000u, 0x463f3294u, 1, 0xc63d99f4u, 0u},
-	{0xb9bd2a07u, 0x3f800000u, 0x451ddb2eu, 0, 0x451ddb2du, 0u},
-	{0xc2cfc0efu, 0x3f800000u, 0xc5730a69u, 1, 0x456c8c62u, 0u},
+	{0xc494cb38u, 0x3f800000u, 0xcff0bf3du, 1, 0x4ff0bf3au, 0u},
+	{0xb95aee1bu, 0x3f800000u, 0x3a201cdau, 0, 0x39d2c2a5u, 0u},
+	{0x42cc503du, 0x3f800000u, 0x463f3294u, 1, 0xc63d99f3u, 0u},
+	{0xb9bd2a07u, 0x3f800000u, 0x451ddb2eu, 0, 0x451ddb2cu, 0u},
+	{0xc2cfc0efu, 0x3f800000u, 0xc5730a69u, 1, 0x456c8c61u, 0u},
 	{0xbaaeb833u, 0x3f800000u, 0x3563ab35u, 0, 0xbaae9bbeu, 0u},
 	{0xb556d230u, 0x3f800000u, 0xa9b57d1cu, 1, 0xb556d22fu, 0u},
 	{0xbfe9553bu, 0x3f800000u, 0x34dcabf8u, 0, 0xbfe95538u, 0u},
-	{0x3a2ce961u, 0x3f800000u, 0x4585376eu, 1, 0xc585376du, 0u},
+	{0x3a2ce961u, 0x3f800000u, 0x4585376eu, 1, 0xc585376cu, 0u},
 	{0xc058aa2eu, 0x3f800000u, 0x38a9a118u, 0, 0xc058a8dbu, 0u},
 	{0x3daca0f3u, 0x3f800000u, 0x33a45aa6u, 1, 0x3daca0e9u, 0u},
-	{0x45f4ede4u, 0x3f800000u, 0xc7fb950bu, 0, 0xc7ec462du, 0u},
+	{0x45f4ede4u, 0x3f800000u, 0xc7fb950bu, 0, 0xc7ec462cu, 0u},
 	{0xbcfcd10eu, 0x3f800000u, 0x3560a544u, 0, 0xbcfccf4du, 0u},
 	{0xc2b750c8u, 0x3f800000u, 0xb7943082u, 1, 0xc2b750c6u, 0u},
 };
@@ -953,4 +970,372 @@ TEST(EeRecFpuFull, MaddWideRoundArms)
 			<< "acc=" << std::hex << r.acc << " fs=" << r.fs << " ft=" << r.ft
 			<< " op=" << std::dec << r.op;
 	}
+}
+
+
+// ---------------------------------------------------------------------------
+// The EE multiplier's one-ULP deficit, in mode 3.
+//
+// The console's multiply array is not correctly rounding: when the exact
+// product has nothing below the single's ULP to absorb it, the result comes
+// back exactly one step closer to zero -- and whether it does is decided by
+// ft's mantissa alone, so mul.s is not commutative. Measured exhaustively on
+// SCPH-90000 (captures/fpmul/): mul.s(1.0, x) is one ULP low for 8257536 of the
+// 2^23 significands, mul.s(x, 1.0) is exact for all of them, and nothing ever
+// came back high or two ULPs low in 16.8M probes.
+//
+// FpuMulHack is a one-point sample of this rule, which is why it compares fs
+// and ft against their own constants and so does not fire with the operands
+// reversed -- exactly what silicon does. iFPUd never had the gamefix; it has
+// the general law instead, which subsumes it (the QTR/PIO2 row below is the
+// gamefix's pair, reached with the gamefix off).
+//
+// The interpreter models the same law in FPU.cpp; these rows are the mode-3
+// codegen of it, at both multiply sites -- recMULop for MUL/MULA and
+// recMaddsub's multiply stage for MADD/MSUB/MADDA/MSUBA, which round through
+// different helpers (ToPS2FPU_Full vs ToPS2FPU_Wide) and so are two separate
+// narrowings of the same decrement.
+namespace {
+struct MulRow { const char* name; u32 fs, ft, want; };
+
+// Every `want` below was measured on an SCPH-90000, FCR0 0x2e40.
+constexpr MulRow kSiliconMulRows[] = {
+	{"1.0 * FLT_MAX",            0x3f800000u, 0x7f7fffffu, 0x7f7ffffeu}, // one ULP low
+	{"FLT_MAX * 1.0 (reversed)", 0x7f7fffffu, 0x3f800000u, 0x7f7fffffu}, // exact: ft mantissa 0
+	{"2.0 * FLT_MAX",            0x40000000u, 0x7f7fffffu, 0x7ffffffeu}, // corpus case 857
+	{"FLT_MAX * 2.0 (reversed)", 0x7f7fffffu, 0x40000000u, 0x7fffffffu}, // corpus case 1
+	{"ft mantissa 0x400000",     0x3f800000u, 0x3fc00000u, 0x3fc00000u}, // exact
+	{"ft mantissa 0x000001",     0x3f800000u, 0x3f800001u, 0x3f800001u}, // exact
+	{"ft mantissa 0x3fffff",     0x3f800000u, 0x3fbfffffu, 0x3fbffffeu}, // low
+	{"2^-126 * pseudo-inf",      0x00800000u, 0x7f800001u, 0x40800001u}, // corpus case 876
+	{"QTR * PIO2 (FpuMulHack)",  0x3e800000u, 0x40490fdbu, 0x3f490fdau},
+	{"PIO2 * QTR (reversed)",    0x40490fdbu, 0x3e800000u, 0x3f490fdbu},
+};
+} // namespace
+
+TEST(EeRecFpuFull, MulDefectMatchesSiliconInRecMulop)
+{
+	for (const MulRow& r : kSiliconMulRows)
+	{
+		EeRecTestHarness h;
+		h.EnableCop1();
+		h.EnableFpuFullMode();
+		h.SetFprBits(0, r.fs);
+		h.SetFprBits(1, r.ft);
+		h.LoadProgram({MUL_S(2, 0, 1)});
+		h.RunJitNoDiff();
+		EXPECT_EQ(h.GetFprBitsJit(2), r.want) << "MUL.S " << r.name;
+
+		EeRecTestHarness ha;
+		ha.EnableCop1();
+		ha.EnableFpuFullMode();
+		ha.SetFprBits(0, r.fs);
+		ha.SetFprBits(1, r.ft);
+		ha.LoadProgram({MULA_S(0, 1)});
+		ha.RunJitNoDiff();
+		EXPECT_EQ(ha.GetAccBitsJit(), r.want) << "MULA.S " << r.name;
+	}
+}
+
+TEST(EeRecFpuFull, MulDefectMatchesSiliconInRecMaddsub)
+{
+	// ACC = +0 so the accumulate is a no-op on the product's bits: the guard
+	// mask reduces a zero operand to its sign and the add leaves the other
+	// operand alone, so what lands in fd is the rounded product and nothing
+	// else. That is what makes this a test of the multiply stage.
+	for (const MulRow& r : kSiliconMulRows)
+	{
+		const u32 neg = r.want ^ 0x80000000u;
+		struct { u32 word; bool is_acc; u32 want; const char* op; } forms[] = {
+			{MADD_S(2, 0, 1),  false, r.want, "MADD.S "},
+			{MSUB_S(2, 0, 1),  false, neg,    "MSUB.S "},
+			{MADDA_S(0, 1),    true,  r.want, "MADDA.S "},
+			{MSUBA_S(0, 1),    true,  neg,    "MSUBA.S "},
+		};
+		for (const auto& f : forms)
+		{
+			EeRecTestHarness h;
+			h.EnableCop1();
+			h.EnableFpuFullMode();
+			h.SetAccBits(0x00000000u);
+			h.SetFprBits(0, r.fs);
+			h.SetFprBits(1, r.ft);
+			h.LoadProgram({f.word});
+			h.RunJitNoDiff();
+			const u32 got = f.is_acc ? h.GetAccBitsJit() : h.GetFprBitsJit(2);
+			EXPECT_EQ(got, f.want) << f.op << r.name;
+		}
+	}
+}
+
+// The tail test is performed by the rounding, not by an integer tail extract:
+// the emitter decrements the double product's bit pattern unconditionally once
+// the predicate fires, and one double ULP is strictly below one single ULP, so
+// only a product that was exactly representable moves. These rows are the two
+// sides of that -- same ft (predicate on for both), fs chosen so the product's
+// tail is zero in one row and non-zero in the next. If the decrement ever
+// reached a non-zero-tail product it would show up here as an off-by-one.
+TEST(EeRecFpuFull, MulDefectOnlyReachesProductsWithAZeroTail)
+{
+	struct Row { const char* name; u32 fs, ft, want; };
+	static const Row kRows[] = {
+		// ft = 0x3fbfffff (mantissa 0x3fffff, predicate on).
+		{"fs = 2^0,  tail 0",   0x3f800000u, 0x3fbfffffu, 0x3fbffffeu},
+		{"fs = 2^-4, tail 0",   0x3d800000u, 0x3fbfffffu, 0x3dbffffeu},
+		{"fs = 1+2^-23, tail!=0", 0x3f800001u, 0x3fbfffffu, 0x3fc00000u},
+		{"fs = 3.0,  tail!=0",  0x40400000u, 0x3fbfffffu, 0x408fffffu},
+	};
+	for (const Row& r : kRows)
+	{
+		EeRecTestHarness h;
+		h.EnableCop1();
+		h.EnableFpuFullMode();
+		h.SetFprBits(0, r.fs);
+		h.SetFprBits(1, r.ft);
+		h.LoadProgram({MUL_S(2, 0, 1)});
+		h.RunJitNoDiff();
+		EXPECT_EQ(h.GetFprBitsJit(2), r.want) << r.name;
+	}
+}
+
+// A zero product must never be decremented. Under FZ a zero or denormal operand
+// widens to +/-0, the product is exactly +/-0, and 0x0000000000000000 - 1 is
+// 0xFFFFFFFFFFFFFFFF -- a NaN, which would then narrow to garbage. The Fcmeq
+// against the product is the guard, and it covers the interpreter's "zero
+// operand" and "flushed result" cases at once, because a product of two EE
+// normals is at least ~2^-252 and so is never exactly zero.
+//
+// The ft values here all have the Booth predicate set, so the guard is the only
+// thing standing between these rows and a NaN.
+//
+// Liveness: unlike the rest of this block this test also passed before the
+// deficit landed -- nothing decremented, so nothing could corrupt a zero -- so
+// its bidirectional witness is the guard, not the feature. Deleting the
+// Fcmeq/Bic pair from emitDefectiveFmul and rebuilding was checked to fail it:
+// +0 comes back 0xFFFFFFFF and -0 comes back 0x7FFFFFFF, which is the NaN
+// narrowing this pins.
+TEST(EeRecFpuFull, MulDefectNeverDecrementsAZeroProduct)
+{
+	struct Row { const char* name; u32 fs, ft, want; };
+	static const Row kRows[] = {
+		{"+0 * predicate-on",       0x00000000u, 0x3fbfffffu, 0x00000000u},
+		{"-0 * predicate-on",       0x80000000u, 0x3fbfffffu, 0x80000000u},
+		{"predicate-on * +0",       0x3fbfffffu, 0x00000000u, 0x00000000u},
+		{"denormal ft (flushed)",   0x3f800000u, 0x000002aau, 0x00000000u},
+		{"denormal fs (flushed)",   0x000002aau, 0x3fbfffffu, 0x00000000u},
+		{"underflow to zero",       0x00800000u, 0x00bfffffu, 0x00000000u},
+	};
+	for (const Row& r : kRows)
+	{
+		EeRecTestHarness h;
+		h.EnableCop1();
+		h.EnableFpuFullMode();
+		h.SetFprBits(0, r.fs);
+		h.SetFprBits(1, r.ft);
+		h.LoadProgram({MUL_S(2, 0, 1)});
+		h.RunJitNoDiff();
+		EXPECT_EQ(h.GetFprBitsJit(2), r.want) << r.name;
+	}
+}
+
+
+
+// ---------------------------------------------------------------------------
+// The one thing this emitter knowingly does not model, held on its own so that
+// closing it trips a test that says why.
+//
+// The measured predicate has two terms: the Booth term `mant & 0x2AA` (bits
+// 1,3,5,7,9 -- the sign bits of the five lowest radix-4 Booth digits) and a
+// boundary term at the truncation column,
+// `bit11 != (8 <= (mant >> 12 & 0xF) <= 13)`. iFPUd emits only the first: the
+// second needs a bitfield extract NEON does not have, about eight more
+// instructions on every multiply, and it can only change the answer where the
+// product's tail is already zero.
+//
+// ft = 0x48b65815 is a witness. Its mantissa 0x365815 has no bit of 0x2AA set,
+// bit 11 is 1, and (0x365815 >> 12) & 0xF is 5, so the boundary term is the
+// only one that fires. The interpreter (FPU.cpp eeMulDefectiveFt) models both
+// and returns the decremented product; iFPUd returns the IEEE one.
+//
+// If iFPUd ever grows the boundary term, this test fails and the fix is to
+// delete it -- along with the carve-out in kGuardMaskWitnesses row 53.
+TEST(EeRecFpuFull, MulDefectDropsTheBoundaryTermTheInterpreterModels)
+{
+	constexpr u32 kFs = 0x3f800000u; // 1.0: the product is ft, tail always zero
+	constexpr u32 kFt = 0x48b65815u;
+
+	EeRecTestHarness hi;
+	hi.EnableCop1();
+	hi.SetFprBits(0, kFs);
+	hi.SetFprBits(1, kFt);
+	hi.LoadProgram({MUL_S(2, 0, 1)});
+	hi.RunInterpOnly();
+	EXPECT_EQ(hi.GetFprBitsInterp(2), 0x48b65814u) << "interp models the boundary term";
+
+	EeRecTestHarness h;
+	h.EnableCop1();
+	h.EnableFpuFullMode();
+	h.SetFprBits(0, kFs);
+	h.SetFprBits(1, kFt);
+	h.LoadProgram({MUL_S(2, 0, 1)});
+	h.RunJitNoDiff();
+	EXPECT_EQ(h.GetFprBitsJit(2), 0x48b65815u) << "iFPUd drops it: one ULP high";
+
+	// The Booth term alone, for contrast: same shape, and here they agree.
+	EeRecTestHarness hb;
+	hb.EnableCop1();
+	hb.EnableFpuFullMode();
+	hb.SetFprBits(0, kFs);
+	hb.SetFprBits(1, 0x48b65a15u); // mantissa 0x365a15: 0x2AA hits bit 9
+	hb.LoadProgram({MUL_S(2, 0, 1)});
+	hb.RunJitNoDiff();
+	EXPECT_EQ(hb.GetFprBitsJit(2), 0x48b65a14u);
+}
+
+// ---------------------------------------------------------------------------
+// Randomised differential: mode 3 against the interpreter, which models the
+// same multiply law independently and in completely different code (FPU.cpp
+// eeMulProduct, an integer tail test on the 48-bit significand product; iFPUd
+// lets the narrowing perform the tail test on a double). Agreement across a
+// wide operand space is what says the emitter implements the law rather than
+// the handful of rows above.
+//
+// Dimensions varied and crossed: six operand classes on each side (arbitrary
+// words, random normals, powers of two -- which force a zero tail and so make
+// the predicate decide every row, the top binade where exp == 0xff is an
+// ordinary EE number, the minimum-normal binade, and denormal/zero), operand
+// order (the law is not commutative, and both sides draw from the same classes),
+// register aliasing (fd == fs and fd == ft), and both emit sites (recMULop and
+// recMaddsub's multiply stage, reached with ACC = +0 so the accumulate is a
+// no-op on the product's bits).
+//
+// Three divergences are licensed, and each is counted so the sweep cannot pass
+// by never reaching them:
+//
+//   1. the boundary term iFPUd drops, one ULP further from zero;
+//   2. an operand in the exponent-0xff binade. fpuDouble() clamps it to
+//      +/-Fmax before multiplying, so the two engines multiply different
+//      numbers and the row says nothing about the multiplier;
+//   3. a product above FLT_MAX. The interpreter saturates there, mode 3 at the
+//      EE's own 0x7FFFFFFF, a whole binade higher.
+//
+// 2 and 3 are the same pre-existing gap seen from two sides: this branch's
+// interpreter has no exponent-0xff binade at all. They are recognised from the
+// operands and the exact product, never from the results, so a wrong result
+// cannot license itself. Anything else -- a wrong predicate, a decrement
+// escaping into a non-zero tail, a zero product turned into a NaN -- fails.
+TEST(EeRecFpuFull, MulDefectRandomisedDifferentialAgainstTheInterpreter)
+{
+	auto splitmix = [](u64& state) {
+		u64 z = (state += 0x9E3779B97F4A7C15ull);
+		z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ull;
+		z = (z ^ (z >> 27)) * 0x94D049BB133111EBull;
+		return z ^ (z >> 31);
+	};
+	auto pick = [&splitmix](u64& state, int cls) -> u32 {
+		const u64 r = splitmix(state);
+		const u32 sign = (r >> 63) ? 0x80000000u : 0u;
+		const u32 mant = static_cast<u32>(r) & 0x7FFFFFu;
+		switch (cls)
+		{
+			case 0: return static_cast<u32>(r);                                    // anything
+			case 1: return sign | ((static_cast<u32>(r >> 32) % 254u + 1u) << 23) | mant; // normal
+			case 2: return sign | ((static_cast<u32>(r >> 32) % 254u + 1u) << 23); // power of two
+			case 3: return sign | 0x7f800000u | mant;                              // top binade
+			case 4: return sign | (1u << 23) | mant;                               // min normal
+			default: return sign | mant;                                           // denormal/zero
+		}
+	};
+	// Both terms of the measured predicate, so a divergence can be classified
+	// rather than merely counted.
+	auto booth = [](u32 ft) { return (ft & 0x2AAu) != 0; };
+	auto full = [](u32 ft) {
+		const u32 m = ft & 0x7FFFFFu;
+		if (m & 0x2AAu)
+			return true;
+		const u32 h = (m >> 12) & 0xFu;
+		return ((m >> 11) & 1u) != ((h >= 8u && h <= 13u) ? 1u : 0u);
+	};
+
+	// The two engine gaps this branch has outside the multiplier, both decided
+	// from the inputs alone. fpuDouble() clamps an exponent-0xff operand to
+	// +/-Fmax, and the interpreter's product saturates at FLT_MAX where mode 3
+	// goes on to 0x7FFFFFFF; either way the row is not about the multiply array.
+	auto clamped = [](u32 x) { return (x & 0x7F800000u) == 0x7F800000u; };
+	auto overflows = [](u32 fs, u32 ft) {
+		auto val = [](u32 x) {
+			if ((x & 0x7F800000u) == 0) x &= 0x80000000u;              // fpuDouble
+			else if ((x & 0x7F800000u) == 0x7F800000u) x = (x & 0x80000000u) | 0x7F7FFFFFu;
+			float f;
+			std::memcpy(&f, &x, sizeof(f));
+			return static_cast<double>(f);
+		};
+		return !(std::fabs(val(fs) * val(ft)) <= FLT_MAX);
+	};
+
+	u64 state = 0x1234567890ABCDEFull;
+	int rows = 0, boundary_gap[4] = {0, 0, 0, 0};
+	int clamp_gap = 0, saturation_gap = 0;
+	for (int i = 0; i < 40000; i++)
+	{
+		const int cs = static_cast<int>(splitmix(state) % 6);
+		const int ct = static_cast<int>(splitmix(state) % 6);
+		const u32 fs = pick(state, cs), ft = pick(state, ct);
+
+		const int form = i % 4;
+		u32 word = 0;
+		int dst = 2;
+		switch (form)
+		{
+			case 0: word = MUL_S(2, 0, 1); dst = 2; break;   // recMULop, distinct fd
+			case 1: word = MUL_S(0, 0, 1); dst = 0; break;   // recMULop, fd == fs
+			case 2: word = MUL_S(1, 0, 1); dst = 1; break;   // recMULop, fd == ft
+			default: word = MADD_S(2, 0, 1); dst = 2; break; // recMaddsub multiply stage
+		}
+
+		EeRecTestHarness h;
+		h.EnableCop1();
+		h.EnableFpuFullMode();
+		h.SetAccBits(0);
+		h.SetFprBits(0, fs);
+		h.SetFprBits(1, ft);
+		h.LoadProgram({word});
+		h.RunJitNoDiff();
+		const u32 jit = h.GetFprBitsJit(dst);
+
+		EeRecTestHarness hi;
+		hi.EnableCop1();
+		hi.SetAccBits(0);
+		hi.SetFprBits(0, fs);
+		hi.SetFprBits(1, ft);
+		hi.LoadProgram({word});
+		hi.RunInterpOnly();
+		const u32 interp = hi.GetFprBitsInterp(dst);
+
+		rows++;
+		if (jit == interp)
+			continue;
+
+		if (clamped(fs) || clamped(ft)) { clamp_gap++; continue; }
+		if (overflows(fs, ft)) { saturation_gap++; continue; }
+
+		const bool boundary_only = !booth(ft) && full(ft);
+		ASSERT_TRUE(boundary_only && jit == interp + 1u)
+			<< "unlicensed divergence: form=" << form << " cs=" << cs << " ct=" << ct
+			<< std::hex << " fs=" << fs << " ft=" << ft
+			<< " jit=" << jit << " interp=" << interp;
+		boundary_gap[form]++;
+	}
+
+	EXPECT_EQ(rows, 40000);
+	// Liveness. "No unlicensed divergence" is also what a harness that never
+	// reached the emitter would report, so each licensed one must actually be
+	// observed -- the boundary term at both emit sites, since they narrow
+	// through different code.
+	EXPECT_GT(clamp_gap, 0) << "no exponent-0xff operand reached the sweep";
+	EXPECT_GT(saturation_gap, 0) << "no product overflowed FLT_MAX in the sweep";
+	EXPECT_GT(boundary_gap[0] + boundary_gap[1] + boundary_gap[2], 0)
+		<< "recMULop never reached the boundary-term class: the sweep is vacuous";
+	EXPECT_GT(boundary_gap[3], 0)
+		<< "recMaddsub never reached the boundary-term class: the sweep is vacuous";
 }

--- a/tests/ctest/core/recompilers/ee_rec_fpu_tests.cpp
+++ b/tests/ctest/core/recompilers/ee_rec_fpu_tests.cpp
@@ -1352,17 +1352,118 @@ TEST(EeRecFpu, MulSFpuMulHackPatchesMagicProduct)
 	EXPECT_EQ(h.GetFprBitsJit(2), 0x3f490fdau);
 }
 
-TEST(EeRecFpu, MulSFpuMulHackOffGivesNativeProduct)
+TEST(EeRecFpu, MulSFpuMulHackOffStillReachesTheConsoleValueOnInterp)
 {
-	// Gamefix off (default): the same operands produce the ordinary product,
-	// which JIT and interp agree on (Run diff), and which is NOT the patch value.
-	EeRecTestHarness h;
-	h.EnableCop1();
-	h.SetFprBits(0, 0x3e800000u);
-	h.SetFprBits(1, 0x40490fdbu);
-	h.LoadProgram({ee::MUL_S(2, 0, 1)});
-	h.Run();
-	EXPECT_NE(h.GetFprBitsJit(2), 0x3f490fdau);
+	// This test used to assert the opposite -- that with the gamefix off the
+	// "ordinary" product comes out, and that JIT and interp agree on it. Its
+	// premise was that the IEEE product is the console's. It is not.
+	//
+	// Measured on SCPH-90000 (captures/fpmul/): mul.s of 0x3E800000 by
+	// 0x40490FDB returns 0x3F490FDA, and the same two words in the reverse
+	// operand order return 0x3F490FDB. FpuMulHack is a one-point sample of the
+	// multiplier's own one-ULP deficit, not a game kludge -- which is why it
+	// compares fs and ft against their own constants and so does not fire
+	// reversed, exactly as the console behaves.
+	//
+	// The interpreter models the deficit itself (eeMulProduct in FPU.cpp), so it
+	// lands on the console value with the gamefix off. The single-precision fast
+	// path does not, so the two legitimately diverge here and this cannot be a
+	// Run() diff -- and RunJitNoDiff() never runs the interpreter at all, so
+	// each engine needs its own harness.
+	EeRecTestHarness hi;
+	hi.EnableCop1();
+	hi.SetFprBits(0, 0x3e800000u);
+	hi.SetFprBits(1, 0x40490fdbu);
+	hi.LoadProgram({ee::MUL_S(2, 0, 1)});
+	hi.RunInterpOnly();
+	EXPECT_EQ(hi.GetFprBitsInterp(2), 0x3f490fdau) << "interp should reach silicon unaided";
+
+	// Reversed: the console returns the un-decremented product, because the
+	// predicate reads ft alone. This is the half that pins it as an operand
+	// order effect rather than a constant fudge.
+	EeRecTestHarness hr;
+	hr.EnableCop1();
+	hr.SetFprBits(0, 0x40490fdbu);
+	hr.SetFprBits(1, 0x3e800000u);
+	hr.LoadProgram({ee::MUL_S(2, 0, 1)});
+	hr.RunInterpOnly();
+	EXPECT_EQ(hr.GetFprBitsInterp(2), 0x3f490fdbu) << "reversed operands: no deficit";
+
+	// The fast path, gamefix off, still produces the IEEE product. Recorded so
+	// the divergence is pinned rather than discovered later as a surprise.
+	EeRecTestHarness hj;
+	hj.EnableCop1();
+	hj.SetFprBits(0, 0x3e800000u);
+	hj.SetFprBits(1, 0x40490fdbu);
+	hj.LoadProgram({ee::MUL_S(2, 0, 1)});
+	hj.RunJitNoDiff();
+	EXPECT_EQ(hj.GetFprBitsJit(2), 0x3f490fdbu);
+}
+
+TEST(EeRecFpu, MulSMultiplierDeficitMatchesSilicon)
+{
+	// Rows measured directly on SCPH-90000. Each is a case where the exact
+	// product is representable with nothing below the ULP, so the sub-ULP
+	// deficit reaches the result.
+	//
+	// Every row's operands and product stay inside the IEEE single range on
+	// purpose. The interpreter multiplies fpuDouble()'d floats, so it cannot
+	// carry a row whose operand or product needs the EE's exponent-0xff binade
+	// -- 2.0 * FLT_MAX (corpus cases 857/1) lands on 0x7FFFFFFF on silicon and
+	// on +Inf here. That gap belongs to fpuDouble, not to the multiplier.
+	struct Row { u32 fs, ft, want; };
+	static const Row rows[] = {
+		{0x3f800000u, 0x7f7fffffu, 0x7f7ffffeu}, // 1.0 * FLT_MAX  -> one ULP low
+		{0x7f7fffffu, 0x3f800000u, 0x7f7fffffu}, // reversed       -> exact
+		{0x3f800000u, 0x3fc00000u, 0x3fc00000u}, // ft mantissa 0x400000: exact
+		{0x3f800000u, 0x3f800001u, 0x3f800001u}, // ft mantissa 0x000001: exact
+		{0x3f800000u, 0x3fbfffffu, 0x3fbffffeu}, // ft mantissa 0x3fffff: low
+		{0x3e800000u, 0x40490fdbu, 0x3f490fdau}, // the FpuMulHack pair
+		{0x40490fdbu, 0x3e800000u, 0x3f490fdbu}, // reversed       -> exact
+	};
+	for (const Row& r : rows)
+	{
+		EeRecTestHarness h;
+		h.EnableCop1();
+		h.SetFprBits(0, r.fs);
+		h.SetFprBits(1, r.ft);
+		h.LoadProgram({ee::MUL_S(2, 0, 1)});
+		h.RunInterpOnly();
+		EXPECT_EQ(h.GetFprBitsInterp(2), r.want)
+			<< "mul.s fs=" << std::hex << r.fs << " ft=" << r.ft;
+	}
+}
+
+TEST(EeRecFpu, MultiplierDeficitReachesTheWholeMultiplyFamily)
+{
+	// MUL/MULA and the four multiply-accumulates all route their product
+	// through eeMulProduct. ACC = +0 (or the MADD/MSUB accumuland) so what
+	// lands in the destination is the rounded product alone.
+	constexpr u32 kFs = 0x3f800000u; // 1.0: the product is ft, tail always zero
+	constexpr u32 kFt = 0x3fbfffffu; // Booth fires
+	constexpr u32 kWant = 0x3fbffffeu;
+
+	struct Form { u32 word; bool is_acc; u32 want; const char* name; };
+	static const Form forms[] = {
+		{ee::MUL_S(2, 0, 1),  false, kWant,                 "MUL.S"},
+		{ee::MULA_S(0, 1),    true,  kWant,                 "MULA.S"},
+		{ee::MADD_S(2, 0, 1), false, kWant,                 "MADD.S"},
+		{ee::MSUB_S(2, 0, 1), false, kWant ^ 0x80000000u,   "MSUB.S"},
+		{ee::MADDA_S(0, 1),   true,  kWant,                 "MADDA.S"},
+		{ee::MSUBA_S(0, 1),   true,  kWant ^ 0x80000000u,   "MSUBA.S"},
+	};
+	for (const Form& f : forms)
+	{
+		EeRecTestHarness h;
+		h.EnableCop1();
+		h.SetAccBits(0x00000000u);
+		h.SetFprBits(0, kFs);
+		h.SetFprBits(1, kFt);
+		h.LoadProgram({f.word});
+		h.RunInterpOnly();
+		const u32 got = f.is_acc ? h.GetAccBitsInterp() : h.GetFprBitsInterp(2);
+		EXPECT_EQ(got, f.want) << f.name;
+	}
 }
 
 TEST(EeRecFpu, MaddSFpuMulHackAppliesToProduct)

--- a/tests/ctest/core/recompilers/ee_vu0_cop2_clamp_residency_tests.cpp
+++ b/tests/ctest/core/recompilers/ee_vu0_cop2_clamp_residency_tests.cpp
@@ -251,13 +251,23 @@ TEST(EeVu0Cop2ClampResidency, SyncStubsReDupClampConsts)
 	}
 }
 
-// q25/q26 are reserved out of the EE NEON allocator pool (like q8/q9); the
-// rest of the pool is untouched.
+// q25/q26 are reserved out of the EE NEON allocator pool (like q8/q9, and like
+// q10 = NEON_RESERVED_FPU_MULMASK); the rest of the pool is untouched.
+//
+// q10 moved from the usable list to the reserved list when the mode-3
+// multiplier-defect mask was parked there. That move is the whole reservation:
+// before it, _getFreeArm64NEON would hand q10 out as an ordinary FPR home, and
+// the first allocation to land there would have overwritten the mask and turned
+// the predicate off for every later multiply in the block. Note also what this
+// test always said about q16-q24 — they are allocator registers, not the free
+// scratch space a `grep` for literal `v16`..`v24` tokens suggests (the COP2 VF
+// residency cache takes q16-q20 through computed indices, and evicts allocator
+// residency to do it).
 TEST(EeVu0Cop2ClampResidency, EeAllocatorReservesClampRegs)
 {
-	for (int reserved : {8, 9, 25, 26})
+	for (int reserved : {8, 9, 10, 25, 26})
 		EXPECT_TRUE(eeTestNeonRegIsReserved(reserved)) << "q" << reserved;
-	for (int usable : {0, 7, 10, 15, 16, 24, 27, 28})
+	for (int usable : {0, 7, 11, 15, 16, 24, 27, 28})
 		EXPECT_FALSE(eeTestNeonRegIsReserved(usable)) << "q" << usable;
 }
 


### PR DESCRIPTION
### Description of Changes
Apply optimizations that open the door for the following accuracy improvement.
Model the EE multiplier's one-ULP deficit in the JIT translator on clamp mode 3 and in the interpreter.
Add supporting tests.

### Rationale behind Changes
This is an approximate generalization of the Tales of Destiny hack. That game won't benefit from these changes and it's not clear which games will benefit from this accuracy improvement at all. With the default settings, the set is limited to the ones that require clamping mode 3.

### Suggested Testing Steps
Play games that require clamping mode 3.

### Did you use AI to help find, test, or implement this issue or feature?
Yes. I told it what to do.