### PR TITLE
iOS: pin the interface to dark instead of following the system

### DIFF
--- a/platforms/ios/app/src/main/cpp/Info.plist.in
+++ b/platforms/ios/app/src/main/cpp/Info.plist.in
@@ -334,6 +334,8 @@
     <string>ARMSX2 uses device motion to control the emulated right analog stick when Gyroscope Camera is enabled.</string>
     <key>UILaunchScreen</key>
     <dict/>
+    <key>UIUserInterfaceStyle</key>
+    <string>Dark</string>
     <key>UIStatusBarStyle</key>
     <string>UIStatusBarStyleDefault</string>
     <key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
* The app is always dark now. It no longer follows the light or dark setting on your device, and there is no option to switch it back.
* The library, the BIOS list and every settings screen used to come up light on a device set to light, while the pause menu and everything over gameplay were already dark. Both halves match now.
* The Speed and Save States panels opened white on top of a running game. They are dark like the rest of the pause menu.
* No more white flash on launch when your device is set to light.
