### PR TITLE
Per-game settings outrank the game database

### DIFF
--- a/common/SettingsWrapper.cpp
+++ b/common/SettingsWrapper.cpp
@@ -167,6 +167,104 @@ void SettingsSaveWrapper::_EnumEntry(const char* section, const char* var, int& 
 	m_si.SetStringValue(section, var, enumArray[index]);
 }
 
+SettingsSaveDeviationsWrapper::SettingsSaveDeviationsWrapper(
+	SettingsInterface& si, std::vector<const MemorySettingsInterface*> references)
+	: SettingsWrapper(si)
+	, m_references(std::move(references))
+{
+}
+
+SettingsSaveDeviationsWrapper::~SettingsSaveDeviationsWrapper() = default;
+
+bool SettingsSaveDeviationsWrapper::IsLoading() const
+{
+	return false;
+}
+
+bool SettingsSaveDeviationsWrapper::IsSaving() const
+{
+	return true;
+}
+
+template <typename WriteFn>
+void SettingsSaveDeviationsWrapper::Keep(const char* section, const char* var, const WriteFn& write)
+{
+	write(m_staging);
+
+	std::string candidate;
+	if (!m_staging.GetStringValue(section, var, &candidate))
+	{
+		// Nothing to compare against, so nothing can be said to be redundant.
+		write(m_si);
+		return;
+	}
+
+	m_staging.DeleteValue(section, var);
+
+	for (const MemorySettingsInterface* reference : m_references)
+	{
+		std::string existing;
+		if (reference->GetStringValue(section, var, &existing) && existing == candidate)
+		{
+			m_si.DeleteValue(section, var);
+			return;
+		}
+	}
+
+	write(m_si);
+}
+
+void SettingsSaveDeviationsWrapper::Entry(const char* section, const char* var, int& value, const int defvalue /*= 0*/)
+{
+	Keep(section, var, [&](SettingsInterface& si) { si.SetIntValue(section, var, value); });
+}
+
+void SettingsSaveDeviationsWrapper::Entry(const char* section, const char* var, uint& value, const uint defvalue /*= 0*/)
+{
+	Keep(section, var, [&](SettingsInterface& si) { si.SetUIntValue(section, var, value); });
+}
+
+void SettingsSaveDeviationsWrapper::Entry(const char* section, const char* var, bool& value, const bool defvalue /*= false*/)
+{
+	Keep(section, var, [&](SettingsInterface& si) { si.SetBoolValue(section, var, value); });
+}
+
+void SettingsSaveDeviationsWrapper::Entry(const char* section, const char* var, float& value, const float defvalue /*= 0.0*/)
+{
+	Keep(section, var, [&](SettingsInterface& si) { si.SetFloatValue(section, var, value); });
+}
+
+void SettingsSaveDeviationsWrapper::Entry(
+	const char* section, const char* var, std::string& value, const std::string& default_value /*= std::string()*/)
+{
+	Keep(section, var, [&](SettingsInterface& si) { si.SetStringValue(section, var, value.c_str()); });
+}
+
+void SettingsSaveDeviationsWrapper::Entry(
+	const char* section, const char* var, SmallStringBase& value, std::string_view default_value /* = std::string_view() */)
+{
+	Keep(section, var, [&](SettingsInterface& si) { si.SetStringValue(section, var, value.c_str()); });
+}
+
+bool SettingsSaveDeviationsWrapper::EntryBitBool(const char* section, const char* var, bool value, const bool defvalue /*= false*/)
+{
+	Keep(section, var, [&](SettingsInterface& si) { si.SetBoolValue(section, var, value); });
+	return value;
+}
+
+int SettingsSaveDeviationsWrapper::EntryBitfield(const char* section, const char* var, int value, const int defvalue /*= 0*/)
+{
+	Keep(section, var, [&](SettingsInterface& si) { si.SetIntValue(section, var, value); });
+	return value;
+}
+
+void SettingsSaveDeviationsWrapper::_EnumEntry(const char* section, const char* var, int& value, const char* const* enumArray, int defvalue)
+{
+	const int cnt = _calcEnumLength(enumArray);
+	const int index = (value < 0 || value >= cnt) ? defvalue : value;
+	Keep(section, var, [&](SettingsInterface& si) { si.SetStringValue(section, var, enumArray[index]); });
+}
+
 SettingsClearWrapper::SettingsClearWrapper(SettingsInterface& si)
 	: SettingsWrapper(si)
 {

--- a/common/SettingsWrapper.h
+++ b/common/SettingsWrapper.h
@@ -3,12 +3,14 @@
 
 #pragma once
 
+#include "MemorySettingsInterface.h"
 #include "SettingsInterface.h"
 
 #include "common/EnumOps.h"
 #include "common/SmallString.h"
 
 #include <optional>
+#include <vector>
 
 // Helper class which loads or saves depending on the derived class.
 class SettingsWrapper
@@ -100,6 +102,51 @@ public:
 
 protected:
 	void _EnumEntry(const char* section, const char* var, int& value, const char* const* enumArray, int defvalue) override;
+};
+
+/// Saves only the values that differ from every reference, and deletes the rest.
+///
+/// A per-game settings file is a record of decisions. Copying a whole configuration
+/// into one verbatim writes hundreds of keys the player never chose and never saw,
+/// and each of those then reads back as a deliberate choice — which is exactly how
+/// a copy of the global settings ends up suppressing every automatic fix a game had.
+/// Give this the values that would apply anyway and only the real deviations land.
+///
+/// Comparison goes through the string form rather than the typed value, so a float
+/// or an enum name compares the way it will actually be stored. That is why the
+/// references must be MemorySettingsInterfaces built the same way: same class, same
+/// formatting, exact comparison.
+class SettingsSaveDeviationsWrapper final : public SettingsWrapper
+{
+public:
+	SettingsSaveDeviationsWrapper(SettingsInterface& si, std::vector<const MemorySettingsInterface*> references);
+	~SettingsSaveDeviationsWrapper();
+
+	bool IsLoading() const override;
+	bool IsSaving() const override;
+
+	void Entry(const char* section, const char* var, int& value, const int defvalue = 0) override;
+	void Entry(const char* section, const char* var, uint& value, const uint defvalue = 0) override;
+	void Entry(const char* section, const char* var, bool& value, const bool defvalue = false) override;
+	void Entry(const char* section, const char* var, float& value, const float defvalue = 0.0) override;
+	void Entry(const char* section, const char* var, std::string& value, const std::string& default_value = std::string()) override;
+	void Entry(const char* section, const char* var, SmallStringBase& value, std::string_view default_value = std::string_view()) override;
+
+	bool EntryBitBool(const char* section, const char* var, bool value, const bool defvalue = false) override;
+	int EntryBitfield(const char* section, const char* var, int value, const int defvalue = 0) override;
+
+protected:
+	void _EnumEntry(const char* section, const char* var, int& value, const char* const* enumArray, int defvalue) override;
+
+private:
+	/// Stages the value with `write`, then keeps it only if no reference already says
+	/// the same thing.
+	template <typename WriteFn>
+	void Keep(const char* section, const char* var, const WriteFn& write);
+
+	std::vector<const MemorySettingsInterface*> m_references;
+	/// Holds the candidate long enough to be rendered the same way a reference is.
+	MemorySettingsInterface m_staging;
 };
 
 class SettingsClearWrapper final : public SettingsWrapper

