### PR TITLE
iOS: give the menu reveal tap a surface that works on iOS 27

### DIFF
--- a/platforms/ios/app/src/main/swift/Views/Controller/DynamicThumbstickControls.swift
+++ b/platforms/ios/app/src/main/swift/Views/Controller/DynamicThumbstickControls.swift
@@ -118,6 +118,8 @@ struct DynamicThumbstickView: View {
     var onInteractionActivity: () -> Void = {}
     var onInteractionTap: () -> Void = {}
     var onInteractionEnded: () -> Void = {}
+    // Fires on every classified tap, unlike onInteractionTap which needs tap actions on.
+    var onAnyTap: () -> Void = {}
 
     @State private var origin = CGPoint.zero
     @State private var dragOffset = CGSize.zero
@@ -194,6 +196,7 @@ struct DynamicThumbstickView: View {
                 let duration = value.time.timeIntervalSince(gestureStartedAt ?? value.time)
                 let travel = max(maximumTravel, hypot(value.translation.width, value.translation.height))
                 if duration <= maximumTapDuration && travel <= tapTravelTolerance {
+                    onAnyTap()
                     if tapActionsEnabled {
                         onInteractionTap()
                     } else {

--- a/platforms/ios/app/src/main/swift/Views/GameScreenView.swift
+++ b/platforms/ios/app/src/main/swift/Views/GameScreenView.swift
@@ -356,6 +356,7 @@ struct GameScreenView: View {
                             .accessibilityLabel("Game display")
                             .accessibilityAddTraits(.isImage)
                             .accessibilityHint("VoiceOver image recognition can read on-screen text.")
+                            .overlay { menuRevealTapCatcher }
                         AccessibilityHUDMirror()
                         if effectiveVirtualPadVisible {
                             VirtualControllerView(
@@ -390,6 +391,7 @@ struct GameScreenView: View {
                             .accessibilityHint("VoiceOver image recognition can read on-screen text.")
                             .overlay {
                                 ZStack {
+                                    menuRevealTapCatcher
                                     AccessibilityHUDMirror()
                                     dynamicCrosshairOverlay
                                 }
@@ -594,6 +596,9 @@ struct GameScreenView: View {
             padRebuildToken &+= 1
             overlayRoute = .paused
         }
+        .onReceive(NotificationCenter.default.publisher(for: gameplaySurfaceTapNotification)) { _ in
+            revealMenuButtonBriefly()
+        }
         .onReceive(NotificationCenter.default.publisher(for: retroAchievementsToastNotification)) { _ in
             consumePendingRetroAchievementsToast()
         }
@@ -791,6 +796,14 @@ struct GameScreenView: View {
             rightRuntime: touchActionSession.right.crosshairState
         )
         .gameplayLaunchChrome(visible: appState.gameplayLaunchControlsVisible)
+    }
+
+    // The render view is non-interactive on iOS 27, so the reveal tap needs a SwiftUI surface.
+    private var menuRevealTapCatcher: some View {
+        Color.clear
+            .contentShape(Rectangle())
+            .onTapGesture { revealMenuButtonBriefly() }
+            .accessibilityHidden(true)
     }
 
     @ViewBuilder

--- a/platforms/ios/app/src/main/swift/Views/VirtualControllerView.swift
+++ b/platforms/ios/app/src/main/swift/Views/VirtualControllerView.swift
@@ -4,6 +4,10 @@
 import SwiftUI
 import UIKit
 
+// Posted when a dynamic input zone classifies a touch as a tap, so the game
+// screen can reveal a hidden menu button the zones would otherwise swallow.
+let gameplaySurfaceTapNotification = Notification.Name("ARMSX2iOSGameplaySurfaceTap")
+
 // Lazily-created haptic generators reused for button presses and explicitly releasable
 // when the gameplay UI is removed.
 @MainActor
@@ -567,6 +571,7 @@ struct VirtualControllerView: View {
                         }
                     },
                     onTap: {
+                        NotificationCenter.default.post(name: gameplaySurfaceTapNotification, object: nil)
                         if dynamicSettings.rightThumbstickActionsEnabled {
                             activeTouchActionSession.right.interactionTapped()
                         }
@@ -644,7 +649,8 @@ struct VirtualControllerView: View {
             onInteractionBegan: { actionController.interactionBegan() },
             onInteractionActivity: { actionController.interactionActivity() },
             onInteractionTap: { actionController.interactionTapped() },
-            onInteractionEnded: { actionController.interactionEnded() }
+            onInteractionEnded: { actionController.interactionEnded() },
+            onAnyTap: { NotificationCenter.default.post(name: gameplaySurfaceTapNotification, object: nil) }
         )
     }
 


### PR DESCRIPTION
* Follow up to the hide menu button change: on iOS 27 the tap that shows a hidden menu button never fired, so the button was unrecoverable in game. Reported on an iPad running the iOS 27 beta.
* The tap sat on the Metal render view, which the app makes non interactive on iOS 27 so the SwiftUI overlays own touch. The reveal now lives on a clear SwiftUI surface over the game view, the same construct the pause screen already uses.
* The dynamic input zones get the same treatment: with Dynamic Thumbsticks or Swipe Camera on they cover the whole landscape screen and swallow every tap, on any iOS version. A tap they classify now also reveals a hidden menu button. Zone behaviour in gameplay is unchanged.
* This missed the original PR by two minutes: it was pushed to that branch just after the merge, so it lands here instead.
