### PR TITLE
iOS: overhaul the sprite hacks and the hack claim system

### DIFF
--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -727,6 +727,12 @@ void VMManager::LoadCoreSettings(SettingsInterface& si)
 {
 	SettingsLoadWrapper slw(si);
 	EmuConfig.LoadSave(slw);
+
+	// A game file's UserHackOverrides replaces the base mask outright, and the
+	// player's global claims still stand for this game.
+	if (SettingsInterface* base = Host::Internal::GetBaseSettingsLayer(); base && base != &si)
+		EmuConfig.GS.UserHackOverrides |= static_cast<u32>(base->GetIntValue("EmuCore/GS", "UserHackOverrides", 0));
+
 	Patch::ApplyPatchSettingOverrides();
 
 	// Achievements hardcore mode disallows setting some configuration options.

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -729,7 +729,7 @@ void VMManager::LoadCoreSettings(SettingsInterface& si)
 	EmuConfig.LoadSave(slw);
 
 	// A game file's UserHackOverrides replaces the base mask outright, and the
-	// player's global claims still stand for this game.
+	// player's global claims still stand here.
 	if (SettingsInterface* base = Host::Internal::GetBaseSettingsLayer(); base && base != &si)
 		EmuConfig.GS.UserHackOverrides |= static_cast<u32>(base->GetIntValue("EmuCore/GS", "UserHackOverrides", 0));
 

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.h
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.h
@@ -151,12 +151,9 @@ typedef void (^ARMSX2RetroAchievementsCompletion)(BOOL success, NSString * _Nonn
         trilinearFiltering:(int)trilinearFiltering
           halfPixelOffset:(int)halfPixelOffset
               roundSprite:(int)roundSprite
-      alignSpriteOverride:(BOOL)alignSpriteOverride
-              alignSprite:(BOOL)alignSprite
-      mergeSpriteOverride:(BOOL)mergeSpriteOverride
-              mergeSprite:(BOOL)mergeSprite
-    wildArmsOffsetOverride:(BOOL)wildArmsOffsetOverride
-           wildArmsOffset:(BOOL)wildArmsOffset
+              alignSprite:(int)alignSprite
+              mergeSprite:(int)mergeSprite
+           wildArmsOffset:(int)wildArmsOffset
     textureOffsetXOverride:(BOOL)textureOffsetXOverride
            textureOffsetX:(int)textureOffsetX
     textureOffsetYOverride:(BOOL)textureOffsetYOverride
@@ -177,7 +174,7 @@ typedef void (^ARMSX2RetroAchievementsCompletion)(BOOL success, NSString * _Nonn
                  enablePatches:(BOOL)enablePatches
               enableGameFixes:(BOOL)enableGameFixes
     enableGameDBHardwareFixes:(BOOL)enableGameDBHardwareFixes
-    NS_SWIFT_NAME(setGameSettings(forISO:enabled:upscaleMultiplier:aspectRatio:textureFiltering:hardwareMipmapping:blendingAccuracy:interlaceMode:trilinearFiltering:halfPixelOffset:roundSprite:alignSpriteOverride:alignSprite:mergeSpriteOverride:mergeSprite:wildArmsOffsetOverride:wildArmsOffset:textureOffsetXOverride:textureOffsetX:textureOffsetYOverride:textureOffsetY:skipDrawStartOverride:skipDrawStart:skipDrawEndOverride:skipDrawEnd:volumeOverride:volumePercent:eeCoreType:mtvu:eeCycleRateOverride:eeCycleRate:fastBootOverride:fastBoot:enableCheats:enablePatches:enableGameFixes:enableGameDBHardwareFixes:));
+    NS_SWIFT_NAME(setGameSettings(forISO:enabled:upscaleMultiplier:aspectRatio:textureFiltering:hardwareMipmapping:blendingAccuracy:interlaceMode:trilinearFiltering:halfPixelOffset:roundSprite:alignSprite:mergeSprite:wildArmsOffset:textureOffsetXOverride:textureOffsetX:textureOffsetYOverride:textureOffsetY:skipDrawStartOverride:skipDrawStart:skipDrawEndOverride:skipDrawEnd:volumeOverride:volumePercent:eeCoreType:mtvu:eeCycleRateOverride:eeCycleRate:fastBootOverride:fastBoot:enableCheats:enablePatches:enableGameFixes:enableGameDBHardwareFixes:));
 + (void)setGameSettingsForCurrentGameWithEnabled:(BOOL)enabled
                                upscaleMultiplier:(float)upscaleMultiplier
                                      aspectRatio:(nonnull NSString *)aspectRatio
@@ -188,12 +185,9 @@ typedef void (^ARMSX2RetroAchievementsCompletion)(BOOL success, NSString * _Nonn
                               trilinearFiltering:(int)trilinearFiltering
                                  halfPixelOffset:(int)halfPixelOffset
                                      roundSprite:(int)roundSprite
-                             alignSpriteOverride:(BOOL)alignSpriteOverride
-                                     alignSprite:(BOOL)alignSprite
-                             mergeSpriteOverride:(BOOL)mergeSpriteOverride
-                                     mergeSprite:(BOOL)mergeSprite
-                           wildArmsOffsetOverride:(BOOL)wildArmsOffsetOverride
-                                  wildArmsOffset:(BOOL)wildArmsOffset
+                                     alignSprite:(int)alignSprite
+                                     mergeSprite:(int)mergeSprite
+                                  wildArmsOffset:(int)wildArmsOffset
                            textureOffsetXOverride:(BOOL)textureOffsetXOverride
                                   textureOffsetX:(int)textureOffsetX
                            textureOffsetYOverride:(BOOL)textureOffsetYOverride
@@ -214,7 +208,7 @@ typedef void (^ARMSX2RetroAchievementsCompletion)(BOOL success, NSString * _Nonn
                                    enablePatches:(BOOL)enablePatches
                                  enableGameFixes:(BOOL)enableGameFixes
                       enableGameDBHardwareFixes:(BOOL)enableGameDBHardwareFixes
-    NS_SWIFT_NAME(setGameSettingsForCurrentGame(enabled:upscaleMultiplier:aspectRatio:textureFiltering:hardwareMipmapping:blendingAccuracy:interlaceMode:trilinearFiltering:halfPixelOffset:roundSprite:alignSpriteOverride:alignSprite:mergeSpriteOverride:mergeSprite:wildArmsOffsetOverride:wildArmsOffset:textureOffsetXOverride:textureOffsetX:textureOffsetYOverride:textureOffsetY:skipDrawStartOverride:skipDrawStart:skipDrawEndOverride:skipDrawEnd:volumeOverride:volumePercent:eeCoreType:mtvu:eeCycleRateOverride:eeCycleRate:fastBootOverride:fastBoot:enableCheats:enablePatches:enableGameFixes:enableGameDBHardwareFixes:));
+    NS_SWIFT_NAME(setGameSettingsForCurrentGame(enabled:upscaleMultiplier:aspectRatio:textureFiltering:hardwareMipmapping:blendingAccuracy:interlaceMode:trilinearFiltering:halfPixelOffset:roundSprite:alignSprite:mergeSprite:wildArmsOffset:textureOffsetXOverride:textureOffsetX:textureOffsetYOverride:textureOffsetY:skipDrawStartOverride:skipDrawStart:skipDrawEndOverride:skipDrawEnd:volumeOverride:volumePercent:eeCoreType:mtvu:eeCycleRateOverride:eeCycleRate:fastBootOverride:fastBoot:enableCheats:enablePatches:enableGameFixes:enableGameDBHardwareFixes:));
 + (nullable NSString *)linkedDiscPathForELF:(nonnull NSString *)elfName NS_SWIFT_NAME(linkedDiscPath(forELF:));
 + (void)setLinkedDiscPath:(nullable NSString *)discPath forELF:(nonnull NSString *)elfName NS_SWIFT_NAME(setLinkedDiscPath(_:forELF:));
 + (nonnull NSString *)clearCacheForISO:(nonnull NSString *)isoName NS_SWIFT_NAME(clearCache(forISO:));

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
@@ -3402,6 +3402,7 @@ extern "C" void ARMSX2_CaptureGraphicsHackState(void)
         VMManager::ReloadGameSettings();
         if (MTGS::IsOpen())
             MTGS::ApplySettings();
+        ARMSX2_CaptureGraphicsHackState();
     });
 }
 
@@ -4119,6 +4120,7 @@ static void ARMSX2RequestPerGameSettingsReload()
                 ARMSX2_ApplyEffectivePresentFPSCap();
                 if (MTGS::IsOpen())
                     MTGS::ApplySettings();
+                ARMSX2_CaptureGraphicsHackState();
             });
         });
 }

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
@@ -2416,7 +2416,7 @@ struct ARMSX2GraphicsHackState
     bool pinned = false;
 };
 