--- a/pcsx2-qt/Settings/SettingsWindow.cpp
+++ b/pcsx2-qt/Settings/SettingsWindow.cpp
@@ -294,7 +294,8 @@ void SettingsWindow::onCopyGlobalSettingsClicked()
 
 	if (QMessageBox::question(this, tr("ARMSX2 Settings"),
 			tr("The configuration for this game will be replaced by the current global settings.\n\nAny current setting values will be "
-			   "overwritten.\n\nDo you want to continue?"),
+			   "overwritten.\n\nOnly the settings that differ from the defaults, or from what the game database sets for this game, are "
+			   "written. Anything else keeps following your global settings.\n\nDo you want to continue?"),
 			QMessageBox::Yes, QMessageBox::No) != QMessageBox::Yes)
 	{
 		return;
@@ -302,7 +303,7 @@ void SettingsWindow::onCopyGlobalSettingsClicked()
 
 	{
 		auto lock = Host::GetSettingsLock();
-		Pcsx2Config::CopyConfiguration(m_sif.get(), *Host::Internal::GetBaseSettingsLayer());
+		Pcsx2Config::CopyConfiguration(m_sif.get(), *Host::Internal::GetBaseSettingsLayer(), m_serial);
 		Pcsx2Config::ClearInvalidPerGameConfiguration(m_sif.get());
 	}
 	saveAndReloadGameSettings();

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -100,6 +100,7 @@ set(pcsx2Sources
 	Patch.cpp
 	Pcsx2Config.cpp
 	PerformanceMetrics.cpp
+	PerGameOverrides.cpp
 	PrecompiledHeader.cpp
 	R3000A.cpp
 	R3000AInterpreter.cpp
@@ -187,6 +188,7 @@ set(pcsx2Headers
 	no-jit-improvements.h
 	Patch.h
 	PerformanceMetrics.h
+	PerGameOverrides.h
 	PrecompiledHeader.h
 	R3000A.h
 	R5900.h

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1651,7 +1651,12 @@ struct Pcsx2Config
 	void CopyRuntimeConfig(Pcsx2Config& cfg);
 
 	/// Copies configuration from one file to another. Does not copy controller settings.
-	static void CopyConfiguration(SettingsInterface* dest_si, SettingsInterface& src_si);
+	/// Copies a configuration into a per-game settings file, writing only the values
+	/// that deviate from what the game would run with anyway — stock defaults, and the
+	/// game database's own opinion for `game_serial`. Everything else is left absent,
+	/// because in a per-game file a key that is present is a key the player is taken to
+	/// have claimed, and the database then stands aside for it.
+	static void CopyConfiguration(SettingsInterface* dest_si, SettingsInterface& src_si, std::string_view game_serial);
 
 	/// Clears all core keys from the specified interface.
 	static void ClearConfiguration(SettingsInterface* dest_si);

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -539,12 +539,14 @@ static std::optional<GSUserHackOverride> UserHackOverrideForHWFix(GameDatabaseSc
 	}
 }
 
-void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool applyAuto, const PerGameOverrides& overrides) const
+void GameDatabaseSchema::GameEntry::applyGameFixes(
+	Pcsx2Config& config, bool applyAuto, const PerGameOverrides& overrides, ApplyMode mode) const
 {
 	std::string suppressed_fixes;
+	const bool quiet = (mode == ApplyMode::Hypothetical);
 
 	// Only apply core game fixes if the user has enabled them.
-	if (!applyAuto)
+	if (!applyAuto && !quiet)
 		Console.Warning("GameDB: Game Fixes are disabled");
 
 	// Decides whether one database value lands, and says why when it does not. Two
@@ -555,6 +557,9 @@ void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool app
 	// Names are the database's own YAML spelling so a log line and a GameIndex entry
 	// read together.
 	const auto wanted = [&](bool claimed, const char* name, std::optional<int> value = std::nullopt) {
+		if (quiet)
+			return applyAuto && !claimed;
+
 		const std::string label = value.has_value() ? fmt::format("{} = {}", name, value.value()) : std::string(name);
 
 		if (claimed)
@@ -576,29 +581,35 @@ void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool app
 	if (eeRoundMode < FPRoundMode::MaxCount &&
 		wanted(overrides.Has(CoreGameDBKnob::EERoundMode), "eeRoundMode", static_cast<int>(eeRoundMode)))
 	{
-		Console.WriteLn("GameDB: Changing EE/FPU roundmode to %d [%s]", eeRoundMode, s_round_modes[static_cast<u8>(eeRoundMode)]);
+		if (!quiet)
+			Console.WriteLn("GameDB: Changing EE/FPU roundmode to %d [%s]", eeRoundMode, s_round_modes[static_cast<u8>(eeRoundMode)]);
 		config.Cpu.FPUFPCR.SetRoundMode(eeRoundMode);
 	}
 
 	if (eeDivRoundMode < FPRoundMode::MaxCount &&
 		wanted(overrides.Has(CoreGameDBKnob::EEDivRoundMode), "eeDivRoundMode", static_cast<int>(eeDivRoundMode)))
 	{
-		Console.WriteLn("GameDB: Changing EE/FPU divison roundmode to %d [%s]", eeDivRoundMode,
-			s_round_modes[static_cast<u8>(eeDivRoundMode)]);
+		if (!quiet)
+		{
+			Console.WriteLn("GameDB: Changing EE/FPU divison roundmode to %d [%s]", eeDivRoundMode,
+				s_round_modes[static_cast<u8>(eeDivRoundMode)]);
+		}
 		config.Cpu.FPUDivFPCR.SetRoundMode(eeDivRoundMode);
 	}
 
 	if (vu0RoundMode < FPRoundMode::MaxCount &&
 		wanted(overrides.Has(CoreGameDBKnob::VU0RoundMode), "vu0RoundMode", static_cast<int>(vu0RoundMode)))
 	{
-		Console.WriteLn("GameDB: Changing VU0 roundmode to %d [%s]", vu0RoundMode, s_round_modes[static_cast<u8>(vu0RoundMode)]);
+		if (!quiet)
+			Console.WriteLn("GameDB: Changing VU0 roundmode to %d [%s]", vu0RoundMode, s_round_modes[static_cast<u8>(vu0RoundMode)]);
 		config.Cpu.VU0FPCR.SetRoundMode(vu0RoundMode);
 	}
 
 	if (vu1RoundMode < FPRoundMode::MaxCount &&
 		wanted(overrides.Has(CoreGameDBKnob::VU1RoundMode), "vu1RoundMode", static_cast<int>(vu1RoundMode)))
 	{
-		Console.WriteLn("GameDB: Changing VU1 roundmode to %d [%s]", vu1RoundMode, s_round_modes[static_cast<u8>(vu1RoundMode)]);
+		if (!quiet)
+			Console.WriteLn("GameDB: Changing VU1 roundmode to %d [%s]", vu1RoundMode, s_round_modes[static_cast<u8>(vu1RoundMode)]);
 		config.Cpu.VU1FPCR.SetRoundMode(vu1RoundMode);
 	}
 
@@ -607,7 +618,8 @@ void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool app
 		const int clampMode = enum_cast(eeClampMode);
 		if (wanted(overrides.Has(CoreGameDBKnob::EEClampMode), "eeClampMode", clampMode))
 		{
-			Console.WriteLn("GameDB: Changing EE/FPU clamp mode [mode=%d]", clampMode);
+			if (!quiet)
+				Console.WriteLn("GameDB: Changing EE/FPU clamp mode [mode=%d]", clampMode);
 			config.Cpu.Recompiler.fpuOverflow = (clampMode >= 1);
 			config.Cpu.Recompiler.fpuExtraOverflow = (clampMode >= 2);
 			config.Cpu.Recompiler.fpuFullMode = (clampMode >= 3);
@@ -620,7 +632,8 @@ void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool app
 		const int clampMode = enum_cast(vu0ClampMode);
 		if (wanted(overrides.Has(CoreGameDBKnob::VU0ClampMode), "vu0ClampMode", clampMode))
 		{
-			Console.WriteLn("GameDB: Changing VU0 clamp mode [mode=%d]", clampMode);
+			if (!quiet)
+				Console.WriteLn("GameDB: Changing VU0 clamp mode [mode=%d]", clampMode);
 			config.Cpu.Recompiler.vu0Overflow = (clampMode >= 1);
 			config.Cpu.Recompiler.vu0ExtraOverflow = (clampMode >= 2);
 			config.Cpu.Recompiler.vu0SignOverflow = (clampMode >= 3);
@@ -632,7 +645,8 @@ void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool app
 		const int clampMode = enum_cast(vu1ClampMode);
 		if (wanted(overrides.Has(CoreGameDBKnob::VU1ClampMode), "vu1ClampMode", clampMode))
 		{
-			Console.WriteLn("GameDB: Changing VU1 clamp mode [mode=%d]", clampMode);
+			if (!quiet)
+				Console.WriteLn("GameDB: Changing VU1 clamp mode [mode=%d]", clampMode);
 			config.Cpu.Recompiler.vu1Overflow = (clampMode >= 1);
 			config.Cpu.Recompiler.vu1ExtraOverflow = (clampMode >= 2);
 			config.Cpu.Recompiler.vu1SignOverflow = (clampMode >= 3);
@@ -648,8 +662,11 @@ void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool app
 		// Legacy note - speedhacks are setup in the GameDB as integer values, but
 		// are effectively booleans like the gamefixes
 		config.Speedhacks.Set(it.first, it.second);
-		Console.WriteLn("GameDB: Setting Speedhack '%s' to [mode=%d]",
-			Pcsx2Config::SpeedhackOptions::GetSpeedHackName(it.first), it.second);
+		if (!quiet)
+		{
+			Console.WriteLn("GameDB: Setting Speedhack '%s' to [mode=%d]",
+				Pcsx2Config::SpeedhackOptions::GetSpeedHackName(it.first), it.second);
+		}
 	}
 
 	// TODO - config - this could be simplified with maps instead of bitfields and enums
@@ -663,15 +680,20 @@ void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool app
 
 		// if the fix is present, it is said to be enabled
 		config.Gamefixes.Set(id, true);
-		Console.WriteLn("GameDB: Enabled Gamefix: %s", Pcsx2Config::GamefixOptions::GetGameFixName(id));
+		if (!quiet)
+			Console.WriteLn("GameDB: Enabled Gamefix: %s", Pcsx2Config::GamefixOptions::GetGameFixName(id));
 
-		// The LUT is only used for 1 game so we allocate it only when the gamefix is enabled (save 4MB)
-		if (id == Fix_GoemonTlbMiss && true)
+		// The LUT is only used for 1 game so we allocate it only when the gamefix is enabled (save 4MB).
+		// A hypothetical apply is not going to run anything, so it does not get the 4MB.
+		if (id == Fix_GoemonTlbMiss && !quiet)
 			vtlb_Alloc_Ppmap();
 	}
 
 	// Keyed so the next settings reload replaces or clears it, matching how the
 	// graphics half reports the same thing.
+	if (quiet)
+		return;
+
 	if (!suppressed_fixes.empty())
 	{
 		Host::AddKeyedOSDMessage("CoreFixesWarning",
@@ -816,14 +838,16 @@ bool GameDatabaseSchema::GameEntry::configMatchesHWFix(const Pcsx2Config::GSOpti
 	}
 }
 
-void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& config, const PerGameOverrides& overrides) const
+void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(
+	Pcsx2Config::GSOptions& config, const PerGameOverrides& overrides, ApplyMode mode) const
 {
 	std::string disabled_fixes;
+	const bool quiet = (mode == ApplyMode::Hypothetical);
 
 	// Only apply GS HW fixes if the user hasn't manually enabled HW fixes.
 	const bool apply_auto_fixes = !config.ManualUserHacks;
 	const bool is_sw_renderer = EmuConfig.GS.Renderer == GSRendererType::SW;
-	if (!apply_auto_fixes)
+	if (!apply_auto_fixes && !quiet)
 		Console.Warning("GameDB: Manual GS hardware renderer fixes are enabled, not using automatic hardware renderer fixes from GameDB.");
 
 	for (const auto& [id, value] : gsHWFixes)
@@ -845,7 +869,7 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 		// to be claimed, which is most of what a player actually changes.
 		if (pinned || (isUserHackHWFix(id) && !apply_auto_fixes))
 		{
-			if (configMatchesHWFix(config, id, value))
+			if (configMatchesHWFix(config, id, value) || quiet)
 				continue;
 
 			Console.Warning("GameDB: Skipping GS Hardware Fix: %s to [mode=%d]", getHWFixName(id), value);
@@ -973,6 +997,7 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 					if (config.TriFilter == TriFiltering::Automatic)
 						config.TriFilter = static_cast<TriFiltering>(value);
 					else if (config.TriFilter > TriFiltering::Off)
+						if (!quiet)
 						Console.Warning("GameDB: Game requires trilinear filtering to be disabled.");
 				}
 			}
@@ -1015,6 +1040,7 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 					if (config.InterlaceMode == GSInterlaceMode::Automatic)
 						config.InterlaceMode = static_cast<GSInterlaceMode>(value);
 					else
+						if (!quiet)
 						Console.Warning("GameDB: Game requires different deinterlace mode but it has been overridden by user setting.");
 				}
 			}
@@ -1065,6 +1091,9 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 
 			case GSHWFixId::RecommendedBlendingLevel:
 			{
+				if (quiet)
+					break;
+
 				if (!is_sw_renderer && value >= 0 && value <= static_cast<int>(AccBlendLevel::Maximum) && static_cast<int>(EmuConfig.GS.AccurateBlendingUnit) < value)
 				{
 					static constexpr std::array<const char*, static_cast<u8>(AccBlendLevel::MaxCount)> s_blending_option_names = {{
@@ -1096,6 +1125,9 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 
 			case GSHWFixId::RecommendedAccurateAlphaTest:
 			{
+				if (quiet)
+					break;
+
 				if (!is_sw_renderer && value >= 0 && value <= 1 &&
 					static_cast<int>(config.HWAccurateAlphaTest) < value)
 				{
@@ -1117,6 +1149,9 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 
 			case GSHWFixId::RecommendedHWAA1:
 			{
+				if (quiet)
+					break;
+
 				if (!is_sw_renderer && value >= 0 && value <= 1 &&
 					static_cast<int>(config.HWAA1) < value)
 				{
@@ -1152,11 +1187,15 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 				break;
 		}
 
-		Console.WriteLn("GameDB: Enabled GS Hardware Fix: %s to [mode=%d]", getHWFixName(id), value);
+		if (!quiet)
+			Console.WriteLn("GameDB: Enabled GS Hardware Fix: %s to [mode=%d]", getHWFixName(id), value);
 	}
 
 	// fixup skipdraw range just in case the db has a bad range (but the linter should catch this)
 	config.SkipDrawEnd = std::max(config.SkipDrawStart, config.SkipDrawEnd);
+
+	if (quiet)
+		return;
 
 	if (!is_sw_renderer && !disabled_fixes.empty())
 	{

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -539,68 +539,73 @@ static std::optional<GSUserHackOverride> UserHackOverrideForHWFix(GameDatabaseSc
 	}
 }
 
-void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool applyAuto) const
+void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool applyAuto, const PerGameOverrides& overrides) const
 {
+	std::string suppressed_fixes;
+
 	// Only apply core game fixes if the user has enabled them.
 	if (!applyAuto)
 		Console.Warning("GameDB: Game Fixes are disabled");
 
-	if (eeRoundMode < FPRoundMode::MaxCount)
+	// Decides whether one database value lands, and says why when it does not. Two
+	// reasons are possible and they are not the same thing: the global switch is off,
+	// or the player set this particular knob for this particular game. Only the second
+	// is worth putting on screen — the first they already know, they threw it.
+	//
+	// Names are the database's own YAML spelling so a log line and a GameIndex entry
+	// read together.
+	const auto wanted = [&](bool claimed, const char* name, std::optional<int> value = std::nullopt) {
+		const std::string label = value.has_value() ? fmt::format("{} = {}", name, value.value()) : std::string(name);
+
+		if (claimed)
+		{
+			Console.Warning("GameDB: Skipping %s, the per-game setting wins", label.c_str());
+			fmt::format_to(std::back_inserter(suppressed_fixes), "{}{}", suppressed_fixes.empty() ? "  " : "\n  ", label);
+			return false;
+		}
+
+		if (!applyAuto)
+		{
+			Console.Warning("GameDB: Skipping %s", label.c_str());
+			return false;
+		}
+
+		return true;
+	};
+
+	if (eeRoundMode < FPRoundMode::MaxCount &&
+		wanted(overrides.Has(CoreGameDBKnob::EERoundMode), "eeRoundMode", static_cast<int>(eeRoundMode)))
 	{
-		if (applyAuto)
-		{
-			Console.WriteLn("GameDB: Changing EE/FPU roundmode to %d [%s]", eeRoundMode, s_round_modes[static_cast<u8>(eeRoundMode)]);
-			config.Cpu.FPUFPCR.SetRoundMode(eeRoundMode);
-		}
-		else
-		{
-			Console.Warning("GameDB: Skipping changing EE/FPU roundmode to %d [%s]", eeRoundMode, s_round_modes[static_cast<u8>(eeRoundMode)]);
-		}
+		Console.WriteLn("GameDB: Changing EE/FPU roundmode to %d [%s]", eeRoundMode, s_round_modes[static_cast<u8>(eeRoundMode)]);
+		config.Cpu.FPUFPCR.SetRoundMode(eeRoundMode);
 	}
 
-	if (eeDivRoundMode < FPRoundMode::MaxCount)
+	if (eeDivRoundMode < FPRoundMode::MaxCount &&
+		wanted(overrides.Has(CoreGameDBKnob::EEDivRoundMode), "eeDivRoundMode", static_cast<int>(eeDivRoundMode)))
 	{
-		if (applyAuto)
-		{
-			Console.WriteLn("GameDB: Changing EE/FPU divison roundmode to %d [%s]", eeRoundMode, s_round_modes[static_cast<u8>(eeDivRoundMode)]);
-			config.Cpu.FPUDivFPCR.SetRoundMode(eeDivRoundMode);
-		}
-		else
-		{
-			Console.Warning("GameDB: Skipping changing EE/FPU roundmode to %d [%s]", eeRoundMode, s_round_modes[static_cast<u8>(eeRoundMode)]);
-		}
+		Console.WriteLn("GameDB: Changing EE/FPU divison roundmode to %d [%s]", eeDivRoundMode,
+			s_round_modes[static_cast<u8>(eeDivRoundMode)]);
+		config.Cpu.FPUDivFPCR.SetRoundMode(eeDivRoundMode);
 	}
 
-	if (vu0RoundMode < FPRoundMode::MaxCount)
+	if (vu0RoundMode < FPRoundMode::MaxCount &&
+		wanted(overrides.Has(CoreGameDBKnob::VU0RoundMode), "vu0RoundMode", static_cast<int>(vu0RoundMode)))
 	{
-		if (applyAuto)
-		{
-			Console.WriteLn("GameDB: Changing VU0 roundmode to %d [%s]", vu0RoundMode, s_round_modes[static_cast<u8>(vu0RoundMode)]);
-			config.Cpu.VU0FPCR.SetRoundMode(vu0RoundMode);
-		}
-		else
-		{
-			Console.Warning("GameDB: Skipping changing VU0 roundmode to %d [%s]", vu0RoundMode, s_round_modes[static_cast<u8>(vu0RoundMode)]);
-		}
+		Console.WriteLn("GameDB: Changing VU0 roundmode to %d [%s]", vu0RoundMode, s_round_modes[static_cast<u8>(vu0RoundMode)]);
+		config.Cpu.VU0FPCR.SetRoundMode(vu0RoundMode);
 	}
 
-	if (vu1RoundMode < FPRoundMode::MaxCount)
+	if (vu1RoundMode < FPRoundMode::MaxCount &&
+		wanted(overrides.Has(CoreGameDBKnob::VU1RoundMode), "vu1RoundMode", static_cast<int>(vu1RoundMode)))
 	{
-		if (applyAuto)
-		{
-			Console.WriteLn("GameDB: Changing VU1 roundmode to %d [%s]", vu1RoundMode, s_round_modes[static_cast<u8>(vu1RoundMode)]);
-			config.Cpu.VU1FPCR.SetRoundMode(vu1RoundMode);
-		}
-		else
-		{
-			Console.Warning("GameDB: Skipping changing VU1 roundmode to %d [%s]", vu1RoundMode, s_round_modes[static_cast<u8>(vu1RoundMode)]);
-		}
+		Console.WriteLn("GameDB: Changing VU1 roundmode to %d [%s]", vu1RoundMode, s_round_modes[static_cast<u8>(vu1RoundMode)]);
+		config.Cpu.VU1FPCR.SetRoundMode(vu1RoundMode);
 	}
 
 	if (eeClampMode != GameDatabaseSchema::ClampMode::Undefined)
 	{
 		const int clampMode = enum_cast(eeClampMode);
-		if (applyAuto)
+		if (wanted(overrides.Has(CoreGameDBKnob::EEClampMode), "eeClampMode", clampMode))
 		{
 			Console.WriteLn("GameDB: Changing EE/FPU clamp mode [mode=%d]", clampMode);
 			config.Cpu.Recompiler.fpuOverflow = (clampMode >= 1);
@@ -608,47 +613,38 @@ void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool app
 			config.Cpu.Recompiler.fpuFullMode = (clampMode >= 3);
 			config.Cpu.Recompiler.fpuExactMode = (clampMode >= 4);
 		}
-		else
-			Console.Warning("GameDB: Skipping changing EE/FPU clamp mode [mode=%d]", clampMode);
 	}
 
 	if (vu0ClampMode != GameDatabaseSchema::ClampMode::Undefined)
 	{
 		const int clampMode = enum_cast(vu0ClampMode);
-		if (applyAuto)
+		if (wanted(overrides.Has(CoreGameDBKnob::VU0ClampMode), "vu0ClampMode", clampMode))
 		{
 			Console.WriteLn("GameDB: Changing VU0 clamp mode [mode=%d]", clampMode);
 			config.Cpu.Recompiler.vu0Overflow = (clampMode >= 1);
 			config.Cpu.Recompiler.vu0ExtraOverflow = (clampMode >= 2);
 			config.Cpu.Recompiler.vu0SignOverflow = (clampMode >= 3);
 		}
-		else
-			Console.Warning("GameDB: Skipping changing VU0 clamp mode [mode=%d]", clampMode);
 	}
 
 	if (vu1ClampMode != GameDatabaseSchema::ClampMode::Undefined)
 	{
 		const int clampMode = enum_cast(vu1ClampMode);
-		if (applyAuto)
+		if (wanted(overrides.Has(CoreGameDBKnob::VU1ClampMode), "vu1ClampMode", clampMode))
 		{
 			Console.WriteLn("GameDB: Changing VU1 clamp mode [mode=%d]", clampMode);
 			config.Cpu.Recompiler.vu1Overflow = (clampMode >= 1);
 			config.Cpu.Recompiler.vu1ExtraOverflow = (clampMode >= 2);
 			config.Cpu.Recompiler.vu1SignOverflow = (clampMode >= 3);
 		}
-		else
-			Console.Warning("GameDB: Skipping changing VU1 clamp mode [mode=%d]", clampMode);
 	}
 
 	// TODO - config - this could be simplified with maps instead of bitfields and enums
 	for (const auto& it : speedHacks)
 	{
-		if (!applyAuto)
-		{
-			Console.Warning("GameDB: Skipping setting Speedhack '%s' to [mode=%d]",
-				Pcsx2Config::SpeedhackOptions::GetSpeedHackName(it.first), it.second);
+		if (!wanted(overrides.Has(it.first), Pcsx2Config::SpeedhackOptions::GetSpeedHackName(it.first), it.second))
 			continue;
-		}
+
 		// Legacy note - speedhacks are setup in the GameDB as integer values, but
 		// are effectively booleans like the gamefixes
 		config.Speedhacks.Set(it.first, it.second);
@@ -659,11 +655,12 @@ void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool app
 	// TODO - config - this could be simplified with maps instead of bitfields and enums
 	for (const GamefixId id : gameFixes)
 	{
-		if (!applyAuto)
-		{
-			Console.Warning("GameDB: Skipping Gamefix: %s", Pcsx2Config::GamefixOptions::GetGameFixName(id));
+		// A database gamefix is only ever switched on, so a player who turned one on
+		// per-game already got their way. The claim matters for the other direction:
+		// turning one off, which until now the database silently undid.
+		if (!wanted(overrides.Has(id), Pcsx2Config::GamefixOptions::GetGameFixName(id)))
 			continue;
-		}
+
 		// if the fix is present, it is said to be enabled
 		config.Gamefixes.Set(id, true);
 		Console.WriteLn("GameDB: Enabled Gamefix: %s", Pcsx2Config::GamefixOptions::GetGameFixName(id));
@@ -671,6 +668,21 @@ void GameDatabaseSchema::GameEntry::applyGameFixes(Pcsx2Config& config, bool app
 		// The LUT is only used for 1 game so we allocate it only when the gamefix is enabled (save 4MB)
 		if (id == Fix_GoemonTlbMiss && true)
 			vtlb_Alloc_Ppmap();
+	}
+
+	// Keyed so the next settings reload replaces or clears it, matching how the
+	// graphics half reports the same thing.
+	if (!suppressed_fixes.empty())
+	{
+		Host::AddKeyedOSDMessage("CoreFixesWarning",
+			fmt::format(ICON_FA_WAND_MAGIC_SPARKLES " {}\n{}",
+				TRANSLATE_SV("GameDatabase", "Your own choice was kept for these settings, so the automatic ones were not applied:"),
+				suppressed_fixes),
+			Host::OSD_ERROR_DURATION);
+	}
+	else
+	{
+		Host::RemoveKeyedOSDMessage("CoreFixesWarning");
 	}
 }
 
@@ -804,7 +816,7 @@ bool GameDatabaseSchema::GameEntry::configMatchesHWFix(const Pcsx2Config::GSOpti
 	}
 }
 
-void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& config) const
+void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& config, const PerGameOverrides& overrides) const
 {
 	std::string disabled_fixes;
 
@@ -818,10 +830,20 @@ void GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions&
 	{
 		// A pin is manual mode for one fix instead of all of them, so it takes the same
 		// road out: the player's value stays and this one gets named in the warning.
+		//
+		// Two vocabularies reach the same conclusion here. The stored UserHackOverrides
+		// mask only names the classic user hacks, and is what MaskUserHacks() and an
+		// already-written INI speak. The per-game overrides name every fix a settings
+		// key exists for, which is a wider set, and is how a setting like the mipmap or
+		// deinterlace picker gets claimed at all.
 		const std::optional<GSUserHackOverride> pin = UserHackOverrideForHWFix(id);
-		const bool pinned = pin.has_value() && config.IsUserHackPinned(pin.value());
+		const bool pinned = (pin.has_value() && config.IsUserHackPinned(pin.value())) || overrides.Has(id);
 
-		if (isUserHackHWFix(id) && (!apply_auto_fixes || pinned))
+		// The pin is tested first and on its own. Nesting it under isUserHackHWFix()
+		// would leave the settings that were never user hacks — mipmapping, trilinear,
+		// deinterlacing, texture preloading, blend level, download mode — with no way
+		// to be claimed, which is most of what a player actually changes.
+		if (pinned || (isUserHackHWFix(id) && !apply_auto_fixes))
 		{
 			if (configMatchesHWFix(config, id, value))
 				continue;

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -5,6 +5,7 @@
 
 #include "Config.h"
 #include "Patch.h"
+#include "PerGameOverrides.h"
 
 #include "common/FPControl.h"
 
@@ -119,11 +120,13 @@ namespace GameDatabaseSchema
 		const std::string* findPatch(u32 crc) const;
 		const char* compatAsString() const;
 
-		/// Applies Core game fixes to an existing config.
-		void applyGameFixes(Pcsx2Config& config, bool applyAuto) const;
+		/// Applies Core game fixes to an existing config. Anything the player set for
+		/// this game specifically is left alone — `overrides` says which, and defaults
+		/// to nothing claimed, which is the old behaviour.
+		void applyGameFixes(Pcsx2Config& config, bool applyAuto, const PerGameOverrides& overrides = {}) const;
 
-		/// Applies GS hardware fixes to an existing config.
-		void applyGSHardwareFixes(Pcsx2Config::GSOptions& config) const;
+		/// Applies GS hardware fixes to an existing config, on the same terms.
+		void applyGSHardwareFixes(Pcsx2Config::GSOptions& config, const PerGameOverrides& overrides = {}) const;
 
 		/// Returns true if the current config value for the specified hw fix id matches the value.
 		static bool configMatchesHWFix(const Pcsx2Config::GSOptions& config, GSHWFixId id, int value);

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -94,6 +94,16 @@ namespace GameDatabaseSchema
 		Count
 	};
 
+	/// Whether the database's values are actually being adopted, or only being worked
+	/// out so something can be compared against them. A hypothetical apply says nothing
+	/// to the log or the screen and allocates nothing, because nothing is going to run
+	/// with the result.
+	enum class ApplyMode : u8
+	{
+		Live,
+		Hypothetical,
+	};
+
 	struct GameEntry
 	{
 		std::string name;
@@ -123,10 +133,12 @@ namespace GameDatabaseSchema
 		/// Applies Core game fixes to an existing config. Anything the player set for
 		/// this game specifically is left alone — `overrides` says which, and defaults
 		/// to nothing claimed, which is the old behaviour.
-		void applyGameFixes(Pcsx2Config& config, bool applyAuto, const PerGameOverrides& overrides = {}) const;
+		void applyGameFixes(Pcsx2Config& config, bool applyAuto, const PerGameOverrides& overrides = {},
+			ApplyMode mode = ApplyMode::Live) const;
 
 		/// Applies GS hardware fixes to an existing config, on the same terms.
-		void applyGSHardwareFixes(Pcsx2Config::GSOptions& config, const PerGameOverrides& overrides = {}) const;
+		void applyGSHardwareFixes(Pcsx2Config::GSOptions& config, const PerGameOverrides& overrides = {},
+			ApplyMode mode = ApplyMode::Live) const;
 
 		/// Returns true if the current config value for the specified hw fix id matches the value.
 		static bool configMatchesHWFix(const Pcsx2Config::GSOptions& config, GSHWFixId id, int value);

--- a/pcsx2/ImGui/FullscreenUI_Internal.h
+++ b/pcsx2/ImGui/FullscreenUI_Internal.h
@@ -513,6 +513,9 @@ namespace FullscreenUI
 	inline SettingsPage s_settings_page = SettingsPage::Interface;
 	inline std::unique_ptr<INISettingsInterface> s_game_settings_interface;
 	inline std::unique_ptr<GameList::Entry> s_game_settings_entry;
+	// Whose settings are being edited. Kept beside the interface rather than read off
+	// the entry, which is null when an ELF is what opened the page. Empty for those.
+	inline std::string s_game_settings_serial;
 	inline std::vector<std::pair<std::string, bool>> s_game_list_directories_cache;
 	inline std::vector<GSAdapterInfo> s_graphics_adapter_list_cache;
 	inline std::vector<Patch::PatchInfo> s_game_patch_list;

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -1649,6 +1649,7 @@ void FullscreenUI::SwitchToSettings()
 {
 	s_game_settings_entry.reset();
 	s_game_settings_interface.reset();
+	s_game_settings_serial.clear();
 	s_game_patch_list = {};
 	s_enabled_game_patch_cache = {};
 	s_game_cheats_list = {};
@@ -1662,6 +1663,7 @@ void FullscreenUI::SwitchToSettings()
 void FullscreenUI::SwitchToGameSettings(const std::string_view serial, u32 crc)
 {
 	s_game_settings_entry.reset();
+	s_game_settings_serial = serial;
 	s_game_settings_interface = std::make_unique<INISettingsInterface>(VMManager::GetGameSettingsPath(serial, crc));
 	s_game_settings_interface->Load();
 	PopulatePatchesAndCheatsList(serial, crc);
@@ -1737,7 +1739,7 @@ void FullscreenUI::DoCopyGameSettings()
 	if (!s_game_settings_interface)
 		return;
 
-	Pcsx2Config::CopyConfiguration(s_game_settings_interface.get(), *GetEditingSettingsInterface(false));
+	Pcsx2Config::CopyConfiguration(s_game_settings_interface.get(), *GetEditingSettingsInterface(false), s_game_settings_serial);
 	Pcsx2Config::ClearInvalidPerGameConfiguration(s_game_settings_interface.get());
 
 	SetSettingsChanged(s_game_settings_interface.get());

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -3,6 +3,7 @@
 
 #include "common/CocoaTools.h"
 #include "common/FileSystem.h"
+#include "common/MemorySettingsInterface.h"
 #include "common/Path.h"
 #include "common/SettingsInterface.h"
 #include "common/SettingsWrapper.h"
@@ -11,6 +12,7 @@
 #include "Config.h"
 #include "GS.h"
 #include "CDVD/CDVDcommon.h"
+#include "GameDatabase.h"
 #include "Host.h"
 #include "Host/AudioStream.h"
 #include "SIO/Memcard/MemoryCardFile.h"
@@ -2315,7 +2317,7 @@ void Pcsx2Config::CopyRuntimeConfig(Pcsx2Config& cfg)
 	}
 }
 
-void Pcsx2Config::CopyConfiguration(SettingsInterface* dest_si, SettingsInterface& src_si)
+void Pcsx2Config::CopyConfiguration(SettingsInterface* dest_si, SettingsInterface& src_si, const std::string_view game_serial)
 {
 	FPControlRegisterBackup fpcr_backup(FPControlRegister::GetDefault());
 
@@ -2324,10 +2326,45 @@ void Pcsx2Config::CopyConfiguration(SettingsInterface* dest_si, SettingsInterfac
 		SettingsLoadWrapper wrapper(src_si);
 		temp.LoadSaveCore(wrapper);
 	}
+
+	// Two things a value can agree with, and agreeing with either means writing it
+	// down would decide nothing.
+	//
+	// Stock defaults: the value is simply untouched, and the file would carry it only
+	// as noise. Copying the whole configuration verbatim is what buried the handful of
+	// real choices under hundreds of these, and in a per-game file a key that is
+	// present is a key the player is taken to have claimed — which is how one press of
+	// this button used to disable every automatic fix a game had.
+	//
+	// What the database would set: it is going to set it regardless, so writing it can
+	// only turn into a claim that suppresses the very fix it agrees with.
+	//
+	// Note the reference is a default configuration with the database applied, not this
+	// one — the question is what the database wants, not what it would leave the source
+	// at. That matters for the few fixes that clamp rather than assign; for those this
+	// errs towards writing the player's value, never towards dropping a fix.
+	MemorySettingsInterface defaults_si;
 	{
-		SettingsSaveWrapper wrapper(*dest_si);
-		temp.LoadSaveCore(wrapper);
+		Pcsx2Config defaults;
+		SettingsSaveWrapper wrapper(defaults_si);
+		defaults.LoadSaveCore(wrapper);
 	}
+
+	MemorySettingsInterface database_si;
+	{
+		Pcsx2Config database;
+		if (const GameDatabaseSchema::GameEntry* game = GameDatabase::findGame(game_serial))
+		{
+			game->applyGameFixes(database, true, {}, GameDatabaseSchema::ApplyMode::Hypothetical);
+			game->applyGSHardwareFixes(database.GS, {}, GameDatabaseSchema::ApplyMode::Hypothetical);
+		}
+
+		SettingsSaveWrapper wrapper(database_si);
+		database.LoadSaveCore(wrapper);
+	}
+
+	SettingsSaveDeviationsWrapper wrapper(*dest_si, {&defaults_si, &database_si});
+	temp.LoadSaveCore(wrapper);
 }
 
 void Pcsx2Config::ClearConfiguration(SettingsInterface* dest_si)

--- a/pcsx2/PerGameOverrides.cpp
+++ b/pcsx2/PerGameOverrides.cpp
@@ -206,8 +206,10 @@ bool PerGameOverrideKeys::ClaimsAGameDBSetting(const char* section, const char* 
 
 	for (u32 i = 0; i < static_cast<u32>(CoreGameDBKnob::MaxCount); i++)
 	{
+		// A knob added to the enum but not to the table lands here with no section.
+		// The drift tests are what catch that; this only keeps it from being a crash.
 		const CoreKnobKeys keys = ForCoreKnob(static_cast<CoreGameDBKnob>(i));
-		if (std::strcmp(section, keys.section) != 0)
+		if (!keys.section || std::strcmp(section, keys.section) != 0)
 			continue;
 
 		for (u32 k = 0; k < keys.count; k++)
@@ -238,6 +240,9 @@ PerGameOverrides ComputePerGameOverrides(const SettingsInterface& game_layer)
 	for (u32 i = 0; i < static_cast<u32>(CoreGameDBKnob::MaxCount); i++)
 	{
 		const PerGameOverrideKeys::CoreKnobKeys keys = PerGameOverrideKeys::ForCoreKnob(static_cast<CoreGameDBKnob>(i));
+		if (!keys.section)
+			continue;
+
 		for (u32 k = 0; k < keys.count; k++)
 		{
 			if (!game_layer.ContainsValue(keys.section, keys.keys[k]))

--- a/pcsx2/PerGameOverrides.cpp
+++ b/pcsx2/PerGameOverrides.cpp
@@ -1,0 +1,264 @@
+// SPDX-FileCopyrightText: 2026 ARMSX2 Contributors
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "PerGameOverrides.h"
+
+#include "GameDatabase.h"
+
+#include "common/Assertions.h"
+#include "common/SettingsInterface.h"
+
+#include <array>
+#include <cstring>
+
+using GSHWFixId = GameDatabaseSchema::GSHWFixId;
+
+static_assert(static_cast<u32>(GSHWFixId::Count) <= 64, "PerGameOverrides::gs_fixes has a bit per GS hardware fix");
+static_assert(static_cast<u32>(GSUserHackOverride::MaxCount) <= 32, "GSOptions::UserHackOverrides has a bit per user hack");
+static_assert(static_cast<u32>(SpeedHack::MaxCount) <= 32, "PerGameOverrides::speedhacks has a bit per speedhack");
+
+namespace
+{
+	// One row per `EmuCore/GS` key the player can set that the game database also has
+	// an opinion about.
+	//
+	// `fix` is what applyGSHardwareFixes() iterates and is the reason a row exists.
+	// `hack` is the older, narrower vocabulary that MaskUserHacks() and the iOS
+	// frontend already speak; most rows carry both, and the two that carry only a
+	// hack are the texture-offset pair, which no database entry ever sets but which
+	// MaskUserHacks() would otherwise strip out from under a player who set it.
+	struct GSKeyRow
+	{
+		const char* key;
+		GSHWFixId fix; // GSHWFixId::Count when the database never writes this one
+		GSUserHackOverride hack; // GSUserHackOverride::MaxCount when it is not a user hack
+	};
+
+	constexpr GSKeyRow s_gs_keys[] = {
+		{"UserHacks_align_sprite_X", GSHWFixId::AlignSprite, GSUserHackOverride::AlignSprite},
+		{"UserHacks_merge_pp_sprite", GSHWFixId::MergeSprite, GSUserHackOverride::MergeSprite},
+		{"UserHacks_round_sprite_offset", GSHWFixId::RoundSprite, GSUserHackOverride::RoundSprite},
+		{"UserHacks_HalfPixelOffset", GSHWFixId::HalfPixelOffset, GSUserHackOverride::HalfPixelOffset},
+		{"UserHacks_ForceEvenSpritePosition", GSHWFixId::ForceEvenSpritePosition, GSUserHackOverride::ForceEvenSpritePosition},
+		{"UserHacks_native_scaling", GSHWFixId::NativeScaling, GSUserHackOverride::NativeScaling},
+		{"UserHacks_NativePaletteDraw", GSHWFixId::NativePaletteDraw, GSUserHackOverride::NativePaletteDraw},
+		{"UserHacks_BilinearHack", GSHWFixId::BilinearUpscale, GSUserHackOverride::BilinearHack},
+		{"UserHacks_TCOffsetX", GSHWFixId::Count, GSUserHackOverride::TextureOffsetX},
+		{"UserHacks_TCOffsetY", GSHWFixId::Count, GSUserHackOverride::TextureOffsetY},
+		{"UserHacks_AutoFlushLevel", GSHWFixId::AutoFlush, GSUserHackOverride::AutoFlush},
+		{"UserHacks_TextureInsideRt", GSHWFixId::TextureInsideRT, GSUserHackOverride::TextureInsideRt},
+		{"preload_frame_with_gs_data", GSHWFixId::PreloadFrameData, GSUserHackOverride::PreloadFrameData},
+		{"UserHacks_DisablePartialInvalidation", GSHWFixId::DisablePartialInvalidation, GSUserHackOverride::DisablePartialInvalidation},
+		{"paltex", GSHWFixId::GPUPaletteConversion, GSUserHackOverride::GPUPaletteConversion},
+		{"UserHacks_DisableDepthSupport", GSHWFixId::DisableDepthSupport, GSUserHackOverride::DisableDepthSupport},
+		{"UserHacks_CPU_FB_Conversion", GSHWFixId::CPUFramebufferConversion, GSUserHackOverride::CPUFBConversion},
+		{"UserHacks_ReadTCOnClose", GSHWFixId::FlushTCOnClose, GSUserHackOverride::ReadTCOnClose},
+		{"UserHacks_Limit24BitDepth", GSHWFixId::Limit24BitDepth, GSUserHackOverride::Limit24BitDepth},
+		{"UserHacks_EstimateTextureRegion", GSHWFixId::EstimateTextureRegion, GSUserHackOverride::EstimateTextureRegion},
+		{"UserHacks_DrawBuffering", GSHWFixId::DrawBuffering, GSUserHackOverride::DrawBuffering},
+		{"UserHacks_CPUSpriteRenderBW", GSHWFixId::CPUSpriteRenderBW, GSUserHackOverride::CPUSpriteRenderBW},
+		{"UserHacks_CPUSpriteRenderLevel", GSHWFixId::CPUSpriteRenderLevel, GSUserHackOverride::CPUSpriteRenderLevel},
+		{"UserHacks_CPUCLUTRender", GSHWFixId::CPUCLUTRender, GSUserHackOverride::CPUCLUTRender},
+		{"UserHacks_GPUTargetCLUTMode", GSHWFixId::GPUTargetCLUT, GSUserHackOverride::GPUTargetCLUT},
+
+		// Settings the database contends that were never part of the user-hack
+		// vocabulary. They have no hack bit because MaskUserHacks() does not strip
+		// them; a claim on these only has to reach applyGSHardwareFixes().
+		{"hw_mipmap", GSHWFixId::Mipmap, GSUserHackOverride::MaxCount},
+		{"HWAccurateAlphaTest", GSHWFixId::AccurateAlphaTest, GSUserHackOverride::MaxCount},
+		{"pcrtc_offsets", GSHWFixId::PCRTCOffsets, GSUserHackOverride::MaxCount},
+		{"pcrtc_overscan", GSHWFixId::PCRTCOverscan, GSUserHackOverride::MaxCount},
+		{"CoalesceRenderPasses", GSHWFixId::CoalesceRenderPasses, GSUserHackOverride::MaxCount},
+		{"TriFilter", GSHWFixId::TrilinearFiltering, GSUserHackOverride::MaxCount},
+		{"UserHacks_SkipDraw_Start", GSHWFixId::SkipDrawStart, GSUserHackOverride::MaxCount},
+		{"UserHacks_SkipDraw_End", GSHWFixId::SkipDrawEnd, GSUserHackOverride::MaxCount},
+		{"texture_preloading", GSHWFixId::TexturePreloading, GSUserHackOverride::MaxCount},
+		{"deinterlace_mode", GSHWFixId::Deinterlace, GSUserHackOverride::MaxCount},
+		{"HWDownloadMode", GSHWFixId::HWDownloadMode, GSUserHackOverride::MaxCount},
+
+		// One control, two database fixes: the database clamps the blend level from
+		// both ends, so claiming the setting has to silence both clamps or the player
+		// still gets moved.
+		{"accurate_blending_unit", GSHWFixId::MinimumBlendingLevel, GSUserHackOverride::MaxCount},
+		{"accurate_blending_unit", GSHWFixId::MaximumBlendingLevel, GSUserHackOverride::MaxCount},
+	};
+
+	// ⚠️ These are the settings keys, NOT GamefixOptions::GetGameFixName(), which
+	// returns the game database's YAML spelling. The database calls the first one
+	// "FpuMul" and the INI calls it "FpuMulHack". Order follows GamefixId.
+	constexpr const char* s_gamefix_keys[GamefixId_COUNT] = {
+		"FpuMulHack", // Fix_FpuMultiply
+		"GoemonTlbHack", // Fix_GoemonTlbMiss
+		"SoftwareRendererFMVHack", // Fix_SoftwareRendererFMV
+		"SkipMPEGHack", // Fix_SkipMpeg
+		"OPHFlagHack", // Fix_OPHFlag
+		"EETimingHack", // Fix_EETiming
+		"InstantDMAHack", // Fix_InstantDMA
+		"DMABusyHack", // Fix_DMABusy
+		"GIFFIFOHack", // Fix_GIFFIFO
+		"VIFFIFOHack", // Fix_VIFFIFO
+		"VIF1StallHack", // Fix_VIF1Stall
+		"VuAddSubHack", // Fix_VuAddSub
+		"IbitHack", // Fix_Ibit
+		"VUSyncHack", // Fix_VUSync
+		"VUOverflowHack", // Fix_VUOverflow
+		"XgKickHack", // Fix_XGKick
+		"BlitInternalFPSHack", // Fix_BlitInternalFPS
+		"FullVU0SyncHack", // Fix_FullVU0Sync
+	};
+
+	constexpr const char* s_speedhack_keys[static_cast<u32>(SpeedHack::MaxCount)] = {
+		"vuFlagHack", // SpeedHack::MVUFlag
+		"vu1Instant", // SpeedHack::InstantVU1
+		"vuThread", // SpeedHack::MTVU
+		"EECycleRate", // SpeedHack::EECycleRate
+	};
+} // namespace
+
+PerGameOverrideKeys::CoreKnobKeys PerGameOverrideKeys::ForCoreKnob(CoreGameDBKnob knob)
+{
+	// A clamp mode is one picker over several booleans, and the settings screens
+	// write every one of them together and delete every one together — see
+	// AdvancedSettingsWidget::setClampingMode and DrawClampingModeSetting. So any one
+	// of them being present is an exact test for "the player set this mode".
+	switch (knob)
+	{
+		case CoreGameDBKnob::EERoundMode:
+			return {"EmuCore/CPU", {"FPU.Roundmode"}, 1};
+		case CoreGameDBKnob::EEDivRoundMode:
+			return {"EmuCore/CPU", {"FPUDiv.Roundmode"}, 1};
+		case CoreGameDBKnob::VU0RoundMode:
+			return {"EmuCore/CPU", {"VU0.Roundmode"}, 1};
+		case CoreGameDBKnob::VU1RoundMode:
+			return {"EmuCore/CPU", {"VU1.Roundmode"}, 1};
+		case CoreGameDBKnob::EEClampMode:
+			return {"EmuCore/CPU/Recompiler", {"fpuOverflow", "fpuExtraOverflow", "fpuFullMode", "fpuExactMode"}, 4};
+		case CoreGameDBKnob::VU0ClampMode:
+			return {"EmuCore/CPU/Recompiler", {"vu0Overflow", "vu0ExtraOverflow", "vu0SignOverflow"}, 3};
+		case CoreGameDBKnob::VU1ClampMode:
+			return {"EmuCore/CPU/Recompiler", {"vu1Overflow", "vu1ExtraOverflow", "vu1SignOverflow"}, 3};
+		default:
+			return {nullptr, {}, 0};
+	}
+}
+
+const char* PerGameOverrideKeys::ForGamefix(GamefixId id)
+{
+	if (id < GamefixId_FIRST || id >= GamefixId_COUNT)
+		return nullptr;
+
+	return s_gamefix_keys[static_cast<size_t>(id)];
+}
+
+const char* PerGameOverrideKeys::ForSpeedHack(SpeedHack hack)
+{
+	if (hack >= SpeedHack::MaxCount)
+		return nullptr;
+
+	return s_speedhack_keys[static_cast<u32>(hack)];
+}
+
+const char* PerGameOverrideKeys::ForGSHWFix(GSHWFixId id)
+{
+	for (const GSKeyRow& row : s_gs_keys)
+	{
+		if (row.fix == id)
+			return row.key;
+	}
+
+	return nullptr;
+}
+
+bool PerGameOverrideKeys::ClaimsAGameDBSetting(const char* section, const char* key)
+{
+	if (std::strcmp(section, "EmuCore/GS") == 0)
+	{
+		for (const GSKeyRow& row : s_gs_keys)
+		{
+			if (std::strcmp(row.key, key) == 0)
+				return true;
+		}
+
+		return false;
+	}
+
+	if (std::strcmp(section, "EmuCore/Gamefixes") == 0)
+	{
+		for (const char* gamefix : s_gamefix_keys)
+		{
+			if (std::strcmp(gamefix, key) == 0)
+				return true;
+		}
+
+		return false;
+	}
+
+	if (std::strcmp(section, "EmuCore/Speedhacks") == 0)
+	{
+		for (const char* speedhack : s_speedhack_keys)
+		{
+			if (std::strcmp(speedhack, key) == 0)
+				return true;
+		}
+
+		return false;
+	}
+
+	for (u32 i = 0; i < static_cast<u32>(CoreGameDBKnob::MaxCount); i++)
+	{
+		const CoreKnobKeys keys = ForCoreKnob(static_cast<CoreGameDBKnob>(i));
+		if (std::strcmp(section, keys.section) != 0)
+			continue;
+
+		for (u32 k = 0; k < keys.count; k++)
+		{
+			if (std::strcmp(keys.keys[k], key) == 0)
+				return true;
+		}
+	}
+
+	return false;
+}
+
+PerGameOverrides ComputePerGameOverrides(const SettingsInterface& game_layer)
+{
+	PerGameOverrides ov;
+
+	for (const GSKeyRow& row : s_gs_keys)
+	{
+		if (!game_layer.ContainsValue("EmuCore/GS", row.key))
+			continue;
+
+		if (row.fix != GSHWFixId::Count)
+			ov.gs_fixes |= u64(1) << static_cast<u64>(row.fix);
+		if (row.hack != GSUserHackOverride::MaxCount)
+			ov.gs_hacks |= 1u << static_cast<u32>(row.hack);
+	}
+
+	for (u32 i = 0; i < static_cast<u32>(CoreGameDBKnob::MaxCount); i++)
+	{
+		const PerGameOverrideKeys::CoreKnobKeys keys = PerGameOverrideKeys::ForCoreKnob(static_cast<CoreGameDBKnob>(i));
+		for (u32 k = 0; k < keys.count; k++)
+		{
+			if (!game_layer.ContainsValue(keys.section, keys.keys[k]))
+				continue;
+
+			ov.core |= 1u << i;
+			break;
+		}
+	}
+
+	for (u32 i = 0; i < static_cast<u32>(SpeedHack::MaxCount); i++)
+	{
+		if (game_layer.ContainsValue("EmuCore/Speedhacks", s_speedhack_keys[i]))
+			ov.speedhacks |= 1u << i;
+	}
+
+	for (u32 i = GamefixId_FIRST; i < GamefixId_COUNT; i++)
+	{
+		if (game_layer.ContainsValue("EmuCore/Gamefixes", s_gamefix_keys[i]))
+			ov.gamefixes.set(i);
+	}
+
+	return ov;
+}

--- a/pcsx2/PerGameOverrides.h
+++ b/pcsx2/PerGameOverrides.h
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 ARMSX2 Contributors
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include "Config.h"
+
+#include <bitset>
+#include <optional>
+
+class SettingsInterface;
+
+// Opaque-enum declaration rather than including GameDatabase.h, which includes this
+// header back for applyGameFixes()'s parameter. A fixed underlying type makes the
+// name a complete type, so it can be cast without the enumerator list.
+namespace GameDatabaseSchema
+{
+	enum class GSHWFixId : u32;
+}
+
+/// The core (non-graphics) settings the game database can write, one entry per
+/// control a player can actually reach. A clamp mode gets one entry rather than one
+/// per boolean it expands to, because every settings screen writes and deletes all
+/// of a mode's keys together.
+enum class CoreGameDBKnob : u8
+{
+	EERoundMode,
+	EEDivRoundMode,
+	VU0RoundMode,
+	VU1RoundMode,
+	EEClampMode,
+	VU0ClampMode,
+	VU1ClampMode,
+
+	MaxCount
+};
+
+/// What a player deliberately chose for one specific game.
+///
+/// "Deliberately" is decided by presence. Every settings screen represents "use the
+/// global setting" by deleting the key — see SettingsWindow::setBoolSettingValue and
+/// the Draw*Setting helpers in the fullscreen UI — so a key sitting in a per-game
+/// file was put there on purpose. That is what lets the game database be overruled
+/// one setting at a time instead of by the all-or-nothing EnableGameFixes and
+/// ManualUserHacks switches, which throw away every other fix the game had.
+struct PerGameOverrides
+{
+	/// Bit per GSHWFixId. This is what applyGSHardwareFixes() consults. It is a u64
+	/// because there are more graphics fixes than the 32-bit UserHackOverrides mask
+	/// below can name, and that mask's width is a persisted INI format.
+	u64 gs_fixes = 0;
+	/// Bit per GSUserHackOverride, for GSOptions::UserHackOverrides. Narrower than
+	/// gs_fixes on purpose: it exists so MaskUserHacks() keeps sparing a claimed hack
+	/// and so a mask already written by the iOS frontend still composes.
+	u32 gs_hacks = 0;
+	u32 core = 0; ///< bit per CoreGameDBKnob
+	u32 speedhacks = 0; ///< bit per SpeedHack
+	std::bitset<GamefixId_COUNT> gamefixes;
+
+	bool Has(GameDatabaseSchema::GSHWFixId id) const { return (gs_fixes & (u64(1) << static_cast<u64>(id))) != 0; }
+	bool Has(CoreGameDBKnob knob) const { return (core & (1u << static_cast<u32>(knob))) != 0; }
+	bool Has(SpeedHack hack) const { return (speedhacks & (1u << static_cast<u32>(hack))) != 0; }
+	bool Has(GamefixId id) const { return gamefixes.test(static_cast<size_t>(id)); }
+
+	bool Any() const { return gs_fixes != 0 || gs_hacks != 0 || core != 0 || speedhacks != 0 || gamefixes.any(); }
+};
+
+/// Reads one per-game settings file — the game layer alone, never the layered stack,
+/// because the whole point is to tell that layer's keys apart from the global ones.
+PerGameOverrides ComputePerGameOverrides(const SettingsInterface& game_layer);
+
+/// The settings keys behind each knob. Exposed so the tests can prove the tables
+/// cover every enumerator: an unmapped knob is a database setting that silently keeps
+/// overriding the player, which is the bug this whole mechanism exists to fix.
+namespace PerGameOverrideKeys
+{
+	/// A knob's section, and the keys that together make it up. A clamp mode has
+	/// three or four; everything else has one.
+	struct CoreKnobKeys
+	{
+		const char* section;
+		const char* keys[4];
+		u32 count;
+	};
+
+	CoreKnobKeys ForCoreKnob(CoreGameDBKnob knob);
+
+	/// ⚠️ NOT the same string as GamefixOptions::GetGameFixName(), which returns the
+	/// game database's YAML name. The database says "FpuMul"; the settings key is
+	/// "FpuMulHack". Both tables are needed and neither can stand in for the other.
+	const char* ForGamefix(GamefixId id);
+
+	const char* ForSpeedHack(SpeedHack hack);
+
+	/// The `EmuCore/GS` key a player sets to claim this fix, or nullptr when the fix
+	/// has no key. Three of them are renderer routine selectors with no setting and no
+	/// UI, and three more only raise a recommendation and write nothing, so for those
+	/// six the database rightly keeps the last word.
+	const char* ForGSHWFix(GameDatabaseSchema::GSHWFixId id);
+
+	/// Whether writing this key into a per-game file claims anything the game database
+	/// contends. For frontends that keep a stored claim mask in step as the player
+	/// edits, rather than deriving it on load.
+	bool ClaimsAGameDBSetting(const char* section, const char* key);
+} // namespace PerGameOverrideKeys

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -27,6 +27,7 @@
 #include "PINE.h"
 #include "Patch.h"
 #include "PerformanceMetrics.h"
+#include "PerGameOverrides.h"
 #include "R3000A.h"
 #include "R5900.h"
 #include "Recording/InputRecording.h"
@@ -734,6 +735,13 @@ void VMManager::LoadCoreSettings(SettingsInterface& si)
 	if (SettingsInterface* base = Host::Internal::GetBaseSettingsLayer(); base && base != &si)
 		EmuConfig.GS.UserHackOverrides |= static_cast<u32>(base->GetIntValue("EmuCore/GS", "UserHackOverrides", 0));
 
+	// A hack key sitting in the per-game file is a claim on that hack, whether or not
+	// a frontend also wrote the mask — only iOS does. This is what makes MaskUserHacks()
+	// below spare it, so the value survives long enough for the database to be told to
+	// leave it alone.
+	if (const SettingsInterface* game_layer = Host::Internal::GetGameSettingsLayer())
+		EmuConfig.GS.UserHackOverrides |= ComputePerGameOverrides(*game_layer).gs_hacks;
+
 	Patch::ApplyPatchSettingOverrides();
 
 	// Achievements hardcore mode disallows setting some configuration options.
@@ -854,8 +862,16 @@ void VMManager::ApplyGameFixes()
 	if (!game)
 		return;
 
-	game->applyGameFixes(EmuConfig, EmuConfig.EnableGameFixes);
-	game->applyGSHardwareFixes(EmuConfig.GS);
+	// What the player set for this game specifically, which the database does not get
+	// to overwrite. Read from the game layer alone — the layered stack cannot tell a
+	// per-game choice from a global one, and only the per-game one outranks the
+	// database. The settings lock is held by both callers of this function.
+	PerGameOverrides overrides;
+	if (const SettingsInterface* game_layer = Host::Internal::GetGameSettingsLayer())
+		overrides = ComputePerGameOverrides(*game_layer);
+
+	game->applyGameFixes(EmuConfig, EmuConfig.EnableGameFixes, overrides);
+	game->applyGSHardwareFixes(EmuConfig.GS, overrides);
 
 	// Re-remove upscaling fixes, make sure they don't apply at native res.
 	// We do this in LoadCoreSettings(), but game fixes get applied afterwards because of the unsafe warning.

--- a/platforms/android/app/src/main/cpp/native-lib.cpp
+++ b/platforms/android/app/src/main/cpp/native-lib.cpp
@@ -46,6 +46,7 @@
 #include "common/Error.h"
 #include "common/HTTPDownloaderAndroid.h"
 #include "Host.h"
+#include "PerGameOverrides.h"
 #include "ImGui/FullscreenUI.h"
 #include "SIO/Pad/PadDualshock2.h"
 #include "MTGS.h"
@@ -1601,6 +1602,12 @@ Java_kr_co_iefriends_pcsx2_NativeApp_applyGSSettingsLive(JNIEnv *env, jclass cla
                 return false;
             SettingsLoadWrapper slw(*si);
             EmuConfig.GS.LoadSave(slw);
+
+            // Mirror VMManager::LoadCoreSettings: the reload above took the mask from
+            // whichever layer answered first, so re-derive the per-game claims or
+            // MaskUserHacks() below strips a hack the player set for this game.
+            if (const SettingsInterface* game_layer = Host::Internal::GetGameSettingsLayer())
+                EmuConfig.GS.UserHackOverrides |= ComputePerGameOverrides(*game_layer).gs_hacks;
         }
 
         // Restore everything RestartOptionsAreEqual() compares (+ the SW-thread quick-
@@ -1634,7 +1641,14 @@ Java_kr_co_iefriends_pcsx2_NativeApp_applyGSSettingsLive(JNIEnv *env, jclass cla
         // until the next launch. Mirrors ApplyGameFixes' GS portion.
         if (const GameDatabaseSchema::GameEntry* game = GameDatabase::findGame(VMManager::GetDiscSerial()))
         {
-            game->applyGSHardwareFixes(EmuConfig.GS);
+            PerGameOverrides overrides;
+            {
+                auto lock = Host::GetSettingsLock();
+                if (const SettingsInterface* game_layer = Host::Internal::GetGameSettingsLayer())
+                    overrides = ComputePerGameOverrides(*game_layer);
+            }
+
+            game->applyGSHardwareFixes(EmuConfig.GS, overrides);
             EmuConfig.GS.MaskUpscalingHacks();
         }
         return true;

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
@@ -51,6 +51,7 @@ extern "C" void ARMSX2_iOSCopyDeviceStats(int* outBatteryPercent, int* outTherma
 #include "SPU2/spu2.h"
 #include "GameList.h"
 #include "GameDatabase.h"
+#include "PerGameOverrides.h"
 #include "ps2/BiosTools.h"
 #include "pcsx2/Host.h"
 #include "pcsx2/INISettingsInterface.h"
@@ -1749,44 +1750,13 @@ static NSMutableDictionary<NSString*, id>* ARMSX2BuildGlobalGameSettingsResult()
 // Overlays per-game INI overrides for the given serial/crc onto a globals-seeded result.
 // Sourcing serial/crc from the caller avoids re-scanning the disc image (which is unsafe
 // while the VM is actively reading the same disc).
-// Every pin-backed hack key with its claim bit, so a file's mask is derivable
-// from which of these keys it holds rather than stored ahead of them.
-static constexpr struct { const char* key; GSUserHackOverride hack; } s_pinned_hack_keys[] = {
-    {"UserHacks_align_sprite_X", GSUserHackOverride::AlignSprite},
-    {"UserHacks_merge_pp_sprite", GSUserHackOverride::MergeSprite},
-    {"UserHacks_round_sprite_offset", GSUserHackOverride::RoundSprite},
-    {"UserHacks_HalfPixelOffset", GSUserHackOverride::HalfPixelOffset},
-    {"UserHacks_ForceEvenSpritePosition", GSUserHackOverride::ForceEvenSpritePosition},
-    {"UserHacks_native_scaling", GSUserHackOverride::NativeScaling},
-    {"UserHacks_NativePaletteDraw", GSUserHackOverride::NativePaletteDraw},
-    {"UserHacks_BilinearHack", GSUserHackOverride::BilinearHack},
-    {"UserHacks_TCOffsetX", GSUserHackOverride::TextureOffsetX},
-    {"UserHacks_AutoFlushLevel", GSUserHackOverride::AutoFlush},
-    {"UserHacks_TextureInsideRt", GSUserHackOverride::TextureInsideRt},
-    {"UserHacks_TCOffsetY", GSUserHackOverride::TextureOffsetY},
-    {"preload_frame_with_gs_data", GSUserHackOverride::PreloadFrameData},
-    {"UserHacks_DisablePartialInvalidation", GSUserHackOverride::DisablePartialInvalidation},
-    {"paltex", GSUserHackOverride::GPUPaletteConversion},
-    {"UserHacks_DisableDepthSupport", GSUserHackOverride::DisableDepthSupport},
-    {"UserHacks_CPU_FB_Conversion", GSUserHackOverride::CPUFBConversion},
-    {"UserHacks_ReadTCOnClose", GSUserHackOverride::ReadTCOnClose},
-    {"UserHacks_Limit24BitDepth", GSUserHackOverride::Limit24BitDepth},
-    {"UserHacks_EstimateTextureRegion", GSUserHackOverride::EstimateTextureRegion},
-    {"UserHacks_DrawBuffering", GSUserHackOverride::DrawBuffering},
-    {"UserHacks_CPUSpriteRenderBW", GSUserHackOverride::CPUSpriteRenderBW},
-    {"UserHacks_CPUSpriteRenderLevel", GSUserHackOverride::CPUSpriteRenderLevel},
-    {"UserHacks_CPUCLUTRender", GSUserHackOverride::CPUCLUTRender},
-    {"UserHacks_GPUTargetCLUTMode", GSUserHackOverride::GPUTargetCLUT},
-};
 
+// A file's mask is derivable from which keys it holds rather than stored ahead of
+// them. The key table lives in PerGameOverrides so the core and this bridge cannot
+// disagree about which settings a player is allowed to claim.
 static u32 ARMSX2DerivePerGameHackClaims(INISettingsInterface& si)
 {
-    u32 claims = 0;
-    for (const auto& entry : s_pinned_hack_keys) {
-        if (si.ContainsValue("EmuCore/GS", entry.key))
-            claims |= 1u << static_cast<u32>(entry.hack);
-    }
-    return claims;
+    return ComputePerGameOverrides(si).gs_hacks;
 }
 
 static void ARMSX2StoreDerivedPerGameHackClaims(INISettingsInterface& si)
@@ -1801,14 +1771,8 @@ static void ARMSX2StoreDerivedPerGameHackClaims(INISettingsInterface& si)
 // The generic per-game helpers write hack keys too, so they keep the mask in step.
 static void ARMSX2SyncClaimsIfPinnedHackKey(INISettingsInterface& si, NSString* section, NSString* key)
 {
-    if (![section isEqualToString:@"EmuCore/GS"])
-        return;
-    for (const auto& entry : s_pinned_hack_keys) {
-        if ([key isEqualToString:@(entry.key)]) {
-            ARMSX2StoreDerivedPerGameHackClaims(si);
-            return;
-        }
-    }
+    if (PerGameOverrideKeys::ClaimsAGameDBSetting([section UTF8String], [key UTF8String]))
+        ARMSX2StoreDerivedPerGameHackClaims(si);
 }
 
 static void ARMSX2ApplyPerGameSettingsOverrides(NSMutableDictionary<NSString*, id>* result, const std::string& serial, u32 crc)

--- a/tests/ctest/core/CMakeLists.txt
+++ b/tests/ctest/core/CMakeLists.txt
@@ -4,6 +4,7 @@ add_pcsx2_test(core_test
 	ee_fpu_reloc_tests.cpp
 	patch_tests.cpp
 	savestate_legacy_tests.cpp
+	settings_precedence_tests.cpp
 	MockMemoryInterface.h
 	StubHost.cpp
 )

--- a/tests/ctest/core/settings_precedence_tests.cpp
+++ b/tests/ctest/core/settings_precedence_tests.cpp
@@ -1,0 +1,425 @@
+// SPDX-FileCopyrightText: 2026 ARMSX2 Contributors
+// SPDX-License-Identifier: GPL-3.0+
+
+// Global settings < GameDB < per-game settings.
+//
+// The middle of that used to be the end of it: the database wrote into EmuConfig
+// after the whole settings read, so a value the player set for one game was quietly
+// replaced. What decides it now is whether the per-game file holds the key, since
+// every settings screen deletes the key rather than writing a value for "use the
+// global setting".
+//
+// That rule only holds while the key tables stay complete. A knob nobody mapped is a
+// setting that silently goes back to being overridden, and it looks like nothing —
+// no warning, no failure, just the old bug for that one setting. Hence the drift
+// guards below, which are the real reason this file exists.
+
+#include <gtest/gtest.h>
+
+#include "Config.h"
+#include "GameDatabase.h"
+#include "PerGameOverrides.h"
+
+#include "common/MemorySettingsInterface.h"
+#include "common/SettingsWrapper.h"
+
+namespace
+{
+
+// Stands in for a per-game INI. Same class the reference configurations are built
+// with, so values compare the way they will be stored.
+class GameFile
+{
+public:
+	GameFile& Set(const char* section, const char* key, int value)
+	{
+		m_si.SetIntValue(section, key, value);
+		return *this;
+	}
+
+	GameFile& Set(const char* section, const char* key, bool value)
+	{
+		m_si.SetBoolValue(section, key, value);
+		return *this;
+	}
+
+	const MemorySettingsInterface& Get() const { return m_si; }
+	PerGameOverrides Overrides() const { return ComputePerGameOverrides(m_si); }
+
+private:
+	MemorySettingsInterface m_si;
+};
+
+} // namespace
+
+// ---------------------------------------------------------------- provenance
+
+TEST(SettingsPrecedence, AnEmptyFileClaimsNothing)
+{
+	const PerGameOverrides ov = GameFile().Overrides();
+	EXPECT_FALSE(ov.Any());
+	EXPECT_EQ(ov.gs_fixes, 0u);
+	EXPECT_EQ(ov.gs_hacks, 0u);
+	EXPECT_EQ(ov.core, 0u);
+	EXPECT_EQ(ov.speedhacks, 0u);
+	EXPECT_TRUE(ov.gamefixes.none());
+}
+
+TEST(SettingsPrecedence, EveryGamefixKeyClaimsItsOwnFixAndNoOther)
+{
+	for (u32 i = GamefixId_FIRST; i < GamefixId_COUNT; i++)
+	{
+		const GamefixId id = static_cast<GamefixId>(i);
+		const char* key = PerGameOverrideKeys::ForGamefix(id);
+		ASSERT_NE(key, nullptr) << "gamefix " << i;
+
+		GameFile file;
+		file.Set("EmuCore/Gamefixes", key, false);
+		const PerGameOverrides ov = file.Overrides();
+
+		EXPECT_EQ(ov.gamefixes.count(), 1u) << key;
+		EXPECT_TRUE(ov.Has(id)) << key;
+		EXPECT_EQ(ov.core, 0u) << key;
+		EXPECT_EQ(ov.speedhacks, 0u) << key;
+	}
+}
+
+TEST(SettingsPrecedence, EverySpeedhackKeyClaimsItsOwnHackAndNoOther)
+{
+	for (u32 i = 0; i < static_cast<u32>(SpeedHack::MaxCount); i++)
+	{
+		const SpeedHack hack = static_cast<SpeedHack>(i);
+		const char* key = PerGameOverrideKeys::ForSpeedHack(hack);
+		ASSERT_NE(key, nullptr) << "speedhack " << i;
+
+		GameFile file;
+		file.Set("EmuCore/Speedhacks", key, 1);
+		const PerGameOverrides ov = file.Overrides();
+
+		EXPECT_EQ(ov.speedhacks, 1u << i) << key;
+		EXPECT_TRUE(ov.gamefixes.none()) << key;
+		EXPECT_EQ(ov.core, 0u) << key;
+	}
+}
+
+// A clamp mode is one picker over three or four keys. The screens write and delete
+// them together, so any one of them present has to claim the whole mode — otherwise
+// the database rewrites the other bits and the player gets a mode they never chose.
+TEST(SettingsPrecedence, AnyOneKeyOfAClampModeClaimsTheWholeMode)
+{
+	for (u32 i = 0; i < static_cast<u32>(CoreGameDBKnob::MaxCount); i++)
+	{
+		const CoreGameDBKnob knob = static_cast<CoreGameDBKnob>(i);
+		const PerGameOverrideKeys::CoreKnobKeys keys = PerGameOverrideKeys::ForCoreKnob(knob);
+		ASSERT_NE(keys.section, nullptr) << "knob " << i;
+		ASSERT_GT(keys.count, 0u) << "knob " << i;
+
+		for (u32 k = 0; k < keys.count; k++)
+		{
+			GameFile file;
+			file.Set(keys.section, keys.keys[k], true);
+			const PerGameOverrides ov = file.Overrides();
+
+			EXPECT_EQ(ov.core, 1u << i) << keys.keys[k];
+			EXPECT_TRUE(ov.gamefixes.none()) << keys.keys[k];
+			EXPECT_EQ(ov.speedhacks, 0u) << keys.keys[k];
+		}
+	}
+}
+
+TEST(SettingsPrecedence, AGraphicsKeyClaimsItsFixAndItsLegacyHackBit)
+{
+	GameFile file;
+	file.Set("EmuCore/GS", "UserHacks_align_sprite_X", true);
+	const PerGameOverrides ov = file.Overrides();
+
+	EXPECT_TRUE(ov.Has(GameDatabaseSchema::GSHWFixId::AlignSprite));
+	// The narrower mask matters too: MaskUserHacks() strips an unclaimed hack before
+	// the database is ever consulted, so without this bit the value is already gone.
+	EXPECT_EQ(ov.gs_hacks, 1u << static_cast<u32>(GSUserHackOverride::AlignSprite));
+}
+
+// Mipmapping was never a "user hack", so it has no bit in the legacy mask. It still
+// has to be claimable, because it is one of the settings people actually change.
+TEST(SettingsPrecedence, ASettingThatWasNeverAUserHackIsStillClaimable)
+{
+	GameFile file;
+	file.Set("EmuCore/GS", "hw_mipmap", false);
+	const PerGameOverrides ov = file.Overrides();
+
+	EXPECT_TRUE(ov.Has(GameDatabaseSchema::GSHWFixId::Mipmap));
+	EXPECT_EQ(ov.gs_hacks, 0u);
+}
+
+// One control, two database fixes. The database clamps the blend level from both
+// ends, so claiming the setting has to silence both or the player still gets moved.
+TEST(SettingsPrecedence, TheBlendingSettingClaimsBothOfItsClamps)
+{
+	GameFile file;
+	file.Set("EmuCore/GS", "accurate_blending_unit", 2);
+	const PerGameOverrides ov = file.Overrides();
+
+	EXPECT_TRUE(ov.Has(GameDatabaseSchema::GSHWFixId::MinimumBlendingLevel));
+	EXPECT_TRUE(ov.Has(GameDatabaseSchema::GSHWFixId::MaximumBlendingLevel));
+}
+
+// ---------------------------------------------------------------- drift guards
+
+TEST(SettingsPrecedenceDrift, EveryGamefixHasASettingsKey)
+{
+	for (u32 i = GamefixId_FIRST; i < GamefixId_COUNT; i++)
+	{
+		const char* key = PerGameOverrideKeys::ForGamefix(static_cast<GamefixId>(i));
+		ASSERT_NE(key, nullptr) << "gamefix " << i << " has no settings key, so it can never be claimed";
+		EXPECT_STRNE(key, "") << "gamefix " << i;
+	}
+}
+
+TEST(SettingsPrecedenceDrift, EverySpeedhackHasASettingsKey)
+{
+	for (u32 i = 0; i < static_cast<u32>(SpeedHack::MaxCount); i++)
+	{
+		const char* key = PerGameOverrideKeys::ForSpeedHack(static_cast<SpeedHack>(i));
+		ASSERT_NE(key, nullptr) << "speedhack " << i << " has no settings key, so it can never be claimed";
+	}
+}
+
+// The six exceptions are deliberate and are the whole list: three renderer routine
+// selectors with no setting and no UI, and three that only raise a recommendation and
+// write no config field. Anything else reaching this list is a setting that has gone
+// back to being silently overridden.
+TEST(SettingsPrecedenceDrift, OnlyTheSixUnsettableGraphicsFixesLackAKey)
+{
+	using GSHWFixId = GameDatabaseSchema::GSHWFixId;
+	static constexpr GSHWFixId kExpected[] = {
+		GSHWFixId::RecommendedBlendingLevel,
+		GSHWFixId::RecommendedAccurateAlphaTest,
+		GSHWFixId::RecommendedHWAA1,
+		GSHWFixId::GetSkipCount,
+		GSHWFixId::BeforeDraw,
+		GSHWFixId::MoveHandler,
+	};
+
+	for (u32 i = 0; i < static_cast<u32>(GSHWFixId::Count); i++)
+	{
+		const GSHWFixId id = static_cast<GSHWFixId>(i);
+		if (PerGameOverrideKeys::ForGSHWFix(id) != nullptr)
+			continue;
+
+		bool expected = false;
+		for (const GSHWFixId allowed : kExpected)
+			expected |= (allowed == id);
+
+		EXPECT_TRUE(expected) << "GS hardware fix " << i << " has no settings key, so the player cannot claim it";
+	}
+}
+
+TEST(SettingsPrecedenceDrift, EveryMappedKeyIsRecognisedAsAClaim)
+{
+	for (u32 i = GamefixId_FIRST; i < GamefixId_COUNT; i++)
+	{
+		EXPECT_TRUE(PerGameOverrideKeys::ClaimsAGameDBSetting(
+			"EmuCore/Gamefixes", PerGameOverrideKeys::ForGamefix(static_cast<GamefixId>(i))))
+			<< "gamefix " << i;
+	}
+
+	for (u32 i = 0; i < static_cast<u32>(SpeedHack::MaxCount); i++)
+	{
+		EXPECT_TRUE(PerGameOverrideKeys::ClaimsAGameDBSetting(
+			"EmuCore/Speedhacks", PerGameOverrideKeys::ForSpeedHack(static_cast<SpeedHack>(i))))
+			<< "speedhack " << i;
+	}
+
+	for (u32 i = 0; i < static_cast<u32>(CoreGameDBKnob::MaxCount); i++)
+	{
+		const PerGameOverrideKeys::CoreKnobKeys keys = PerGameOverrideKeys::ForCoreKnob(static_cast<CoreGameDBKnob>(i));
+		for (u32 k = 0; k < keys.count; k++)
+			EXPECT_TRUE(PerGameOverrideKeys::ClaimsAGameDBSetting(keys.section, keys.keys[k])) << keys.keys[k];
+	}
+
+	EXPECT_FALSE(PerGameOverrideKeys::ClaimsAGameDBSetting("EmuCore/GS", "Renderer"));
+	EXPECT_FALSE(PerGameOverrideKeys::ClaimsAGameDBSetting("EmuCore", "EnableCheats"));
+}
+
+// ---------------------------------------------------------------- the apply side
+
+TEST(SettingsPrecedenceApply, AnUnclaimedCoreKnobStillTakesTheDatabaseValue)
+{
+	GameDatabaseSchema::GameEntry entry;
+	entry.eeClampMode = static_cast<GameDatabaseSchema::ClampMode>(3);
+	entry.gameFixes.push_back(Fix_EETiming);
+	entry.speedHacks.emplace_back(SpeedHack::MTVU, 1);
+
+	Pcsx2Config config;
+	config.Cpu.Recompiler.SetEEClampMode(1);
+	config.Gamefixes.Set(Fix_EETiming, false);
+	config.Speedhacks.vuThread = false;
+
+	entry.applyGameFixes(config, true, {}, GameDatabaseSchema::ApplyMode::Hypothetical);
+
+	EXPECT_EQ(config.Cpu.Recompiler.GetEEClampMode(), 3u);
+	EXPECT_TRUE(config.Gamefixes.Get(Fix_EETiming));
+	EXPECT_TRUE(config.Speedhacks.vuThread);
+}
+
+TEST(SettingsPrecedenceApply, AClaimedCoreKnobKeepsThePlayersValue)
+{
+	GameDatabaseSchema::GameEntry entry;
+	entry.eeClampMode = static_cast<GameDatabaseSchema::ClampMode>(3);
+	entry.gameFixes.push_back(Fix_EETiming);
+	entry.speedHacks.emplace_back(SpeedHack::MTVU, 1);
+
+	const PerGameOverrides ov = GameFile()
+									.Set("EmuCore/CPU/Recompiler", "fpuFullMode", false)
+									.Set("EmuCore/Gamefixes", "EETimingHack", false)
+									.Set("EmuCore/Speedhacks", "vuThread", false)
+									.Overrides();
+
+	Pcsx2Config config;
+	config.Cpu.Recompiler.SetEEClampMode(1);
+	config.Gamefixes.Set(Fix_EETiming, false);
+	config.Speedhacks.vuThread = false;
+
+	entry.applyGameFixes(config, true, ov, GameDatabaseSchema::ApplyMode::Hypothetical);
+
+	EXPECT_EQ(config.Cpu.Recompiler.GetEEClampMode(), 1u);
+	EXPECT_FALSE(config.Gamefixes.Get(Fix_EETiming));
+	EXPECT_FALSE(config.Speedhacks.vuThread);
+}
+
+// Claiming one setting must not cost the game every other fix it had. That was the
+// whole failing of the two all-or-nothing switches this replaces.
+TEST(SettingsPrecedenceApply, ClaimingOneKnobLeavesTheRestOfTheEntryAlone)
+{
+	GameDatabaseSchema::GameEntry entry;
+	entry.eeClampMode = static_cast<GameDatabaseSchema::ClampMode>(3);
+	entry.vu1ClampMode = static_cast<GameDatabaseSchema::ClampMode>(2);
+	entry.gameFixes.push_back(Fix_EETiming);
+
+	const PerGameOverrides ov = GameFile().Set("EmuCore/CPU/Recompiler", "fpuOverflow", true).Overrides();
+
+	Pcsx2Config config;
+	config.Cpu.Recompiler.SetEEClampMode(1);
+	config.Cpu.Recompiler.vu1Overflow = false;
+	config.Cpu.Recompiler.vu1ExtraOverflow = false;
+	config.Cpu.Recompiler.vu1SignOverflow = false;
+	config.Gamefixes.Set(Fix_EETiming, false);
+
+	entry.applyGameFixes(config, true, ov, GameDatabaseSchema::ApplyMode::Hypothetical);
+
+	EXPECT_EQ(config.Cpu.Recompiler.GetEEClampMode(), 1u) << "the claimed one";
+	EXPECT_TRUE(config.Cpu.Recompiler.vu1Overflow) << "an unclaimed one";
+	EXPECT_TRUE(config.Cpu.Recompiler.vu1ExtraOverflow) << "an unclaimed one";
+	EXPECT_TRUE(config.Gamefixes.Get(Fix_EETiming)) << "an unclaimed one";
+}
+
+TEST(SettingsPrecedenceApply, AClaimedGraphicsFixKeepsThePlayersValue)
+{
+	GameDatabaseSchema::GameEntry entry;
+	entry.gsHWFixes.emplace_back(GameDatabaseSchema::GSHWFixId::Mipmap, 1);
+	entry.gsHWFixes.emplace_back(GameDatabaseSchema::GSHWFixId::TextureInsideRT, 1);
+
+	Pcsx2Config::GSOptions gs;
+	gs.HWMipmap = false;
+	gs.UserHacks_TextureInsideRt = GSTextureInRtMode::Disabled;
+
+	const PerGameOverrides ov = GameFile().Set("EmuCore/GS", "hw_mipmap", false).Overrides();
+	entry.applyGSHardwareFixes(gs, ov, GameDatabaseSchema::ApplyMode::Hypothetical);
+
+	EXPECT_FALSE(gs.HWMipmap) << "claimed, so the database stands aside";
+	EXPECT_EQ(gs.UserHacks_TextureInsideRt, GSTextureInRtMode::InsideTargets) << "unclaimed, so it still applies";
+}
+
+// ---------------------------------------------------------------- the copy filter
+
+namespace
+{
+
+// Everything CopyConfiguration would write, as key counts per section.
+size_t CountKeys(const MemorySettingsInterface& si, const char* section)
+{
+	return si.GetKeyValueList(section).size();
+}
+
+} // namespace
+
+TEST(SettingsCopyFilter, CopyingAnUntouchedConfigurationWritesNothing)
+{
+	MemorySettingsInterface source;
+	{
+		Pcsx2Config defaults;
+		SettingsSaveWrapper wrapper(source);
+		defaults.LoadSaveCore(wrapper);
+	}
+
+	MemorySettingsInterface dest;
+	Pcsx2Config::CopyConfiguration(&dest, source, std::string_view());
+
+	EXPECT_EQ(CountKeys(dest, "EmuCore/GS"), 0u);
+	EXPECT_EQ(CountKeys(dest, "EmuCore/Gamefixes"), 0u);
+	EXPECT_EQ(CountKeys(dest, "EmuCore/Speedhacks"), 0u);
+	EXPECT_EQ(CountKeys(dest, "EmuCore/CPU/Recompiler"), 0u);
+	EXPECT_TRUE(dest.IsEmpty()) << "a copy of stock settings is not a set of decisions";
+}
+
+// The other half of the filter, and the one that keeps the copy button from
+// suppressing fixes: a value the database is going to set anyway is not a decision,
+// so writing it down would only create a claim against the fix it agrees with.
+//
+// Driven through the wrapper rather than CopyConfiguration because building the real
+// second reference means loading the game database off disk, which a unit test has no
+// business doing. The reference here is what a database entry would have produced.
+TEST(SettingsCopyFilter, AValueTheDatabaseWouldSetAnywayIsNotWritten)
+{
+	MemorySettingsInterface defaults_si;
+	{
+		Pcsx2Config defaults;
+		SettingsSaveWrapper wrapper(defaults_si);
+		defaults.LoadSaveCore(wrapper);
+	}
+
+	MemorySettingsInterface database_si;
+	{
+		// Stands in for a game whose entry carries `gameFixes: [EETiming]`.
+		Pcsx2Config database;
+		database.Gamefixes.Set(Fix_EETiming, true);
+		SettingsSaveWrapper wrapper(database_si);
+		database.LoadSaveCore(wrapper);
+	}
+
+	// The player turned the same fix on globally, and separately turned another one on
+	// that the database says nothing about.
+	Pcsx2Config source;
+	source.Gamefixes.Set(Fix_EETiming, true);
+	source.Gamefixes.Set(Fix_XGKick, true);
+
+	MemorySettingsInterface dest;
+	{
+		SettingsSaveDeviationsWrapper wrapper(dest, {&defaults_si, &database_si});
+		source.LoadSaveCore(wrapper);
+	}
+
+	EXPECT_FALSE(dest.ContainsValue("EmuCore/Gamefixes", "EETimingHack"))
+		<< "the database sets this one, so claiming it would suppress the fix it agrees with";
+	EXPECT_TRUE(dest.ContainsValue("EmuCore/Gamefixes", "XgKickHack"))
+		<< "the database says nothing about this one, so it is a real decision";
+	EXPECT_EQ(CountKeys(dest, "EmuCore/Gamefixes"), 1u);
+}
+
+TEST(SettingsCopyFilter, OnlyTheChangedValueIsWritten)
+{
+	MemorySettingsInterface source;
+	{
+		Pcsx2Config config;
+		config.Gamefixes.Set(Fix_EETiming, true);
+		SettingsSaveWrapper wrapper(source);
+		config.LoadSaveCore(wrapper);
+	}
+
+	MemorySettingsInterface dest;
+	Pcsx2Config::CopyConfiguration(&dest, source, std::string_view());
+
+	EXPECT_EQ(CountKeys(dest, "EmuCore/Gamefixes"), 1u);
+	EXPECT_TRUE(dest.ContainsValue("EmuCore/Gamefixes", "EETimingHack"));
+	EXPECT_EQ(CountKeys(dest, "EmuCore/GS"), 0u);
+}


### PR DESCRIPTION
Change a setting in the per-game settings screen and it does not take. The widget keeps the new value, the file on disk keeps it, and the emulator runs with something else — for every game the database has an entry for.

The layered read already puts the per-game file above the global one. The inversion is that the database writes into `EmuConfig` afterwards, from `VMManager::ApplyGameFixes`, with no idea where any value came from. The only ways out today are two all-or-nothing switches, `EnableGameFixes` and Manual Hardware Fixes, and either one rescues the setting you wanted by discarding every other fix the game had.

## How it decides

A key sitting in a per-game file is a deliberate act: every settings screen represents "use the global setting" by deleting the key. `PerGameOverrides` reads the game layer alone and reports what it claims; both apply functions then leave those settings alone, down the road they already had for the global switches, so each is still named in the log and now on screen too.

This finishes the per-hack pin `915e914ba6` added and left without a writer outside iOS. That mask stays and the derived bits merge into it, but the claim itself is keyed by hardware-fix id: there are more fixes than its 32 bits can name, and the settings people actually change — mipmapping, trilinear, deinterlacing, texture preloading, blend level, download mode — were never user hacks and had no bit at all.

The database keeps the last word on the three renderer routine selectors, which have no setting and no UI, and the BIOS path is untouched.

## Copy Global Settings

That button wrote every key — around seven hundred, including sections no settings page shows. Harmless until a key present means the player claimed it; then one press disables every automatic fix the game had.

It now writes a value only when it differs from the stock default *and* from what the database would set for that game. Agreeing with either decides nothing: the first is noise, the second only creates a claim against the fix it agrees with. Working out that second reference means applying the database for an outcome nobody will run with, so the apply functions take a mode that logs nothing, raises no recommendations, and skips the Goemon fix's 4 MB allocation.

## Tests

18 cases, none needing a VM. The load-bearing ones are drift guards: every gamefix, speedhack and clamp mode must have a settings key, and only the six graphics fixes with no setting behind them may lack one. An unmapped knob is a setting that silently goes back to being overridden.

Build clean, 6/6 ctest suites, `recompiler_tests` 1901 plus the known DXSTG skip.

## Known gaps

- **Android and iOS are uncompiled** — no SDK on the machine this was written on. Both changes are small and mechanical, but they need a build elsewhere.
- **Files from the old copy button are not migrated.** They hold every key and will suppress that game's fixes. An automatic prune was rejected: it would rewrite files in `gamesettings/` unasked, and a copied file cannot be told from a hand-made one. Release note instead — *if a game's automatic compatibility fixes stopped applying after you used "Copy Global Settings", press "Clear Settings" for that game and set your preferences again.*
