### PR TITLE
Update FileSystem.cpp

### DIFF
--- a/common/FileSystem.cpp
+++ b/common/FileSystem.cpp
@@ -1367,7 +1367,7 @@ std::span<const u8> FileSystem::MapBinaryFileForRead(const char* path)
 	return result;
 #else
 	int fd = open(path, O_RDONLY);
-	if (fd <= 0)
+	if (fd < 0)
 		return {};
 	std::span<const u8> result = ::MapBinaryFileForRead(fd);
 	close(fd);


### PR DESCRIPTION
open() reports failure as -1. 0 is a perfectly valid descriptor, and on a bare-init system where stdin was never opened it is the first one handed out, therefore `fd <= 0` rejects the very first file the process tries to read. Considering this is a project aiming ARM, and lots of embedded systems use ARM, it's reasonable to assume that could happen.

### Description of Changes
Properly handles open() returning 0

### Rationale behind Changes
0 is a perfectly valid descriptor, and on a bare-init system that would likely be the case. 

### Suggested Testing Steps
Try to run on a bare init-system (e.g an embedded system with bare Linux) where there is no stdin/out.