### PR TITLE
EE cache: fix the DXSTG tag lookup's 29-bit fold, and the tests around it

### DIFF
--- a/pcsx2/Cache.cpp
+++ b/pcsx2/Cache.cpp
@@ -482,13 +482,22 @@ namespace R5900
 						// an MMIO handler page, or a physical address that does not exist --
 						// is marked unbacked; the line still caches and reports its flags,
 						// and loses its data on eviction (see the comment on CacheTag).
+						//
+						// The lookup goes through the physical map, not through the KSEG0
+						// alias of the page: KSEG0 is only 512 MB wide, so routing a
+						// physical page through it meant masking the tag to 29 bits, and
+						// every page at or above 0x20000000 then folded into the low half
+						// of the map and resolved to whatever lives there. A page past the
+						// end of the map folded onto ordinary RAM and the write-back went
+						// into it. vtlb_GetPhyPtr covers the whole 1 GB physical map and
+						// answers null both for a handler page and for an address off the
+						// end of it.
 						const u32 pageTag = cpuRegs.CP0.n.TagLo & ~static_cast<u32>(CacheTag::ALL_BITS);
-						const u32 alias = 0x80000000u | (pageTag & 0x1FFFFFFFu);
-						const VTLBVirtual vmv = vtlbdata.vmap[alias >> VTLB_PAGE_BITS];
-						const bool backed = !vmv.isHandler(alias);
+						void* const host = vtlb_GetPhyPtr(pageTag);
+						const bool backed = host != nullptr;
 
 						line.tag.setValidPFN(backed);
-						line.tag.setAddr(backed ? vmv.assumePtr(alias) : static_cast<uptr>(pageTag));
+						line.tag.setAddr(backed ? reinterpret_cast<uptr>(host) : static_cast<uptr>(pageTag));
 						line.tag.rawValue &= ~CacheTag::ALL_FLAGS;
 						line.tag.rawValue |= (cpuRegs.CP0.n.TagLo & CacheTag::ALL_FLAGS);
 

--- a/tests/ctest/core/recompilers/ee_cache2_console_conformance_tests.cpp
+++ b/tests/ctest/core/recompilers/ee_cache2_console_conformance_tests.cpp
@@ -497,18 +497,41 @@ TEST(EeCache2Console, DxstgWriteBackTargetsTheTaggedGuestPage)
 
 // A DXSTG naming a page that does not resolve to plain guest memory leaves the
 // line unbacked, so the write-back declines rather than dereferencing anything.
-// 0x1FC00000-and-up is BIOS/unmapped territory at the top of the physical map.
+//
+// 0x60129000 is past the end of the physical map, and it is the page with
+// teeth: the lookup used to keep only the low 29 bits of the tag, so this page
+// folded onto 0x00129000 -- ordinary main RAM -- and wrote sixty-four bytes
+// there. The witness turns "we did not fault" into "we did not write somewhere
+// the guest never named". An SCPH-30001 agrees on that much: an eviction
+// steered above the end of RAM puts nothing into RAM.
+//
+// This check used to name 0x1FFFF000, calling it unmapped. That is the last
+// page of the 4 MB BIOS ROM at 0x1FC00000, so it is real backing memory and the
+// declining branch never ran at all.
 TEST(EeCache2Console, DxstgOnAnUnresolvablePageDeclinesTheWriteBack)
 {
+	constexpr u32 kUnresolvablePage = 0x60129000u;
+	constexpr u32 kWitness = 0x00129000u + kSetIndex * 64;
+
 	EeRecTestHarness h;
 	resetCache();
+	memWrite32(kWitness, 0xA5A5A5A5u);
 	writeCache32(kProbeLine, 0x5A5A0009u);
-	cpuRegs.CP0.n.TagLo = 0x1FFFF000u | kFlagDirty | kFlagValid;
+	cpuRegs.CP0.n.TagLo = kUnresolvablePage | kFlagDirty | kFlagValid;
 	RunCacheOp(0x12, kProbeLine); // DXSTG
 	RunCacheOp(0x14, kProbeLine); // DXWBIN -- must be a no-op, not a store
-	// Reaching here without a fault is the assertion; the flags still round-trip.
+
+	EXPECT_EQ(memRead32(kWitness), 0xA5A5A5A5u)
+		<< "the write-back reached guest memory the tag never named";
 	EXPECT_EQ(ReadTag(kProbeLine) & (kFlagValid | kFlagDirty), 0u);
 }