-static constexpr std::array<ARMSX2GraphicsHackDescriptor, 9> s_graphics_hacks = {{
+static constexpr std::array<ARMSX2GraphicsHackDescriptor, 13> s_graphics_hacks = {{
     {"UserHacks_align_sprite_X", GSUserHackOverride::AlignSprite, GameDatabaseSchema::GSHWFixId::AlignSprite, true, true,
         [](const Pcsx2Config::GSOptions& gs) { return static_cast<int>(gs.UserHacks_AlignSpriteX); }},
     {"UserHacks_merge_pp_sprite", GSUserHackOverride::MergeSprite, GameDatabaseSchema::GSHWFixId::MergeSprite, true, true,
@@ -2435,6 +2435,14 @@ static constexpr std::array<ARMSX2GraphicsHackDescriptor, 9> s_graphics_hacks = 
         [](const Pcsx2Config::GSOptions& gs) { return static_cast<int>(gs.UserHacks_TCOffsetX); }},
     {"UserHacks_TCOffsetY", GSUserHackOverride::TextureOffsetY, GameDatabaseSchema::GSHWFixId::Count, true, false,
         [](const Pcsx2Config::GSOptions& gs) { return static_cast<int>(gs.UserHacks_TCOffsetY); }},
+    {"UserHacks_TextureInsideRt", GSUserHackOverride::TextureInsideRt, GameDatabaseSchema::GSHWFixId::TextureInsideRT, false, false,
+        [](const Pcsx2Config::GSOptions& gs) { return static_cast<int>(gs.UserHacks_TextureInsideRt); }},
+    {"UserHacks_BilinearHack", GSUserHackOverride::BilinearHack, GameDatabaseSchema::GSHWFixId::BilinearUpscale, true, false,
+        [](const Pcsx2Config::GSOptions& gs) { return static_cast<int>(gs.UserHacks_BilinearHack); }},
+    {"preload_frame_with_gs_data", GSUserHackOverride::PreloadFrameData, GameDatabaseSchema::GSHWFixId::PreloadFrameData, false, true,
+        [](const Pcsx2Config::GSOptions& gs) { return static_cast<int>(gs.PreloadFrameWithGSData); }},
+    {"UserHacks_DisablePartialInvalidation", GSUserHackOverride::DisablePartialInvalidation, GameDatabaseSchema::GSHWFixId::DisablePartialInvalidation, false, true,
+        [](const Pcsx2Config::GSOptions& gs) { return static_cast<int>(gs.UserHacks_DisablePartialInvalidation); }},
 }};
 
 static std::mutex s_graphics_hack_mutex;

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
@@ -1749,6 +1749,46 @@ static NSMutableDictionary<NSString*, id>* ARMSX2BuildGlobalGameSettingsResult()
 // Overlays per-game INI overrides for the given serial/crc onto a globals-seeded result.
 // Sourcing serial/crc from the caller avoids re-scanning the disc image (which is unsafe
 // while the VM is actively reading the same disc).
+// Every pin-backed hack key, paired with its claim bit. A per-game file's claim
+// mask is derivable from which of these keys it holds, so the mask is never
+// stored ahead of the keys.
+static constexpr struct { const char* key; GSUserHackOverride hack; } s_pinned_hack_keys[] = {
+    {"UserHacks_align_sprite_X", GSUserHackOverride::AlignSprite},
+    {"UserHacks_merge_pp_sprite", GSUserHackOverride::MergeSprite},
+    {"UserHacks_round_sprite_offset", GSUserHackOverride::RoundSprite},
+    {"UserHacks_HalfPixelOffset", GSUserHackOverride::HalfPixelOffset},
+    {"UserHacks_ForceEvenSpritePosition", GSUserHackOverride::ForceEvenSpritePosition},
+    {"UserHacks_native_scaling", GSUserHackOverride::NativeScaling},
+    {"UserHacks_NativePaletteDraw", GSUserHackOverride::NativePaletteDraw},
+    {"UserHacks_BilinearHack", GSUserHackOverride::BilinearHack},
+    {"UserHacks_TCOffsetX", GSUserHackOverride::TextureOffsetX},
+    {"UserHacks_AutoFlushLevel", GSUserHackOverride::AutoFlush},
+    {"UserHacks_TextureInsideRt", GSUserHackOverride::TextureInsideRt},
+    {"UserHacks_TCOffsetY", GSUserHackOverride::TextureOffsetY},
+    {"preload_frame_with_gs_data", GSUserHackOverride::PreloadFrameData},
+    {"UserHacks_DisablePartialInvalidation", GSUserHackOverride::DisablePartialInvalidation},
+};
+
+static u32 ARMSX2DerivePerGameHackClaims(INISettingsInterface& si)
+{
+    u32 claims = 0;
+    for (const auto& entry : s_pinned_hack_keys) {
+        if (si.ContainsValue("EmuCore/GS", entry.key))
+            claims |= 1u << static_cast<u32>(entry.hack);
+    }
+    return claims;
+}
+
+// Writes the derived mask, or removes it when nothing claims anything.
+static void ARMSX2StoreDerivedPerGameHackClaims(INISettingsInterface& si)
+{
+    const u32 claims = ARMSX2DerivePerGameHackClaims(si);
+    if (claims != 0)
+        si.SetIntValue("EmuCore/GS", "UserHackOverrides", static_cast<int>(claims));
+    else
+        si.DeleteValue("EmuCore/GS", "UserHackOverrides");
+}
+
 static void ARMSX2ApplyPerGameSettingsOverrides(NSMutableDictionary<NSString*, id>* result, const std::string& serial, u32 crc)
 {
     const std::string settingsPath = VMManager::GetGameSettingsPath(serial, crc);
@@ -1771,6 +1811,19 @@ static void ARMSX2ApplyPerGameSettingsOverrides(NSMutableDictionary<NSString*, i
         const bool saved = si.Save(&saveError);
         std::fprintf(stderr, "@@IOS_PERGAME_MTVU_REPAIR@@ file=\"%s\" ui_read=1 removed_stale_false=1 saved=%d error=\"%s\"\n",
             settingsPath.c_str(), saved ? 1 : 0, saveError.GetDescription().c_str());
+        std::fflush(stderr);
+    }
+
+    // Older saves froze the global claim mask into this file, where it went stale.
+    const u32 derivedClaims = ARMSX2DerivePerGameHackClaims(si);
+    const u32 storedClaims = static_cast<u32>(si.GetIntValue("EmuCore/GS", "UserHackOverrides", 0));
+    if (storedClaims != derivedClaims) {
+        ARMSX2StoreDerivedPerGameHackClaims(si);
+        si.RemoveEmptySections();
+        Error claimError;
+        const bool saved = si.Save(&claimError);
+        std::fprintf(stderr, "@@IOS_PERGAME_CLAIM_REPAIR@@ file=\"%s\" stored=%u derived=%u saved=%d\n",
+            settingsPath.c_str(), storedClaims, derivedClaims, saved ? 1 : 0);
         std::fflush(stderr);
     }
 
@@ -2103,37 +2156,9 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
             si.DeleteValue("EmuCore/GS", "UserHacks_TCOffsetY");
 
         // Overriding a hack for one game only counts if the GameDB stops writing that
-        // hack for that game, so the claim goes in this file too.
-        u32 perGameClaims = 0;
-        const auto claim = [&perGameClaims](GSUserHackOverride hack) {
-            perGameClaims |= 1u << static_cast<u32>(hack);
-        };
-        if (halfPixelOffset != ARMSX2UseGlobalIntSentinel)
-            claim(GSUserHackOverride::HalfPixelOffset);
-        if (roundSprite != ARMSX2UseGlobalIntSentinel)
-            claim(GSUserHackOverride::RoundSprite);
-        if (alignSpriteOverride)
-            claim(GSUserHackOverride::AlignSprite);
-        if (mergeSpriteOverride)
-            claim(GSUserHackOverride::MergeSprite);
-        if (wildArmsOffsetOverride)
-            claim(GSUserHackOverride::ForceEvenSpritePosition);
-        if (textureOffsetXOverride)
-            claim(GSUserHackOverride::TextureOffsetX);
-        if (textureOffsetYOverride)
-            claim(GSUserHackOverride::TextureOffsetY);
-
-        // The per-game layer replaces this key rather than merging into it, so the global
-        // claims have to be carried across or they vanish for any game with its own file,
-        // and the database takes those hacks straight back.
-        const u32 globalClaims = g_p44_settings_interface ?
-            static_cast<u32>(g_p44_settings_interface->GetIntValue("EmuCore/GS", "UserHackOverrides", 0)) : 0;
-        const u32 combinedClaims = globalClaims | perGameClaims;
-
-        if (combinedClaims != 0)
-            si.SetIntValue("EmuCore/GS", "UserHackOverrides", static_cast<int>(combinedClaims));
-        else
-            si.DeleteValue("EmuCore/GS", "UserHackOverrides");
+        // hack for that game, so the claim mask goes in this file too. Derived from the
+        // keys just written; the core folds the global claims back in at load.
+        ARMSX2StoreDerivedPerGameHackClaims(si);
 
         if (skipDrawStartOverride)
             si.SetIntValue("EmuCore/GS", "UserHacks_SkipDraw_Start", ARMSX2ClampInt(skipDrawStart, 0, 5000));

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
@@ -1789,6 +1789,19 @@ static void ARMSX2StoreDerivedPerGameHackClaims(INISettingsInterface& si)
         si.DeleteValue("EmuCore/GS", "UserHackOverrides");
 }
 
+// The generic per-game helpers write hack keys too, so they keep the mask in step.
+static void ARMSX2SyncClaimsIfPinnedHackKey(INISettingsInterface& si, NSString* section, NSString* key)
+{
+    if (![section isEqualToString:@"EmuCore/GS"])
+        return;
+    for (const auto& entry : s_pinned_hack_keys) {
+        if ([key isEqualToString:@(entry.key)]) {
+            ARMSX2StoreDerivedPerGameHackClaims(si);
+            return;
+        }
+    }
+}
+
 static void ARMSX2ApplyPerGameSettingsOverrides(NSMutableDictionary<NSString*, id>* result, const std::string& serial, u32 crc)
 {
     const std::string settingsPath = VMManager::GetGameSettingsPath(serial, crc);
@@ -2050,12 +2063,9 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
                                                 int trilinearFiltering,
                                                 int halfPixelOffset,
                                                 int roundSprite,
-                                                BOOL alignSpriteOverride,
-                                                BOOL alignSprite,
-                                                BOOL mergeSpriteOverride,
-                                                BOOL mergeSprite,
-                                                BOOL wildArmsOffsetOverride,
-                                                BOOL wildArmsOffset,
+                                                int alignSprite,
+                                                int mergeSprite,
+                                                int wildArmsOffset,
                                                 BOOL textureOffsetXOverride,
                                                 int textureOffsetX,
                                                 BOOL textureOffsetYOverride,
@@ -2130,20 +2140,20 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
         else
             si.SetIntValue("EmuCore/GS", "UserHacks_round_sprite_offset", ARMSX2ClampInt(roundSprite, 0, 2));
 
-        if (alignSpriteOverride)
-            si.SetBoolValue("EmuCore/GS", "UserHacks_align_sprite_X", alignSprite);
-        else
+        if (alignSprite == ARMSX2UseGlobalIntSentinel)
             si.DeleteValue("EmuCore/GS", "UserHacks_align_sprite_X");
-
-        if (mergeSpriteOverride)
-            si.SetBoolValue("EmuCore/GS", "UserHacks_merge_pp_sprite", mergeSprite);
         else
+            si.SetBoolValue("EmuCore/GS", "UserHacks_align_sprite_X", alignSprite != 0);
+
+        if (mergeSprite == ARMSX2UseGlobalIntSentinel)
             si.DeleteValue("EmuCore/GS", "UserHacks_merge_pp_sprite");
-
-        if (wildArmsOffsetOverride)
-            si.SetBoolValue("EmuCore/GS", "UserHacks_ForceEvenSpritePosition", wildArmsOffset);
         else
+            si.SetBoolValue("EmuCore/GS", "UserHacks_merge_pp_sprite", mergeSprite != 0);
+
+        if (wildArmsOffset == ARMSX2UseGlobalIntSentinel)
             si.DeleteValue("EmuCore/GS", "UserHacks_ForceEvenSpritePosition");
+        else
+            si.SetBoolValue("EmuCore/GS", "UserHacks_ForceEvenSpritePosition", wildArmsOffset != 0);
 
         if (textureOffsetXOverride)
             si.SetIntValue("EmuCore/GS", "UserHacks_TCOffsetX", ARMSX2ClampInt(textureOffsetX, -4096, 4096));
@@ -3289,12 +3299,9 @@ extern "C" void ARMSX2_CaptureGraphicsHackState(void)
         trilinearFiltering:(int)trilinearFiltering
           halfPixelOffset:(int)halfPixelOffset
               roundSprite:(int)roundSprite
-      alignSpriteOverride:(BOOL)alignSpriteOverride
-              alignSprite:(BOOL)alignSprite
-      mergeSpriteOverride:(BOOL)mergeSpriteOverride
-              mergeSprite:(BOOL)mergeSprite
-    wildArmsOffsetOverride:(BOOL)wildArmsOffsetOverride
-           wildArmsOffset:(BOOL)wildArmsOffset
+              alignSprite:(int)alignSprite
+              mergeSprite:(int)mergeSprite
+           wildArmsOffset:(int)wildArmsOffset
     textureOffsetXOverride:(BOOL)textureOffsetXOverride
            textureOffsetX:(int)textureOffsetX
     textureOffsetYOverride:(BOOL)textureOffsetYOverride
@@ -3325,9 +3332,8 @@ extern "C" void ARMSX2_CaptureGraphicsHackState(void)
     const std::string settingsSerial = (entry.type == GameList::EntryType::ELF) ? std::string() : entry.serial;
     ARMSX2WriteGameSettingsForIdentity(settingsSerial, entry.crc, enabled, upscaleMultiplier, aspectRatio,
                                         textureFiltering, hardwareMipmapping, blendingAccuracy, interlaceMode,
-                                        trilinearFiltering, halfPixelOffset, roundSprite, alignSpriteOverride,
-                                        alignSprite, mergeSpriteOverride, mergeSprite, wildArmsOffsetOverride,
-                                        wildArmsOffset, textureOffsetXOverride, textureOffsetX,
+                                        trilinearFiltering, halfPixelOffset, roundSprite, alignSprite,
+                                        mergeSprite, wildArmsOffset, textureOffsetXOverride, textureOffsetX,
                                         textureOffsetYOverride, textureOffsetY, skipDrawStartOverride,
                                         skipDrawStart, skipDrawEndOverride, skipDrawEnd,
                                         volumeOverride, volumePercent, eeCoreType, mtvu,
@@ -3345,12 +3351,9 @@ extern "C" void ARMSX2_CaptureGraphicsHackState(void)
                               trilinearFiltering:(int)trilinearFiltering
                                  halfPixelOffset:(int)halfPixelOffset
                                      roundSprite:(int)roundSprite
-                             alignSpriteOverride:(BOOL)alignSpriteOverride
-                                     alignSprite:(BOOL)alignSprite
-                             mergeSpriteOverride:(BOOL)mergeSpriteOverride
-                                     mergeSprite:(BOOL)mergeSprite
-                           wildArmsOffsetOverride:(BOOL)wildArmsOffsetOverride
-                                  wildArmsOffset:(BOOL)wildArmsOffset
+                                     alignSprite:(int)alignSprite
+                                     mergeSprite:(int)mergeSprite
+                                  wildArmsOffset:(int)wildArmsOffset
                            textureOffsetXOverride:(BOOL)textureOffsetXOverride
                                   textureOffsetX:(int)textureOffsetX
                            textureOffsetYOverride:(BOOL)textureOffsetYOverride
@@ -3386,9 +3389,8 @@ extern "C" void ARMSX2_CaptureGraphicsHackState(void)
 
     ARMSX2WriteGameSettingsForIdentity(serial, crc, enabled, upscaleMultiplier, aspectRatio,
                                         textureFiltering, hardwareMipmapping, blendingAccuracy, interlaceMode,
-                                        trilinearFiltering, halfPixelOffset, roundSprite, alignSpriteOverride,
-                                        alignSprite, mergeSpriteOverride, mergeSprite, wildArmsOffsetOverride,
-                                        wildArmsOffset, textureOffsetXOverride, textureOffsetX,
+                                        trilinearFiltering, halfPixelOffset, roundSprite, alignSprite,
+                                        mergeSprite, wildArmsOffset, textureOffsetXOverride, textureOffsetX,
                                         textureOffsetYOverride, textureOffsetY, skipDrawStartOverride,
                                         skipDrawStart, skipDrawEndOverride, skipDrawEnd,
                                         volumeOverride, volumePercent, eeCoreType, mtvu,
@@ -4133,6 +4135,7 @@ static void ARMSX2RequestPerGameSettingsReload()
     INISettingsInterface si(ARMSX2PerGameSettingsPath(serial, crc));
     si.Load();
     si.SetIntValue(section.UTF8String, key.UTF8String, value);
+    ARMSX2SyncClaimsIfPinnedHackKey(si, section, key);
     Error error;
     si.Save(&error);
 }
@@ -4145,6 +4148,7 @@ static void ARMSX2RequestPerGameSettingsReload()
     INISettingsInterface si(ARMSX2PerGameSettingsPath(serial, crc));
     si.Load();
     si.SetBoolValue(section.UTF8String, key.UTF8String, value);
+    ARMSX2SyncClaimsIfPinnedHackKey(si, section, key);
     Error error;
     si.Save(&error);
 }
@@ -4159,6 +4163,7 @@ static void ARMSX2RequestPerGameSettingsReload()
         return;
     si.DeleteValue(section.UTF8String, key.UTF8String);
     si.RemoveEmptySections();
+    ARMSX2SyncClaimsIfPinnedHackKey(si, section, key);
     Error error;
     si.Save(&error);
 }
@@ -4204,6 +4209,7 @@ static void ARMSX2RequestPerGameSettingsReload()
     INISettingsInterface si(ARMSX2PerGameSettingsPath(serial, crc));
     si.Load();
     si.SetIntValue(section.UTF8String, key.UTF8String, value);
+    ARMSX2SyncClaimsIfPinnedHackKey(si, section, key);
     Error error;
     si.Save(&error);
     ARMSX2RequestPerGameSettingsReload();
@@ -4217,6 +4223,7 @@ static void ARMSX2RequestPerGameSettingsReload()
     INISettingsInterface si(ARMSX2PerGameSettingsPath(serial, crc));
     si.Load();
     si.SetBoolValue(section.UTF8String, key.UTF8String, value);
+    ARMSX2SyncClaimsIfPinnedHackKey(si, section, key);
     Error error;
     si.Save(&error);
     ARMSX2RequestPerGameSettingsReload();
@@ -4241,6 +4248,7 @@ static void ARMSX2RequestPerGameSettingsReload()
     INISettingsInterface si(ARMSX2PerGameSettingsPath(serial, crc));
     si.Load();
     si.SetFloatValue(section.UTF8String, key.UTF8String, value);
+    ARMSX2SyncClaimsIfPinnedHackKey(si, section, key);
     Error error;
     si.Save(&error);
 }
@@ -4264,6 +4272,7 @@ static void ARMSX2RequestPerGameSettingsReload()
     INISettingsInterface si(ARMSX2PerGameSettingsPath(serial, crc));
     si.Load();
     si.SetFloatValue(section.UTF8String, key.UTF8String, value);
+    ARMSX2SyncClaimsIfPinnedHackKey(si, section, key);
     Error error;
     si.Save(&error);
     ARMSX2RequestPerGameSettingsReload();
@@ -4279,6 +4288,7 @@ static void ARMSX2RequestPerGameSettingsReload()
         return;
     si.DeleteValue(section.UTF8String, key.UTF8String);
     si.RemoveEmptySections();
+    ARMSX2SyncClaimsIfPinnedHackKey(si, section, key);
     Error error;
     si.Save(&error);
     ARMSX2RequestPerGameSettingsReload();

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
@@ -1749,9 +1749,8 @@ static NSMutableDictionary<NSString*, id>* ARMSX2BuildGlobalGameSettingsResult()
 // Overlays per-game INI overrides for the given serial/crc onto a globals-seeded result.
 // Sourcing serial/crc from the caller avoids re-scanning the disc image (which is unsafe
 // while the VM is actively reading the same disc).
-// Every pin-backed hack key, paired with its claim bit. A per-game file's claim
-// mask is derivable from which of these keys it holds, so the mask is never
-// stored ahead of the keys.
+// Every pin-backed hack key with its claim bit, so a file's mask is derivable
+// from which of these keys it holds rather than stored ahead of them.
 static constexpr struct { const char* key; GSUserHackOverride hack; } s_pinned_hack_keys[] = {
     {"UserHacks_align_sprite_X", GSUserHackOverride::AlignSprite},
     {"UserHacks_merge_pp_sprite", GSUserHackOverride::MergeSprite},
@@ -1779,7 +1778,6 @@ static u32 ARMSX2DerivePerGameHackClaims(INISettingsInterface& si)
     return claims;
 }
 
-// Writes the derived mask, or removes it when nothing claims anything.
 static void ARMSX2StoreDerivedPerGameHackClaims(INISettingsInterface& si)
 {
     const u32 claims = ARMSX2DerivePerGameHackClaims(si);
@@ -2165,9 +2163,8 @@ static void ARMSX2WriteGameSettingsForIdentity(const std::string& serial,
         else
             si.DeleteValue("EmuCore/GS", "UserHacks_TCOffsetY");
 
-        // Overriding a hack for one game only counts if the GameDB stops writing that
-        // hack for that game, so the claim mask goes in this file too. Derived from the
-        // keys just written; the core folds the global claims back in at load.
+        // Derived from the keys just written, so the GameDB stops writing them for
+        // this game. The core folds the global claims back in at load.
         ARMSX2StoreDerivedPerGameHackClaims(si);
 
         if (skipDrawStartOverride)

--- a/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
@@ -1001,10 +1001,20 @@ final class SettingsStore {
     /// The single write funnel for those hacks. They live in a dictionary rather
     /// than a Setting<T>, so the default EmuCore/GS apply hook cannot reach them;
     /// this is their equivalent. Everything that changes one goes through here.
+    // The three keys the GameDB also writes; the rest have no pin bit in the core.
+    private static let pinnableBoolHacks: Set<String> = [
+        "UserHacks_NativePaletteDraw",
+        "UserHacks_DisablePartialInvalidation",
+        "preload_frame_with_gs_data"
+    ]
+
     func setGSBoolHack(_ key: String, _ value: Bool) {
         gsBoolHacks[key] = value
         guard !suppressINIWrites else { return }
         ARMSX2Bridge.setINIBool("EmuCore/GS", key: key, value: value)
+        if Self.pinnableBoolHacks.contains(key) {
+            ARMSX2Bridge.setGraphicsHackPinned(key, pinned: true)
+        }
         requestGraphicsApplyGuarded()
     }
 

--- a/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
@@ -973,6 +973,24 @@ final class SettingsStore {
         requestGraphicsApplyGuarded()
     }
 
+    /// Unpinning hands the hack back to the automatics, so the stored value goes back
+    /// to its default too, or the row keeps showing a value the core will discard.
+    func resetGraphicsHackValue(_ key: String) {
+        switch key {
+        case "UserHacks_align_sprite_X": alignSprite = false
+        case "UserHacks_merge_pp_sprite": mergeSprite = false
+        case "UserHacks_round_sprite_offset": roundSprite = 0
+        case "UserHacks_HalfPixelOffset": halfPixelOffset = 0
+        case "UserHacks_ForceEvenSpritePosition": wildArmsOffset = false
+        case "UserHacks_native_scaling": nativeScaling = 0
+        case "UserHacks_TCOffsetX": textureOffsetX = 0
+        case "UserHacks_TCOffsetY": textureOffsetY = 0
+        case "UserHacks_TextureInsideRt": textureInsideRt = 0
+        case "UserHacks_BilinearHack": bilinearUpscaleHack = 0
+        default: setGSBoolHack(key, false)
+        }
+    }
+
     /// Homogeneous bool GS hacks — see SettingsStore+Graphics.swift for the option list.
     var gsBoolHacks: [String: Bool] = [:]
 

--- a/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
+++ b/platforms/ios/app/src/main/swift/Models/SettingsStore.swift
@@ -1841,13 +1841,9 @@ final class SettingsStore {
         normalizeDEV9Settings()
         VPadSkinLibraryStore.shared.adoptLegacySelection(virtualPadSkin)
         _aspectRatioConfig.write(aspectRatio)
-        // Do NOT re-apply the OSD preset here. The saved per-item OSD flags are the
-        // source of truth and are pushed into the live GSConfig natively by
-        // ARMSX2ApplyIOSOsdPresetFromConfig() at scene startup. Calling
-        // applyOsdPreset(preset) at load rewrote every flag from the preset and
-        // discarded the user settings.
-        // Seed the Custom OSD snapshot once from the loaded flags so cycling to Custom
-        // before any manual edit shows the current set rather than an empty overlay.
+        // The saved per-item flags are the source of truth, so applying the preset here
+        // would rewrite every one of them. Seed the Custom snapshot once instead, or
+        // cycling to Custom shows an empty overlay.
         if !ARMSX2Bridge.getINIBool("ARMSX2iOS/UI", key: "OsdCustomSeeded", defaultValue: false) {
             snapshotCustomOsd()
             ARMSX2Bridge.setINIBool("ARMSX2iOS/UI", key: "OsdCustomSeeded", value: true)
@@ -2016,13 +2012,9 @@ final class SettingsStore {
 
     func setRuntimeFastForwardEnabled(_ enabled: Bool) {
         fastForwardRuntimeEnabled = enabled
-        // Fast forward is purely a limiter-mode switch (Nominal <-> Turbo). The
-        // previous implementation also flipped frameLimiterEnabled, whose didSet
-        // writes NominalScalar=10 to the INI — that made the OSD report T: 1000%
-        // (the Nominal scalar) while the real turbo target was the FF scalar, and
-        // churned the INI on every toggle. Turbo mode alone is sufficient: the
-        // core computes the target from TurboScalar while in Turbo, and switching
-        // back to Nominal restores the user's normal target (T: 100%).
+        // Purely a limiter mode switch. Touching frameLimiterEnabled as well writes
+        // NominalScalar=10, which makes the OSD report the nominal scalar rather than
+        // the turbo target and churns the INI on every toggle.
         if enabled {
             NSLog("@@FF_UI@@ enabled=1 turbo=%.3f", fastForwardScalar)
             ARMSX2Bridge.setLimiterMode(1)

--- a/platforms/ios/app/src/main/swift/Views/PerGameSettingsPanel.swift
+++ b/platforms/ios/app/src/main/swift/Views/PerGameSettingsPanel.swift
@@ -76,12 +76,9 @@ struct PerGameSettingsPanel: View {
     @State private var trilinearFiltering: Int
     @State private var halfPixelOffset: Int
     @State private var roundSprite: Int
-    @State private var alignSpriteOverride: Bool
-    @State private var alignSprite: Bool
-    @State private var mergeSpriteOverride: Bool
-    @State private var mergeSprite: Bool
-    @State private var wildArmsOffsetOverride: Bool
-    @State private var wildArmsOffset: Bool
+    @State private var alignSprite: Int
+    @State private var mergeSprite: Int
+    @State private var wildArmsOffset: Int
     @State private var textureOffsetXOverride: Bool
     @State private var textureOffsetX: Int
     @State private var textureOffsetYOverride: Bool
@@ -209,12 +206,9 @@ struct PerGameSettingsPanel: View {
         _trilinearFiltering = State(initialValue: Self.boolValue(info["hasTrilinearFilteringOverride"], defaultValue: false) ? Self.intValue(info["trilinearFiltering"], defaultValue: -1) : Self.trilinearUseGlobalSentinel)
         _halfPixelOffset = State(initialValue: Self.boolValue(info["hasHalfPixelOffsetOverride"], defaultValue: false) ? Self.intValue(info["halfPixelOffset"], defaultValue: 0) : Self.useGlobalSentinel)
         _roundSprite = State(initialValue: Self.boolValue(info["hasRoundSpriteOverride"], defaultValue: false) ? Self.intValue(info["roundSprite"], defaultValue: 0) : Self.useGlobalSentinel)
-        _alignSpriteOverride = State(initialValue: Self.boolValue(info["hasAlignSpriteOverride"], defaultValue: false))
-        _alignSprite = State(initialValue: Self.boolValue(info["alignSprite"], defaultValue: false))
-        _mergeSpriteOverride = State(initialValue: Self.boolValue(info["hasMergeSpriteOverride"], defaultValue: false))
-        _mergeSprite = State(initialValue: Self.boolValue(info["mergeSprite"], defaultValue: false))
-        _wildArmsOffsetOverride = State(initialValue: Self.boolValue(info["hasWildArmsOffsetOverride"], defaultValue: false))
-        _wildArmsOffset = State(initialValue: Self.boolValue(info["wildArmsOffset"], defaultValue: false))
+        _alignSprite = State(initialValue: Self.boolValue(info["hasAlignSpriteOverride"], defaultValue: false) ? (Self.boolValue(info["alignSprite"], defaultValue: false) ? 1 : 0) : Self.useGlobalSentinel)
+        _mergeSprite = State(initialValue: Self.boolValue(info["hasMergeSpriteOverride"], defaultValue: false) ? (Self.boolValue(info["mergeSprite"], defaultValue: false) ? 1 : 0) : Self.useGlobalSentinel)
+        _wildArmsOffset = State(initialValue: Self.boolValue(info["hasWildArmsOffsetOverride"], defaultValue: false) ? (Self.boolValue(info["wildArmsOffset"], defaultValue: false) ? 1 : 0) : Self.useGlobalSentinel)
         _textureOffsetXOverride = State(initialValue: Self.boolValue(info["hasTextureOffsetXOverride"], defaultValue: false))
         _textureOffsetX = State(initialValue: Self.clampedTextureOffset(Self.intValue(info["textureOffsetX"], defaultValue: 0)))
         _textureOffsetYOverride = State(initialValue: Self.boolValue(info["hasTextureOffsetYOverride"], defaultValue: false))
@@ -350,7 +344,7 @@ struct PerGameSettingsPanel: View {
     /// there is never anything of its own left for Save to commit.
     private func perGameFingerprint() -> String {
         let fixes = SettingsStore.gameFixOptions.map { "\($0.key):\(perGameFixes[$0.key] ?? -1)" }.joined(separator: ",")
-        return "\(enabled)|\(upscaleMultiplier)|\(aspectRatio)|\(textureFiltering)|\(hardwareMipmapping)|\(blendingAccuracy)|\(interlaceMode)|\(trilinearFiltering)|\(halfPixelOffset)|\(roundSprite)|\(alignSpriteOverride)|\(alignSprite)|\(mergeSpriteOverride)|\(mergeSprite)|\(wildArmsOffsetOverride)|\(wildArmsOffset)|\(textureOffsetXOverride)|\(textureOffsetX)|\(textureOffsetYOverride)|\(textureOffsetY)|\(skipDrawStartOverride)|\(skipDrawStart)|\(skipDrawEndOverride)|\(skipDrawEnd)|\(volumeOverride)|\(volumePercent)|\(eeCoreType)|\(mtvu)|\(eeCycleRate)|\(eeCycleSkip)|\(fastBoot)|\(enableCheats)|\(enablePatches)|\(enableGameFixes)|\(enableGameDBHardwareFixes)|\(perGameAAT)|\(perGameTextureInsideRt)|\(perGameRenderer)|\(perGameFXAA)|\(perGameUpscaler)|\(perGameShadeBoost)|\(perGameTVShader)|\(perGameCASMode)|\(perGameMaxAnisotropy)|\(perGameCASSharpness)|\(perGamePCRTCOffsets)|\(perGameIntegerScaling)|\(perGameSkipDupFrames)|\(perGamePCRTCOverscan)|\(perGamePCRTCAntiBlur)|\(perGameDisableInterlaceOffset)|\(perGameWidescreen)|\(perGameNoInterlace)|\(perGameShadeBoostBrightness)|\(perGameShadeBoostContrast)|\(perGameShadeBoostSaturation)|\(perGameShadeBoostGamma)|\(perGameDithering)|\(perGameFastForwardVolume)|\(perGameIOP)|\(perGameVU0)|\(perGameVU1)|\(perGameHWDownloadMode)|\(perGameCPUCLUT)|\(perGameGPUTargetCLUT)|\(perGameVsyncQueue)|\(perGameLoadTextureReplacements)|\(perGameLoadTextureReplacementsAsync)|\(perGamePrecacheTextureReplacements)|\(perGameSyncToHostRefresh)|\(perGameBufferMS)|\(perGameOutputLatencyMS)|\(perGameEEFpuRound)|\(perGameVU0Round)|\(perGameVU1Round)|\(perGameEEClamp)|\(perGameVUClamp)|\(raEnabledOverride)|\(raHardcoreOverride)|\(perGameFramePacingPreset)|\(perGameFrameLimiter)|\(perGameTargetFPS)|\(fixes)"
+        return "\(enabled)|\(upscaleMultiplier)|\(aspectRatio)|\(textureFiltering)|\(hardwareMipmapping)|\(blendingAccuracy)|\(interlaceMode)|\(trilinearFiltering)|\(halfPixelOffset)|\(roundSprite)|\(alignSprite)|\(mergeSprite)|\(wildArmsOffset)|\(textureOffsetXOverride)|\(textureOffsetX)|\(textureOffsetYOverride)|\(textureOffsetY)|\(skipDrawStartOverride)|\(skipDrawStart)|\(skipDrawEndOverride)|\(skipDrawEnd)|\(volumeOverride)|\(volumePercent)|\(eeCoreType)|\(mtvu)|\(eeCycleRate)|\(eeCycleSkip)|\(fastBoot)|\(enableCheats)|\(enablePatches)|\(enableGameFixes)|\(enableGameDBHardwareFixes)|\(perGameAAT)|\(perGameTextureInsideRt)|\(perGameRenderer)|\(perGameFXAA)|\(perGameUpscaler)|\(perGameShadeBoost)|\(perGameTVShader)|\(perGameCASMode)|\(perGameMaxAnisotropy)|\(perGameCASSharpness)|\(perGamePCRTCOffsets)|\(perGameIntegerScaling)|\(perGameSkipDupFrames)|\(perGamePCRTCOverscan)|\(perGamePCRTCAntiBlur)|\(perGameDisableInterlaceOffset)|\(perGameWidescreen)|\(perGameNoInterlace)|\(perGameShadeBoostBrightness)|\(perGameShadeBoostContrast)|\(perGameShadeBoostSaturation)|\(perGameShadeBoostGamma)|\(perGameDithering)|\(perGameFastForwardVolume)|\(perGameIOP)|\(perGameVU0)|\(perGameVU1)|\(perGameHWDownloadMode)|\(perGameCPUCLUT)|\(perGameGPUTargetCLUT)|\(perGameVsyncQueue)|\(perGameLoadTextureReplacements)|\(perGameLoadTextureReplacementsAsync)|\(perGamePrecacheTextureReplacements)|\(perGameSyncToHostRefresh)|\(perGameBufferMS)|\(perGameOutputLatencyMS)|\(perGameEEFpuRound)|\(perGameVU0Round)|\(perGameVU1Round)|\(perGameEEClamp)|\(perGameVUClamp)|\(raEnabledOverride)|\(raHardcoreOverride)|\(perGameFramePacingPreset)|\(perGameFrameLimiter)|\(perGameTargetFPS)|\(fixes)"
     }
 
     private var hasPendingChanges: Bool {
@@ -631,11 +625,8 @@ struct PerGameSettingsPanel: View {
             trilinearFiltering: $trilinearFiltering,
             halfPixelOffset: $halfPixelOffset,
             roundSprite: $roundSprite,
-            alignSpriteOverride: $alignSpriteOverride,
             alignSprite: $alignSprite,
-            mergeSpriteOverride: $mergeSpriteOverride,
             mergeSprite: $mergeSprite,
-            wildArmsOffsetOverride: $wildArmsOffsetOverride,
             wildArmsOffset: $wildArmsOffset,
             textureOffsetXOverride: $textureOffsetXOverride,
             textureOffsetX: $textureOffsetX,
@@ -1073,12 +1064,9 @@ struct PerGameSettingsPanel: View {
                 trilinearFiltering: Int32(trilinearFiltering),
                 halfPixelOffset: Int32(halfPixelOffset),
                 roundSprite: Int32(roundSprite),
-                alignSpriteOverride: alignSpriteOverride,
-                alignSprite: alignSprite,
-                mergeSpriteOverride: mergeSpriteOverride,
-                mergeSprite: mergeSprite,
-                wildArmsOffsetOverride: wildArmsOffsetOverride,
-                wildArmsOffset: wildArmsOffset,
+                alignSprite: Int32(alignSprite),
+                mergeSprite: Int32(mergeSprite),
+                wildArmsOffset: Int32(wildArmsOffset),
                 textureOffsetXOverride: textureOffsetXOverride,
                 textureOffsetX: Int32(textureOffsetX),
                 textureOffsetYOverride: textureOffsetYOverride,
@@ -1113,12 +1101,9 @@ struct PerGameSettingsPanel: View {
                 trilinearFiltering: Int32(trilinearFiltering),
                 halfPixelOffset: Int32(halfPixelOffset),
                 roundSprite: Int32(roundSprite),
-                alignSpriteOverride: alignSpriteOverride,
-                alignSprite: alignSprite,
-                mergeSpriteOverride: mergeSpriteOverride,
-                mergeSprite: mergeSprite,
-                wildArmsOffsetOverride: wildArmsOffsetOverride,
-                wildArmsOffset: wildArmsOffset,
+                alignSprite: Int32(alignSprite),
+                mergeSprite: Int32(mergeSprite),
+                wildArmsOffset: Int32(wildArmsOffset),
                 textureOffsetXOverride: textureOffsetXOverride,
                 textureOffsetX: Int32(textureOffsetX),
                 textureOffsetYOverride: textureOffsetYOverride,

--- a/platforms/ios/app/src/main/swift/Views/PerGameSettingsPanel.swift
+++ b/platforms/ios/app/src/main/swift/Views/PerGameSettingsPanel.swift
@@ -1337,12 +1337,9 @@ struct PerGameSettingsPanel: View {
         } else {
             Self.clearPerGameValue("ARMSX2iOS/FramePacing", "Preset", useCurrent: useCurrent, iso: iso)
         }
-        // Cascade the preset's individual keys when a named preset is picked
-        // per-game (raw values 0...3). FramePacingPreset(rawValue:) returns nil
-        // for Use Global (-1); framePacingPresetTable[preset] returns nil for
-        // .custom (raw 4 — not in the table). Placed after the individual-key
-        // writes above so the named preset's curated profile wins over stale
-        // per-game Picker state.
+        // Cascade a named preset's own keys. Use Global and .custom both miss the
+        // table and fall through. After the individual writes on purpose, so the
+        // preset's profile wins over stale per-game picker state.
         if enabled, let preset = FramePacingPreset(rawValue: perGameFramePacingPreset),
            let values = SettingsStore.framePacingPresetTable[preset] {
             Self.setPerGameIntValue("EmuCore/GS", "VsyncQueueSize", values.vsyncQueueSize, useCurrent: useCurrent, iso: iso)

--- a/platforms/ios/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
@@ -46,6 +46,7 @@ struct GraphicsSettingsView: View {
             }
             if status.pinned {
                 Button(settings.localized("Use the game database value")) {
+                    // Reset first; the value write may pin again, so the unpin must come last.
                     settings.resetGraphicsHackValue(key)
                     settings.setGraphicsHackPinned(key, false)
                 }
@@ -370,18 +371,21 @@ struct GraphicsSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                intPicker("Texture Inside RT", selection: $settings.textureInsideRt, shared: SettingsOptions.textureInsideRT)
+                intPicker("Texture Inside RT", selection: claiming("UserHacks_TextureInsideRt", $settings.textureInsideRt), shared: SettingsOptions.textureInsideRT)
+                hackNote("UserHacks_TextureInsideRt", shown: settings.textureInsideRt)
                 intPicker("Limit 24-Bit Depth", selection: $settings.limit24BitDepth, options: [
                     ("Off", 0), ("Prioritise Upper Bits", 1), ("Prioritise Lower Bits", 2)
                 ])
-                intPicker("Native Scaling", selection: $settings.nativeScaling, options: [
+                intPicker("Native Scaling", selection: claiming("UserHacks_native_scaling", $settings.nativeScaling), options: [
                     ("Off", 0), ("Normal", 1), ("Aggressive", 2), ("Normal (Maintain Upscale)", 3), ("Aggressive (Maintain Upscale)", 4)
                 ])
+                hackNote("UserHacks_native_scaling", shown: settings.nativeScaling)
                 intPicker("CPU CLUT Render", selection: $settings.cpuClutRender, shared: SettingsOptions.cpuClutRender)
                 intPicker("GPU Target CLUT", selection: $settings.gpuTargetClut, shared: SettingsOptions.gpuTargetClut)
-                intPicker("Bilinear Upscale", selection: $settings.bilinearUpscaleHack, options: [
+                intPicker("Bilinear Upscale", selection: claiming("UserHacks_BilinearHack", $settings.bilinearUpscaleHack), options: [
                     ("Automatic", 0), ("Force Bilinear", 1), ("Force Nearest", 2)
                 ])
+                hackNote("UserHacks_BilinearHack", shown: settings.bilinearUpscaleHack)
                 NumberRow(.cpuSpriteRenderBw, value: $settings.cpuSpriteRenderBw,
                           settings: settings)
                 intPicker("CPU Sprite Render Level", selection: $settings.cpuSpriteRenderLevel,
@@ -395,6 +399,7 @@ struct GraphicsSettingsView: View {
                         get: { settings.gsBoolHackEnabled(option.key) },
                         set: { settings.setGSBoolHack(option.key, $0) }
                     ))
+                    hackNote(option.key, shown: settings.gsBoolHackEnabled(option.key) ? 1 : 0)
                 }
             } header: {
                 Text(settings.localized("Hardware Fixes"))

--- a/platforms/ios/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
@@ -217,8 +217,7 @@ struct GraphicsSettingsView: View {
 
             Section(settings.localized("Display")) {
                 Picker(settings.localized("Deinterlace"), selection: $settings.interlaceMode) {
-                    // Tags are GSInterlaceMode values. This list used to be shifted by one, so
-                    // every label from Weave down named the mode below it.
+                    // Tags are GSInterlaceMode values; a shift by one renames every mode.
                     Text(settings.localized("Automatic (Default)")).tag(0)
                     Text(settings.localized("Off (No Deinterlacing)")).tag(1)
                     Text(settings.localized("Weave (TFF)")).tag(2)

--- a/platforms/ios/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift
@@ -46,6 +46,7 @@ struct GraphicsSettingsView: View {
             }
             if status.pinned {
                 Button(settings.localized("Use the game database value")) {
+                    settings.resetGraphicsHackValue(key)
                     settings.setGraphicsHackPinned(key, false)
                 }
                 .font(.caption)

--- a/platforms/ios/app/src/main/swift/Views/Settings/PerGame/GraphicsTab.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/PerGame/GraphicsTab.swift
@@ -276,12 +276,12 @@ struct GraphicsTab: View {
         }
 
         Section(settings.localized("Advanced Upscaling Hacks")) {
-            Text(settings.localized("Manual advanced hacks only apply when Use Per-Game Overrides is on and GameDB Graphics Fixes is off. " + (savesToRunningGame ? "They apply when you save." : "They apply on next boot.")))
+            Text(settings.localized("A hack you set here outranks the game database for this game, and everything on Use Global stays automatic. " + (savesToRunningGame ? "Changes apply when you save." : "Changes apply on next boot.")))
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
             if enabled && enableGameDBHardwareFixes {
-                Text(settings.localized("GameDB Graphics Fixes is on, so manual advanced hacks are saved but ignored until it is turned off for this game."))
+                Text(settings.localized("Skipdraw is the exception: it only applies while GameDB Graphics Fixes is off for this game."))
                     .font(.caption)
                     .foregroundStyle(.orange)
             }
@@ -298,45 +298,45 @@ struct GraphicsTab: View {
 
             sharedPicker("Half-pixel Offset", selection: $halfPixelOffset,
                          Self.halfPixelOffsetOptions)
-                .disabled(!manualAdvancedHacksEnabled)
+                .disabled(!enabled)
 
             sharedPicker("Round Sprite", selection: $roundSprite,
                          Self.roundSpriteOptions)
-                .disabled(!manualAdvancedHacksEnabled)
+                .disabled(!enabled)
 
             Picker(settings.localized("Align Sprite"), selection: $alignSprite) {
                 Text(settings.localized("Use Global")).tag(Self.useGlobalSentinel)
                 Text(settings.localized("Off")).tag(0)
                 Text(settings.localized("On")).tag(1)
             }
-            .disabled(!manualAdvancedHacksEnabled)
+            .disabled(!enabled)
 
             Picker(settings.localized("Merge Sprite"), selection: $mergeSprite) {
                 Text(settings.localized("Use Global")).tag(Self.useGlobalSentinel)
                 Text(settings.localized("Off")).tag(0)
                 Text(settings.localized("On")).tag(1)
             }
-            .disabled(!manualAdvancedHacksEnabled)
+            .disabled(!enabled)
 
             Picker(settings.localized("Wild Arms Offset"), selection: $wildArmsOffset) {
                 Text(settings.localized("Use Global")).tag(Self.useGlobalSentinel)
                 Text(settings.localized("Off")).tag(0)
                 Text(settings.localized("On")).tag(1)
             }
-            .disabled(!manualAdvancedHacksEnabled)
+            .disabled(!enabled)
 
             Toggle(settings.localized("Override Texture Offset X"), isOn: $textureOffsetXOverride)
-                .disabled(!manualAdvancedHacksEnabled)
+                .disabled(!enabled)
             if textureOffsetXOverride {
                 NumberRow(.textureOffsetX, value: $textureOffsetX, settings: settings)
-                    .disabled(!manualAdvancedHacksEnabled)
+                    .disabled(!enabled)
             }
 
             Toggle(settings.localized("Override Texture Offset Y"), isOn: $textureOffsetYOverride)
-                .disabled(!manualAdvancedHacksEnabled)
+                .disabled(!enabled)
             if textureOffsetYOverride {
                 NumberRow(.textureOffsetY, value: $textureOffsetY, settings: settings)
-                    .disabled(!manualAdvancedHacksEnabled)
+                    .disabled(!enabled)
             }
 
             Toggle(settings.localized("Override Skipdraw Start"), isOn: $skipDrawStartOverride)

--- a/platforms/ios/app/src/main/swift/Views/Settings/PerGame/GraphicsTab.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/PerGame/GraphicsTab.swift
@@ -247,8 +247,7 @@ struct GraphicsTab: View {
             .disabled(!enabled)
         }
 
-        // Its own section, the way the global screen has it. The header is what lets the four rows
-        // be called Brightness and Contrast rather than repeating Shade Boost four times.
+        // Its own section, as on the global screen, so the four rows can be named plainly.
         Section(settings.localized("Shade Boost")) {
             Picker(settings.localized("Shade Boost"), selection: $perGameShadeBoost) {
                 Text(settings.localized("Use Global")).tag(-1)

--- a/platforms/ios/app/src/main/swift/Views/Settings/PerGame/GraphicsTab.swift
+++ b/platforms/ios/app/src/main/swift/Views/Settings/PerGame/GraphicsTab.swift
@@ -24,12 +24,9 @@ struct GraphicsTab: View {
     @Binding var trilinearFiltering: Int
     @Binding var halfPixelOffset: Int
     @Binding var roundSprite: Int
-    @Binding var alignSpriteOverride: Bool
-    @Binding var alignSprite: Bool
-    @Binding var mergeSpriteOverride: Bool
-    @Binding var mergeSprite: Bool
-    @Binding var wildArmsOffsetOverride: Bool
-    @Binding var wildArmsOffset: Bool
+    @Binding var alignSprite: Int
+    @Binding var mergeSprite: Int
+    @Binding var wildArmsOffset: Int
     @Binding var textureOffsetXOverride: Bool
     @Binding var textureOffsetX: Int
     @Binding var textureOffsetYOverride: Bool
@@ -307,26 +304,26 @@ struct GraphicsTab: View {
                          Self.roundSpriteOptions)
                 .disabled(!manualAdvancedHacksEnabled)
 
-            Toggle(settings.localized("Override Align Sprite"), isOn: $alignSpriteOverride)
-                .disabled(!manualAdvancedHacksEnabled)
-            if alignSpriteOverride {
-                Toggle(settings.localized("Align Sprite"), isOn: $alignSprite)
-                    .disabled(!manualAdvancedHacksEnabled)
+            Picker(settings.localized("Align Sprite"), selection: $alignSprite) {
+                Text(settings.localized("Use Global")).tag(Self.useGlobalSentinel)
+                Text(settings.localized("Off")).tag(0)
+                Text(settings.localized("On")).tag(1)
             }
+            .disabled(!manualAdvancedHacksEnabled)
 
-            Toggle(settings.localized("Override Merge Sprite"), isOn: $mergeSpriteOverride)
-                .disabled(!manualAdvancedHacksEnabled)
-            if mergeSpriteOverride {
-                Toggle(settings.localized("Merge Sprite"), isOn: $mergeSprite)
-                    .disabled(!manualAdvancedHacksEnabled)
+            Picker(settings.localized("Merge Sprite"), selection: $mergeSprite) {
+                Text(settings.localized("Use Global")).tag(Self.useGlobalSentinel)
+                Text(settings.localized("Off")).tag(0)
+                Text(settings.localized("On")).tag(1)
             }
+            .disabled(!manualAdvancedHacksEnabled)
 
-            Toggle(settings.localized("Override Wild Arms Offset"), isOn: $wildArmsOffsetOverride)
-                .disabled(!manualAdvancedHacksEnabled)
-            if wildArmsOffsetOverride {
-                Toggle(settings.localized("Wild Arms Offset"), isOn: $wildArmsOffset)
-                    .disabled(!manualAdvancedHacksEnabled)
+            Picker(settings.localized("Wild Arms Offset"), selection: $wildArmsOffset) {
+                Text(settings.localized("Use Global")).tag(Self.useGlobalSentinel)
+                Text(settings.localized("Off")).tag(0)
+                Text(settings.localized("On")).tag(1)
             }
+            .disabled(!manualAdvancedHacksEnabled)
 
             Toggle(settings.localized("Override Texture Offset X"), isOn: $textureOffsetXOverride)
                 .disabled(!manualAdvancedHacksEnabled)

--- a/platforms/ios/scripts/tests/test_ios_hack_claims.py
+++ b/platforms/ios/scripts/tests/test_ios_hack_claims.py
@@ -1,0 +1,55 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[4]
+BRIDGE = ROOT / "platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm"
+GRAPHICS_VIEW = ROOT / "platforms/ios/app/src/main/swift/Views/Settings/GraphicsSettingsView.swift"
+STORE = ROOT / "platforms/ios/app/src/main/swift/Models/SettingsStore.swift"
+
+HACK_TABLE = re.compile(r'\{"([\w_]+)", GSUserHackOverride::\w+')
+PINNED_KEYS = re.compile(r'\{"([\w_]+)", GSUserHackOverride::\w+\},')
+
+
+class HackClaimPlumbing(unittest.TestCase):
+    def setUp(self):
+        self.bridge = BRIDGE.read_text()
+        self.view = GRAPHICS_VIEW.read_text()
+        self.store = STORE.read_text()
+
+    def table_keys(self):
+        block = self.bridge.split("s_graphics_hacks = {{", 1)[1].split("}};", 1)[0]
+        return HACK_TABLE.findall(block)
+
+    def pinned_hack_keys(self):
+        block = self.bridge.split("s_pinned_hack_keys[] = {", 1)[1].split("};", 1)[0]
+        return PINNED_KEYS.findall(block)
+
+    def test_every_reported_hack_row_claims_on_write(self):
+        """A hack the bridge reports must pin when its global row changes, or the
+        GameDB silently overwrites it and the row lies."""
+        bool_hack_pins = re.search(
+            r"pinnableBoolHacks: Set<String> = \[(.*?)\]", self.store, re.S)
+        pinned_via_bool = set(re.findall(r'"([\w_]+)"', bool_hack_pins.group(1)))
+        for key in self.table_keys():
+            with self.subTest(key=key):
+                claimed = f'claiming("{key}"' in self.view or key in pinned_via_bool
+                self.assertTrue(claimed, f"{key} is reported but never pinned from the UI")
+
+    def test_every_reported_hack_is_a_pinned_key(self):
+        """The writer derives per-game claims from s_pinned_hack_keys, so a reported
+        hack missing there loses its per-game claim on save."""
+        pinned = set(self.pinned_hack_keys())
+        for key in self.table_keys():
+            with self.subTest(key=key):
+                self.assertIn(key, pinned)
+
+    def test_writer_never_merges_global_claims(self):
+        """The core folds base claims across the layers now; freezing them into a
+        game file is the leak that suppressed database fixes forever."""
+        self.assertNotIn("globalClaims", self.bridge)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* Align Sprite and Merge Sprite finally turn off when you turn them off. This report has come back three times and survived five earlier fixes, every one of which landed on the global screen and left the per game path alone.
* The per game rows were the trap. They greyed out whenever GameDB Graphics Fixes was on, kept showing the old value, and the save kept writing it, so the hack stayed live in game with no way out except the per game master toggle.
* Align Sprite, Merge Sprite and Wild Arms Offset are now one Use Global, Off, On picker each, matching every other row on that tab, and they no longer need manual hacks mode. Skipdraw still does, because the core has no claim bit for it, and the captions now say so.
* A per game file used to freeze the global claim mask inside itself. The game layer replaces that key rather than merging it, so a later global unpin could never reach that game and its database fixes stayed suppressed for good. The core folds the base claims back in at load now, the writer stores only what the game itself claims, and a file with a stale mask is repaired when its panel opens.
* Saving per game settings refreshes the effective hack notes, so a change that worked stops reading as stuck.
* Unpinning a hack with Use the game database value also writes its default back, so a row can no longer show a value the core is discarding.
* Texture Inside RT, Native Scaling, Bilinear Upscale, Unscaled Palette Draw, Preload Frame Data and Disable Partial Invalidation had the same defect and never claimed anything. They claim now, with working notes and unpin buttons.
* Three source assertions guard the plumbing: every reported hack claims from its row, every reported hack is in the per game derivation table, and the writer can never grow the global claim merge back.
* Verified on the simulator down to the INI file: setting a hack writes only that game's claim bit, Use Global removes both the key and the bit, and a hand corrupted mask is repaired on the next panel open. The visible half needs a device at 2x internal resolution or higher, since the core masks these hacks off at native resolution by design.
