### PR TITLE
GameDB: internal FPS by DISPFB blit for NASCAR Thunder 2002 through NASCAR 06

### DIFF
--- a/bin/resources-overlay/armsx2_overrides.yaml
+++ b/bin/resources-overlay/armsx2_overrides.yaml
@@ -38,6 +38,48 @@ SLES-53299:
     hwDownloadMode: 3
     nativeScaling: 2
     textureInsideRT: 1
+# NASCAR Thunder 2002 through NASCAR 06 — count DISPFB blits instead of
+# privileged register writes when working out the internal frame rate. Reported
+# by yuasasa on Android handhelds.
+#
+# The register-write detector reads these engines as producing a new image every
+# vblank. SkipDuplicateFrames (default on) trusts that answer, so no duplicate is
+# ever dropped and every repeated frame still pays for a full present. Counting
+# blits into the displayed framebuffer gives the real render rate and lets the
+# skip fire again.
+#
+# Scope is the five titles the reporter named; every serial each was released
+# under is listed, since the fix is a property of the engine and not the region.
+# The rest of the series is out on his word that it does not need this. NASCAR 07
+# is a separate case — upstream GameIndex.yaml already sets the fix on both its
+# serials, and restating it here would put its gameFixes list under this overlay's
+# clear-then-replace rule, so anything upstream added later would be dropped on
+# mobile.
+#
+# gameFixes only, for that same rule: upstream carries roundSprite on the Thunder
+# entries and deinterlace on Total Team Control, and naming gsHWFixes here would
+# delete them.
+SLES-53635:            # NASCAR 06 - Total Team Control (PAL-E)
+  gameFixes:
+    - BlitInternalFPSHack
+SLUS-20266:            # NASCAR Thunder 2002
+  gameFixes:
+    - BlitInternalFPSHack
+SLUS-20535:            # NASCAR Thunder 2003
+  gameFixes:
+    - BlitInternalFPSHack
+SLUS-20754:            # NASCAR Thunder 2004
+  gameFixes:
+    - BlitInternalFPSHack
+SLUS-20824:            # NASCAR Thunder 2004
+  gameFixes:
+    - BlitInternalFPSHack
+SLUS-21003:            # NASCAR 2005 - Chase for the Cup
+  gameFixes:
+    - BlitInternalFPSHack
+SLUS-21266:            # NASCAR 06 - Total Team Control (NTSC-U)
+  gameFixes:
+    - BlitInternalFPSHack
 PAPX-90522:
   clampModes:
     eeClampMode: 3


### PR DESCRIPTION
Adds `BlitInternalFPSHack` to five NASCAR titles in the mobile GameDB overlay
(`bin/resources-overlay/armsx2_overrides.yaml`).

**Credit:** reported by **yuasasa** on Android handhelds.

### Why it does anything

Internal frame rate is inferred one of two ways. The default counts writes to the
privileged display registers; the fix counts draws into the framebuffer currently
being scanned out. That choice is not just cosmetic — `SkipDuplicateFrames`
(default on) asks the same detector whether a frame is new, and skips presenting
the ones that aren't.

On these engines the register detector answers "new" every vblank, so no
duplicate is ever dropped and every repeated frame still pays for a swapchain
acquire, a composition blit and a wait on the display refresh. Blit counting
reports the real render rate, so the skip fires again. Emulation work is
unchanged — the saving is purely on the presentation side, which is where it
matters on a handheld.

### Scope

Seven entries, `gameFixes` only, covering five titles:

| Title | Serials |
|---|---|
| NASCAR Thunder 2002 | SLUS-20266 |
| NASCAR Thunder 2003 | SLUS-20535 |
| NASCAR Thunder 2004 | SLUS-20754, SLUS-20824 |
| NASCAR 2005 - Chase for the Cup | SLUS-21003 |
| NASCAR 06 - Total Team Control | SLUS-21266, SLES-53635 |

Thunder 2004 shipped under two serials and 06 under two regions; all four are
listed, since the behaviour belongs to the engine rather than the release.

- The overlay is **clear-then-replace per field**, so naming `gsHWFixes` would
  delete what upstream carries on five of these: `roundSprite` on the three
  Thunder entries and `deinterlace` on the two Total Team Control ones. Verified
  in `populateEntry` that unnamed fields are left alone.
- **The rest of the series is out** on the reporter's word that it does not need
  this.
- **NASCAR 07 is a separate case.** Upstream `GameIndex.yaml` already sets
  `BlitInternalFPSHack` on both SLES-54223 and SLUS-21461, so it needs nothing
  here — and restating it would put that list under the replace rule, dropping
  anything upstream adds to those entries later. It also independently
  corroborates the report: upstream already found this on one title in the series.

### Testing

The per-title effect is user-reported and not independently measured here. Worth
noting for anyone confirming it: the OSD "FPS" line **is** the internal FPS, so
it changes by definition when the detector changes, and blit counting reads high
on games that composite in several draws. Read **Emulation speed %** instead —
it comes from actual vblanks and is unaffected by which detector is active.

Validated: YAML parses, no duplicate serials, all seven exist upstream, every
added entry is `gameFixes`-only, and the five upstream `gsHWFixes` survive the
merge.