### PR TITLE
cmake: allow setting version as fallback

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -21,6 +21,7 @@ option(USE_VTUNE "Plug VTUNE to profile GS JIT.")
 option(USE_PERF_JITDUMP "Emit Linux perf jitdump (jit-<pid>.dump) for recompiled JIT blocks; use with perf record/inject." OFF)
 option(USE_PERF_MAP "Emit simple /tmp/perf-<pid>.map symbol table for recompiled JIT blocks." OFF)
 option(PACKAGE_MODE "Use this option to ease packaging of PCSX2 (developer/distribution option)")
+set(ARMSX2_VERSION "" CACHE STRING "Reported version for builds without a git checkout")
 option(BUNDLE_EMOJI_FONT "Bundles Noto Color Emoji for systems whose system emoji font isn't usable by freetype" ON)
 option(POSITION_INDEPENDENT_CODE "Generate position-independent code. It is recommended that you leave this on." ON)
 

--- a/cmake/Pcsx2Utils.cmake
+++ b/cmake/Pcsx2Utils.cmake
@@ -84,6 +84,10 @@ function(get_git_version_info)
 			OUTPUT_VARIABLE PCSX2_GIT_DATE
 			OUTPUT_STRIP_TRAILING_WHITESPACE
 			ERROR_QUIET)
+	elseif (ARMSX2_VERSION)
+		# Version for builds without a git checkout.
+		set(PCSX2_GIT_REV "${ARMSX2_VERSION}")
+		set(PCSX2_GIT_TAG "${ARMSX2_VERSION}")
 	endif()
 	if (NOT PCSX2_GIT_REV)
 		EXECUTE_PROCESS(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD


### PR DESCRIPTION
### Description of Changes
Adds an fallback option to set version. 

### Rationale behind Changes
For distros that pull tarballs they do not have .git and would require carrying a patch. 
Behavior is unchanged in other scenarios. 

### Suggested Testing Steps
Building

### Did you use AI to help find, test, or implement this issue or feature?
No