### PR TITLE
GS: query ShouldSkipPresentingFrame() only once per VSync

### DIFF
--- a/pcsx2/GS/Renderers/Common/GSDevice.h
+++ b/pcsx2/GS/Renderers/Common/GSDevice.h
@@ -1791,6 +1791,11 @@ public:
 	virtual std::vector<std::string> GetExtendedStats() const { return {}; }
 
 	/// Returns true if not enough time has passed for present to not block.
+	/// ⚠️ Not a pure query: answering "present" books this frame as the one that was displayed,
+	/// so the next call within the same throttle period answers "skip". Ask exactly once per
+	/// vsync, at the point the decision is acted on. A second caller — even a diagnostic that
+	/// only reads the result — spends the credit and freezes the picture for as long as the
+	/// throttle is armed.
 	bool ShouldSkipPresentingFrame();
 
 	/// Sleeps to the time the next frame can be displayed.

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -17,7 +17,6 @@
 #endif
 #include "Host.h"
 #include "PerformanceMetrics.h"
-#include "common/Console.h" // @@ANDROID_STALEFRAMES@@ diagnostic
 #include "common/HostSys.h" // GetCPUTicks — present-cap pacer
 #include "pcsx2/Config.h"
 #include "VMManager.h"
@@ -797,9 +796,6 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 	//
 	// Manual skipping omits presentation only. Platform-opted FPS caps may additionally omit final
 	// composition after Merge() has verified the current outputs; emulation and GS writes still run.