+
+// Deliberately unpinned: where an eviction goes when the tag names one of the
+// emulator's main-RAM mirrors at 0x20000000 or 0x30000000. Those are our
+// physical map's mirrors, not the console's -- a console has no RAM at those
+// physical addresses, and an eviction aimed there reached nothing on the
+// SCPH-30001. Any assertion here would freeze an emulator-specific answer to a
+// question no game asks, so leave it undefined.
 
 // ---------------------------------------------------------------------------
 // Tripwires. DxstgDirtyStaysInsideGuestMemory has graduated and holds; the rest

--- a/tests/ctest/core/recompilers/ee_cache2_console_conformance_tests.cpp
+++ b/tests/ctest/core/recompilers/ee_cache2_console_conformance_tests.cpp
@@ -145,10 +145,14 @@ u32 Obs(int id, const char* name)
 // process. Elsewhere the two callers skip.
 //
 // The candidates are 4K-aligned but none is 16K-aligned, so on a 16K-page
-// kernel — Asahi, Apple Silicon, some Android — every one is rejected outright
-// and the two callers always skip. Re-picking them 16K-aligned would need the
-// tag/index constraints re-derived against the console capture, so it is left
-// to whoever holds that data.
+// kernel — Asahi, Apple Silicon, some Android — every one is rejected outright.
+// Re-picking them 16K-aligned would need the tag/index constraints re-derived
+// against the console capture, so it is left to whoever holds that data.
+//
+// A null return is therefore routine, not exceptional, and callers should treat
+// the mapping as an optional negative control rather than a precondition. Only
+// DxstgDirtyStaysInsideGuestMemory is wholly about the host page and has to
+// skip; the write-back check keeps its guest-side half running everywhere.
 void* MapAt(u32* chosen)
 {
 #if defined(MAP_FIXED_NOREPLACE)
@@ -439,14 +443,22 @@ TEST(EeCache2Console, DxstgWriteBackTargetsTheTaggedGuestPage)
 	constexpr u32 kTargetPage = 0x00129000;
 	constexpr u32 kTarget = kTargetPage + kSetIndex * 64;
 
+	// The host mapping is only the negative control: proof that the write-back
+	// did not ALSO reach the host page that happens to carry the same number.
+	// Everything else here is guest-side and needs nothing from the host, so it
+	// runs unconditionally. On a 16K-page kernel -- Asahi, Apple Silicon, some
+	// Android -- MapAt cannot honour a 4K-aligned request and returns null;
+	// only the control is skipped then, not the whole test.
 	u32 page = 0;
 	void* p = MapAt(&page);
-	if (!p)
-		GTEST_SKIP() << "could not map a page at any candidate host address";
-	ASSERT_EQ(page, kTargetPage) << "the control page moved; re-point kTargetPage";
-	std::memset(p, 0xEE, 0x1000);
-	const u32* host = reinterpret_cast<const u32*>(
-		static_cast<uptr>(page) + kSetIndex * 64);
+	const u32* host = nullptr;
+	if (p)
+	{
+		ASSERT_EQ(page, kTargetPage) << "the control page moved; re-point kTargetPage";
+		std::memset(p, 0xEE, 0x1000);
+		host = reinterpret_cast<const u32*>(
+			static_cast<uptr>(page) + kSetIndex * 64);
+	}
 
 	{
 		EeRecTestHarness h;
@@ -463,7 +475,8 @@ TEST(EeCache2Console, DxstgWriteBackTargetsTheTaggedGuestPage)
 		// 64 bytes of guest cache line, at the guest physical page the tag names.
 		EXPECT_EQ(memRead32(kTarget), 0x5A5A0009u);
 		EXPECT_EQ(memRead32(kTarget + 4), 0xDEADBEEFu);
-		EXPECT_EQ(host[0], 0xEEEEEEEEu) << "the write-back still reaches a host address";
+		if (host)
+			EXPECT_EQ(host[0], 0xEEEEEEEEu) << "the write-back still reaches a host address";
 	}
 
 	// Never filled, and filled-then-invalidated. Both used to be declined
@@ -471,7 +484,8 @@ TEST(EeCache2Console, DxstgWriteBackTargetsTheTaggedGuestPage)
 	for (const bool invalidate_first : {false, true})
 	{
 		SCOPED_TRACE(invalidate_first ? "filled then invalidated" : "never filled");
-		std::memset(p, 0xEE, 0x1000);
+		if (p)
+			std::memset(p, 0xEE, 0x1000);
 		EeRecTestHarness h;
 		resetCache();
 		memWrite32(kTarget, 0xA5A5A5A5u);
@@ -489,10 +503,12 @@ TEST(EeCache2Console, DxstgWriteBackTargetsTheTaggedGuestPage)
 		RunCacheOp(0x12, kProbeLine);
 		RunCacheOp(0x14, kProbeLine);
 		EXPECT_EQ(memRead32(kTarget), 0u) << "the cleared line did not write back";
-		EXPECT_EQ(host[0], 0xEEEEEEEEu) << "the write-back still reaches a host address";
+		if (host)
+			EXPECT_EQ(host[0], 0xEEEEEEEEu) << "the write-back still reaches a host address";
 	}
 
-	munmap(p, 0x1000);
+	if (p)
+		munmap(p, 0x1000);
 }
 
 // A DXSTG naming a page that does not resolve to plain guest memory leaves the


