### PR TITLE
iOS: make the per game renderer override save and apply

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -3348,6 +3348,13 @@ void VMManager::CheckForMiscConfigChanges(const Pcsx2Config& old_config)
 
 void VMManager::CheckForConfigChanges(const Pcsx2Config& old_config)
 {
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+	// GSreopen would recreate the Metal device under the running game, so a
+	// renderer change brought in by a reload waits for the next boot.
+	if (MTGS::IsOpen())
+		EmuConfig.GS.Renderer = old_config.GS.Renderer;
+#endif
+
 	if (HasValidVM())
 	{
 		CheckForCPUConfigChanges(old_config);

--- a/platforms/ios/app/src/main/swift/Views/PerGameSettingsPanel.swift
+++ b/platforms/ios/app/src/main/swift/Views/PerGameSettingsPanel.swift
@@ -1170,15 +1170,11 @@ struct PerGameSettingsPanel: View {
         } else {
             Self.clearPerGameValue("EmuCore/GS", "UserHacks_TextureInsideRt", useCurrent: useCurrent, iso: iso)
         }
-        // Renderer is a boot-time choice — switching Metal↔Software mid-game would
-        // require recreating the GS device, which PCSX2's GSreopen does support but
-        // not from the per-game INI write path. Write the file only (bypassing the
-        // live-apply ForCurrentGame variant) so it takes effect on next boot.
-        let rendererIso = game.bootName
+        // The core keeps a running game on its booted renderer, so this applies next boot.
         if enabled && perGameRenderer != -1 {
-            ARMSX2Bridge.setPerGameINIInt("EmuCore/GS", key: "Renderer", value: Int32(perGameRenderer), forISO: rendererIso)
+            Self.setPerGameIntValue("EmuCore/GS", "Renderer", perGameRenderer, useCurrent: useCurrent, iso: iso)
         } else {
-            ARMSX2Bridge.deletePerGameINIValue("EmuCore/GS", key: "Renderer", forISO: rendererIso)
+            Self.clearPerGameValue("EmuCore/GS", "Renderer", useCurrent: useCurrent, iso: iso)
         }
         if enabled && perGameFXAA != -1 {
             Self.setPerGameBoolValue("EmuCore/GS", "fxaa", perGameFXAA == 1, useCurrent: useCurrent, iso: iso)

--- a/platforms/ios/app/src/main/swift/Views/PerGameSettingsPanel.swift
+++ b/platforms/ios/app/src/main/swift/Views/PerGameSettingsPanel.swift
@@ -621,6 +621,7 @@ struct PerGameSettingsPanel: View {
             enableGameDBHardwareFixes: $enableGameDBHardwareFixes,
             trilinearUseGlobalSentinel: Self.trilinearUseGlobalSentinel,
             ophFlagHackEffective: ophFlagHackEffective,
+            perGameRenderer: $perGameRenderer,
             upscaleMultiplier: $upscaleMultiplier,
             aspectRatio: $aspectRatio,
             textureFiltering: $textureFiltering,
@@ -747,7 +748,6 @@ struct PerGameSettingsPanel: View {
     private var fixesTab: some View {
         FixesTab(
             enabled: $enabled,
-            perGameRenderer: $perGameRenderer,
             perGameAAT: $perGameAAT,
             perGameTextureInsideRt: $perGameTextureInsideRt,
             perGameFixes: $perGameFixes,

--- a/platforms/ios/app/src/main/swift/Views/Settings/PerGame/FixesTab.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/PerGame/FixesTab.swift
@@ -5,7 +5,6 @@ import SwiftUI
 
 struct FixesTab: View {
     @Binding var enabled: Bool
-    @Binding var perGameRenderer: Int
     @Binding var perGameAAT: Int
     @Binding var perGameTextureInsideRt: Int
     @Binding var perGameFixes: [String: Int]
@@ -16,15 +15,6 @@ struct FixesTab: View {
     var body: some View {
         PerGameTab(title: settings.localized("Fixes & Compatibility")) {
             Section {
-                Picker(settings.localized("Renderer"), selection: $perGameRenderer) {
-                    ForEach(SettingsOptions.withUseGlobal(SettingsOptions.renderer), id: \.id) { option in
-                        Text(settings.localized(option.title)).tag(option.id)
-                    }
-                }
-                .disabled(!enabled)
-                Text(settings.localized("Software Renderer is much slower but can fix games that break on Metal. It applies the next time this game boots."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
                 Picker(settings.localized("Accurate Alpha Test"), selection: $perGameAAT) {
                     Text(settings.localized("Use Global")).tag(-1)
                     Text(settings.localized("Off")).tag(0)
@@ -62,7 +52,7 @@ struct FixesTab: View {
             } header: {
                 Text(settings.localized("Compatibility Overrides"))
             } footer: {
-                Text(settings.localized("Override global settings for this game only. Game fixes apply while per-game GameDB Core Fixes is on. " + (savesToRunningGame ? "Most changes apply when you save; the renderer needs a reset." : "Changes apply on next boot.")))
+                Text(settings.localized("Override global settings for this game only. Game fixes apply while per-game GameDB Core Fixes is on. " + (savesToRunningGame ? "Changes apply when you save." : "Changes apply on next boot.")))
             }
         }
     }

--- a/platforms/ios/app/src/main/swift/Views/Settings/PerGame/GraphicsTab.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/PerGame/GraphicsTab.swift
@@ -12,6 +12,7 @@ struct GraphicsTab: View {
 
     // Core graphics overrides. Each carries a use-global sentinel so an untouched setting is not
     // written to the per-game file at all, plus the global value to label what it inherits.
+    @Binding var perGameRenderer: Int
     @Binding var upscaleMultiplier: Float
     @Binding var aspectRatio: String
     @Binding var textureFiltering: Int
@@ -111,6 +112,14 @@ struct GraphicsTab: View {
     @ViewBuilder
     private var graphicsContent: some View {
         Section(settings.localized("Graphics")) {
+            sharedPicker("Renderer", selection: $perGameRenderer,
+                         SettingsOptions.withUseGlobal(SettingsOptions.renderer))
+                .disabled(!enabled)
+
+            Text(settings.localized("Software Renderer is much slower but can fix games that break on Metal. It applies the next time this game boots."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
             EnumPicker([(id: Self.upscaleUseGlobalSentinel, title: settings.localized("Use Global"))] + UpscaleOptions.all, selection: $upscaleMultiplier) {
                 Text(settings.localized("Internal Resolution"))
             }


### PR DESCRIPTION
* Changing the renderer in per game settings now actually saves, and it applies the next time that game boots. Before this, saving while a game ran could silently write nothing at all, so the picker reverted and the game never switched.
* The renderer was the only per game setting written through a different identity than the one the panel reads back and the boot path loads. While a game was running that lookup could quietly fail, or land the key in a different file than the one the game uses.
* The core now keeps a running game on the renderer it booted with, so a mid game save can no longer tear the Metal device down under the game.
* The renderer picker moved from Fixes and Compatibility to the top of the Graphics tab, where testers kept looking for it.
* Switching renderers live while a game runs stays off on purpose. The caption has always said the change applies at the next boot, and now that is true.
* One small note: until that next boot, database hardware fixes are still judged against the renderer written in the file rather than the one on screen. It corrects itself when the game boots.