-	// Set when the user ASKED for a dropped present, so the stale-frame diagnostic below doesn't
-	// report their own frame-skip/FPS-cap settings as a fault.
-	bool deliberate_present_skip = false;
 	bool fps_cap_present_skip = false;
 	{
 		const u32 manual_skip = GSGetManualFrameSkip();
@@ -808,10 +804,7 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 			// Present 1 frame in every (manual_skip + 1).
 			m_manual_frameskip_phase = (m_manual_frameskip_phase + 1) % (manual_skip + 1);
 			if (m_manual_frameskip_phase != 0)
-			{
 				skip_frame = true;
-				deliberate_present_skip = true;
-			}
 		}
 		else
 		{
@@ -835,7 +828,6 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 				if (now < m_next_present_deadline)
 				{
 					skip_frame = true;
-					deliberate_present_skip = true;
 					fps_cap_present_skip = true;
 				}
 				else if ((now - m_next_present_deadline) > interval)
@@ -928,58 +920,10 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 	constexpr bool skip_blank = false;
 #endif
 
-	// ShouldSkipPresentingFrame() is stateful: when it answers "present" it consumes the
-	// present-throttle credit (m_last_frame_displayed_time), so it must be queried at most
-	// once per vsync. The stale-frame diagnostic below used to make up to two extra calls,
-	// eating the credit before the present decision ever saw it — with FIFO + throttle
-	// (fast forward with vsync on; Metal coerces Mailbox to FIFO) the real present was then
-	// skipped every frame and the picture froze while emulation kept running. Frames already
-	// being skipped bypass the query so they don't consume credit, preserving the original
-	// short-circuit behaviour.
-	const bool device_present_throttled =
-		!skip_frame && !skip_blank && g_gs_device->ShouldSkipPresentingFrame();
-
-	// ★ @@ANDROID_STALEFRAMES@@ — diagnostic for "the picture freezes but emulation keeps running".
-	// Measured on a Retroid Pocket 6: SurfaceFlinger presents steadily at 120 Hz straight through
-	// the freeze (worst present gap across a whole session was 142 ms, frame count never dipped),
-	// so frame DELIVERY is healthy and a stale image can only come from frame PRODUCTION here.
-	// There are exactly three ways this function fails to put something new on screen: the
-	// duplicate-frame skip above, the device's present throttle, and Merge() yielding nothing.
-	// Logged only when a RUN of such frames ends, and only if it was long enough to be visible, so
-	// a healthy frame costs one branch. GS thread only, hence plain statics.
-	{
-		const bool stale = !deliberate_present_skip &&
-			(skip_frame || blank_frame || device_present_throttled);
-		static u32 s_stale_run = 0, s_stale_skipdup = 0, s_stale_blank = 0, s_stale_throttle = 0;
-		if (stale)
-		{
-			s_stale_run++;
-			if (skip_frame)
-				s_stale_skipdup++;
-			if (blank_frame)
-				s_stale_blank++;
-			if (device_present_throttled)
-				s_stale_throttle++;
-		}
-		else
-		{
-			// ~10 frames is the shortest run a person could notice; below that it is normal churn.
-			if (s_stale_run >= 10)
-			{
-				Console.Warning("@@ANDROID_STALEFRAMES@@ run=%u frames (skipdup=%u blank=%u "
-								"throttle=%u) fpsmethod=%d",
-					s_stale_run, s_stale_skipdup, s_stale_blank, s_stale_throttle,
-					static_cast<int>(PerformanceMetrics::GetInternalFPSMethod()));
-			}
-			s_stale_run = 0;
-			s_stale_skipdup = 0;
-			s_stale_blank = 0;
-			s_stale_throttle = 0;
-		}
-	}
-
-	// Skip presentation when running uncapped while vsync is on.
-	if (skip_frame || skip_blank || device_present_throttled)
+	// Skip presentation when running uncapped while vsync is on. ShouldSkipPresentingFrame()
+	// consumes the present-throttle credit when it answers "present", so it belongs last in
+	// this disjunction and nowhere else in the function — see its declaration.
+	if (skip_frame || skip_blank || g_gs_device->ShouldSkipPresentingFrame())
 	{
 		if (BeginPresentFrame(true))
 			EndPresentFrame();

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -891,45 +891,6 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 	if (!skipped_final_render)
 		m_consecutive_blank_frames = blank_frame ? (m_consecutive_blank_frames + 1) : 0;
 
-	// ★ @@ANDROID_STALEFRAMES@@ — diagnostic for "the picture freezes but emulation keeps running".
-	// Measured on a Retroid Pocket 6: SurfaceFlinger presents steadily at 120 Hz straight through
-	// the freeze (worst present gap across a whole session was 142 ms, frame count never dipped),
-	// so frame DELIVERY is healthy and a stale image can only come from frame PRODUCTION here.
-	// There are exactly three ways this function fails to put something new on screen: the
-	// duplicate-frame skip above, the device's present throttle, and Merge() yielding nothing.
-	// Logged only when a RUN of such frames ends, and only if it was long enough to be visible, so
-	// a healthy frame costs one branch. GS thread only, hence plain statics.
-	{
-		const bool stale = !deliberate_present_skip &&
-			(skip_frame || blank_frame || g_gs_device->ShouldSkipPresentingFrame());
-		static u32 s_stale_run = 0, s_stale_skipdup = 0, s_stale_blank = 0, s_stale_throttle = 0;
-		if (stale)
-		{
-			s_stale_run++;
-			if (skip_frame)
-				s_stale_skipdup++;
-			if (blank_frame)
-				s_stale_blank++;
-			if (g_gs_device->ShouldSkipPresentingFrame())
-				s_stale_throttle++;
-		}
-		else
-		{
-			// ~10 frames is the shortest run a person could notice; below that it is normal churn.
-			if (s_stale_run >= 10)
-			{
-				Console.Warning("@@ANDROID_STALEFRAMES@@ run=%u frames (skipdup=%u blank=%u "
-								"throttle=%u) fpsmethod=%d",
-					s_stale_run, s_stale_skipdup, s_stale_blank, s_stale_throttle,
-					static_cast<int>(PerformanceMetrics::GetInternalFPSMethod()));
-			}
-			s_stale_run = 0;
-			s_stale_skipdup = 0;
-			s_stale_blank = 0;
-			s_stale_throttle = 0;
-		}
-	}
-
 	m_last_draw_n = s_n;
 	m_last_transfer_n = s_transfer_n;
 
@@ -967,8 +928,58 @@ void GSRenderer::VSync(u32 field, bool registers_written, bool idle_frame)
 	constexpr bool skip_blank = false;
 #endif
 
+	// ShouldSkipPresentingFrame() is stateful: when it answers "present" it consumes the
+	// present-throttle credit (m_last_frame_displayed_time), so it must be queried at most
+	// once per vsync. The stale-frame diagnostic below used to make up to two extra calls,
+	// eating the credit before the present decision ever saw it — with FIFO + throttle
+	// (fast forward with vsync on; Metal coerces Mailbox to FIFO) the real present was then
+	// skipped every frame and the picture froze while emulation kept running. Frames already
+	// being skipped bypass the query so they don't consume credit, preserving the original
+	// short-circuit behaviour.
+	const bool device_present_throttled =
+		!skip_frame && !skip_blank && g_gs_device->ShouldSkipPresentingFrame();
+
+	// ★ @@ANDROID_STALEFRAMES@@ — diagnostic for "the picture freezes but emulation keeps running".
+	// Measured on a Retroid Pocket 6: SurfaceFlinger presents steadily at 120 Hz straight through
+	// the freeze (worst present gap across a whole session was 142 ms, frame count never dipped),
+	// so frame DELIVERY is healthy and a stale image can only come from frame PRODUCTION here.
+	// There are exactly three ways this function fails to put something new on screen: the
+	// duplicate-frame skip above, the device's present throttle, and Merge() yielding nothing.
+	// Logged only when a RUN of such frames ends, and only if it was long enough to be visible, so
+	// a healthy frame costs one branch. GS thread only, hence plain statics.
+	{
+		const bool stale = !deliberate_present_skip &&
+			(skip_frame || blank_frame || device_present_throttled);
+		static u32 s_stale_run = 0, s_stale_skipdup = 0, s_stale_blank = 0, s_stale_throttle = 0;
+		if (stale)
+		{
+			s_stale_run++;
+			if (skip_frame)
+				s_stale_skipdup++;
+			if (blank_frame)
+				s_stale_blank++;
+			if (device_present_throttled)
+				s_stale_throttle++;
+		}
+		else
+		{
+			// ~10 frames is the shortest run a person could notice; below that it is normal churn.
+			if (s_stale_run >= 10)
+			{
+				Console.Warning("@@ANDROID_STALEFRAMES@@ run=%u frames (skipdup=%u blank=%u "
+								"throttle=%u) fpsmethod=%d",
+					s_stale_run, s_stale_skipdup, s_stale_blank, s_stale_throttle,
+					static_cast<int>(PerformanceMetrics::GetInternalFPSMethod()));
+			}
+			s_stale_run = 0;
+			s_stale_skipdup = 0;
+			s_stale_blank = 0;
+			s_stale_throttle = 0;
+		}
+	}
+
 	// Skip presentation when running uncapped while vsync is on.
-	if (skip_frame || skip_blank || g_gs_device->ShouldSkipPresentingFrame())
+	if (skip_frame || skip_blank || device_present_throttled)
 	{
 		if (BeginPresentFrame(true))
 			EndPresentFrame();


### PR DESCRIPTION
### Description of Changes

`GSRenderer::VSync()` now queries `g_gs_device->ShouldSkipPresentingFrame()` exactly once per VSync. The single query runs after the `skip_frame`/`skip_blank` decisions — so frames that are already being skipped don't consume throttle credit, preserving the original short-circuit behaviour — and its result is reused by both the `@@ANDROID_STALEFRAMES@@` diagnostic and the present decision. The diagnostic block moves below `skip_blank` so it can share the cached result; its logic is otherwise unchanged.

### Rationale behind Changes

Fixes #557.

`ShouldSkipPresentingFrame()` is stateful: when it answers "present", it consumes the present-throttle credit (`m_last_frame_displayed_time = now`). The stale-frame diagnostic called it up to two extra times per frame before the real present decision ran, eating the credit first. With `m_allow_present_throttle` and FIFO — i.e. fast forward with vsync enabled; Metal coerces `Mailbox → FIFO` — the real decision then skipped the present every frame: the picture froze on the last image while emulation and audio kept running. Android/Vulkan was unaffected (real Mailbox support bails out of the function before any state is touched), which is why this only surfaced on macOS. Upstream PCSX2 queries the function exactly once and has no such freeze.

### Suggested Testing Steps

1. macOS (Apple Silicon), Metal renderer, `VsyncEnable = true` (default). Boot any game.
2. Toggle fast forward repeatedly: without this patch the picture freezes while audio continues; with it, the picture keeps updating (presents throttled to the display refresh rate, as intended).
3. Regression check at normal speed: with vsync on and off, presentation behaves as before (the throttle path is inert outside fast forward).
4. Android: behaviour unchanged — the cached query is equivalent there since the function early-outs on non-FIFO modes.

Tested on an Apple M1 Pro (Darwin 25.5.0) with Rogue Galaxy (PAL), A/B against the stock nightly-20260806 build: stock freezes on every turbo activation, patched build presents correctly through repeated toggles with vsync enabled.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. The bug was diagnosed and the patch implemented with the assistance of Claude Code (Anthropic): it correlated the emulator log's vsync-mode transitions with the present-throttle code path, identified the extra stateful calls by comparing against upstream PCSX2, and drafted this change. The fix was then built and manually verified on real hardware (A/B test above), and the code has been reviewed and is understood by the submitter.

https://claude.ai/code/session_01F429k5AsUh7XXkXjQViVTc
