### PR TITLE
Android: gate librashader on cargo version, not just presence (AI-ass…

### DIFF
--- a/platforms/android/app/src/main/cpp/3rdparty/librashader/CMakeLists.txt
+++ b/platforms/android/app/src/main/cpp/3rdparty/librashader/CMakeLists.txt
@@ -33,6 +33,22 @@ if(NOT CARGO_EXECUTABLE)
 	return()
 endif()
 
+# cargo must be recent enough to parse the pinned tree's dependency graph. moxcms (a
+# transitive dep) is edition 2024, which needs cargo >= 1.85; an older-but-present cargo
+# otherwise fails the WHOLE native build deep inside an opaque transitive manifest parse
+# ("feature `edition2024` is required"). Disable + warn instead, matching the "cargo not
+# found" contract above so a stale toolchain compiles the feature out rather than breaking
+# the build.
+execute_process(COMMAND ${CARGO_EXECUTABLE} --version
+	OUTPUT_VARIABLE _lrs_cargo_ver OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" _lrs_cargo_ver "${_lrs_cargo_ver}")
+if(_lrs_cargo_ver VERSION_LESS "1.85.0")
+	message(STATUS "librashader: cargo ${_lrs_cargo_ver} too old (need >= 1.85 for edition2024) "
+	               "-> RetroArch shader support DISABLED. Run `rustup update` to enable it.")
+	set(ARMSX2_HAVE_LIBRASHADER OFF PARENT_SCOPE)
+	return()
+endif()
+
 # ---- Android ABI -> Rust target ---------------------------------------------------
 if(ANDROID_ABI STREQUAL "arm64-v8a")
 	set(_lrs_rust_target "aarch64-linux-android")


### PR DESCRIPTION
…isted)

librashader's CMake shim disabled the feature (and left the build working) only when cargo was absent. A present-but-old cargo instead failed the whole native build deep inside an opaque transitive manifest parse — the pinned tree's moxcms dep is edition 2024, which needs cargo >= 1.85.

Extend the existing optional-toolchain gate to also check `cargo --version` and disable + warn when it is < 1.85, matching the "cargo not found" contract directly above it so a stale toolchain compiles the shader chain out via #ifdef rather than breaking the build.

### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

### AI Assistance (optional)
<!-- AI-assisted contributions are welcome here — we use these tools ourselves, and this is not a gate on your PR. If AI did a meaningful share of the work, a line on where it helped lets reviewers focus their attention. What we ask regardless of how the patch was written: you understand the change, you can explain why it is correct, and you have built and tested it. We review the code, not the toolchain. -->