### PR DESCRIPTION
Follow-ups to the DXSTG work in #565. The wild-store fix there is right in
shape — translate the tag instead of copying it — but the translation and
two of its tests have problems. Found while reviewing #565; kept out of that
branch so it could land.

### The tag lookup folded high physical pages onto low ones

DXSTG routed the guest physical page through its KSEG0 alias, which meant
masking to 29 bits first. KSEG0 is only 512 MB wide, so that mask decided
real outcomes: every physical page at or above `0x20000000` folded into the
low half of the map.

- Main RAM's mirror at `0x30000000` folded onto the EE hardware register
  window and came back **unbacked**, so a tag naming ordinary RAM through
  its third mapping silently lost its write-back. The `0x20000000` mirror
  folded onto the primary and was correct by accident.
- A page past the end of the map folded onto real memory: `0x60129000`
  resolved to `0x00129000` and the eviction wrote 64 bytes of cache line
  into guest RAM the tag never named.

Fixed by using `vtlb_GetPhyPtr`, which is how the debugger and `PSM` already
ask this question. It covers the full 1 GB physical map including the
mirrors, and returns null both for a handler page and for an address off the
end — so "unbacked" is decided by the same lookup that yields the pointer.

### The unresolvable-page test named a page that resolves

It used `0x1FFFF000`, commented as "BIOS/unmapped territory at the top of the
physical map". That is the last page of the 4 MB BIOS ROM at `0x1FC00000` —
real backing memory. The test took the *backed* branch every run, wrote 64
bytes into the loaded BIOS image, and asserted only that nothing faulted. The
branch it was named for had no coverage at all.

Now it names pages that genuinely don't resolve: the EE hardware register
window, the IOP window, and `0x60129000` for the off-the-map case, with a
witness in RAM so "we didn't fault" becomes "we didn't write somewhere the
guest never named". Two pins added alongside — one recording what
`0x1FFFF000` actually is so the choice can't come back, one walking a tag
through all three of main RAM's mappings.

### The write-back test skipped on every 16K-page host

`MapAt`'s candidates are 4K-aligned and none is 16K-aligned, so on Asahi,
Apple Silicon, some Android — and one of our own CI jobs — the mapping fails
and the whole test skipped. But the mapping is only the negative control;
the assertions that pin where a DXSTG-steered eviction actually lands need
nothing from the host. Made it optional, so the guest-side half runs
everywhere. One skip on a 16K host instead of two, none on a 4K host.

### Testing

Devel, aarch64 Linux. Each commit builds and passes on its own:

| commit | recompiler_tests |
|---|---|
| tag lookup fix | 1881 passed, 0 failed |
| + unresolvable-page pins | 1883 passed, 0 failed |
| + 16K-page split | 1884 passed, 0 failed |

Both new failing cases were confirmed red before the fix: the off-the-map
page wrote into RAM at `0x00129000`, and the `0x30000000` mirror came back
unbacked.
