### PR TITLE
Common: fix unpaced frame limiter when CNTFRQ_EL0 reads 0

### DIFF
--- a/common/Linux/LnxMisc.cpp
+++ b/common/Linux/LnxMisc.cpp
@@ -89,14 +89,38 @@ u64 GetAvailablePhysicalMemory()
 	return (static_cast<u64>(info.freeram) + static_cast<u64>(info.bufferram)) * static_cast<u64>(info.mem_unit);
 }
 
+// On AArch64 every tick consumer (frame limiter, present pacer, perf metrics) derives time from
+// the architected timer: GetCPUTicks() reads CNTVCT_EL0 and GetTickFrequency() reads CNTFRQ_EL0.
+// Some kernels — Exynos 88xx boards on LineageOS-family ROMs are a known case — leave CNTFRQ_EL0
+// uninitialized (it reads 0). GetTickFrequency() then returns 0, ticks-per-frame collapses to 0
+// (the log literally shows "ticks per frame: 0"), Throttle() never sleeps, and the emulation runs
+// completely unpaced with every speed control dead. Detect the missing frequency once and fall
+// back to the CLOCK_MONOTONIC nanosecond domain, keeping GetCPUTicks() and GetTickFrequency()
+// in the same time domain.
+#if defined(__aarch64__)
+static bool ArchTimerUsable()
+{
+	static const bool usable = []() {
+		u64 freq;
+		asm volatile("mrs %0, cntfrq_el0" : "=r"(freq));
+		return freq >= 1000000u; // real ARM timers are MHz-range (19.2/24/26/50 MHz, 1GHz with ECV)
+	}();
+	return usable;
+}
+#endif
+
 u64 GetTickFrequency()
 {
 #if defined(__aarch64__)
 	// Frequency of the architected virtual counter read by GetCPUTicks() (e.g. 19.2MHz on
 	// Snapdragon 865, 24MHz on Apple M2, 1GHz on ARMv8.6+ with FEAT_ECV).
-	u64 freq;
-	asm volatile("mrs %0, cntfrq_el0" : "=r"(freq));
-	return freq;
+	if (ArchTimerUsable())
+	{
+		u64 freq;
+		asm volatile("mrs %0, cntfrq_el0" : "=r"(freq));
+		return freq;
+	}
+	return 1000000000; // unix measures in nanoseconds
 #else
 	return 1000000000; // unix measures in nanoseconds
 #endif
@@ -111,14 +135,16 @@ u64 GetCPUTicks()
 	// Linux always enables EL0 counter access since its own vDSO fast path requires it. Resolution
 	// is coarser than 1ns (~52ns at 19.2MHz), which is ample for every consumer of this clock; all
 	// consumers must convert through GetTickFrequency() rather than assuming nanoseconds.
-	u64 val;
-	asm volatile("mrs %0, cntvct_el0" : "=r"(val)::"memory");
-	return val;
-#else
+	if (ArchTimerUsable())
+	{
+		u64 val;
+		asm volatile("mrs %0, cntvct_el0" : "=r"(val)::"memory");
+		return val;
+	}
+#endif
 	struct timespec ts;
 	clock_gettime(CLOCK_MONOTONIC, &ts);
 	return (static_cast<u64>(ts.tv_sec) * 1000000000ULL) + ts.tv_nsec;
-#endif
 }
 
 std::string GetOSVersionString()

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -48,6 +48,7 @@
 #include "common/Error.h"
 #include "common/FileSystem.h"
 #include "common/FPControl.h"
+#include "common/HostSys.h"
 #include "common/Perf.h"
 #include "common/ScopedGuard.h"
 #include "common/SettingsWrapper.h"
@@ -2510,10 +2511,11 @@ void VMManager::Internal::Throttle()
 	}
 
 	// Conversion to milliseconds loses some precision; after sleeping off whole milliseconds,
-	// spin the thread without sleeping until we finally reach our expected end time.
+	// spin the thread without sleeping until we finally reach our expected end time. Hint the
+	// spin with the calibrated pause bursts (pause on x86, isb on AArch64) instead of hammering
+	// the counter bare - the hint keeps the co-resident cores' throughput and cuts power.
 	while (GetCPUTicks() < uExpectedEnd)
-	{
-	}
+		ShortSpin();
 
 	// Finally, set our next frame start to when this one ends
 	s_limiter_frame_start = uExpectedEnd;


### PR DESCRIPTION
### Description of Changes
common/Linux/LnxMisc.cpp: fall back when CNTFRQ_EL0 is unset.
Adds ArchTimerUsable() (cached, freq >= 1 MHz sanity check). When CNTFRQ_EL0 reads 0/unusable, GetTickFrequency() returns 1e9 and GetCPUTicks() returns clock_gettime(CLOCK_MONOTONIC) ns. Keeps both functions in the same time domain, matching the existing non-AArch64 path.

pcsx2/VMManager.cpp: hint the frame-limiter spin.
Adds #include "common/HostSys.h" and replaces the bare while (GetCPUTicks() < uExpectedEnd) {} in Throttle() with while (GetCPUTicks() < uExpectedEnd) ShortSpin();. Reuses the existing calibrated helper (common/HostSys.cpp:MultiPause → 8× isb on AArch64 / 8× _mm_pause on x86, ~500ns per ShortSpin()), same pattern already used in GSDumpReplayer.cpp:254.

### Rationale behind Changes
On the Exynos variant of Samsung Galaxy S8 (lineage 21.0 custom rom), the emulator would run well over 100% emulation speed no matter what setting was adjusted or changed from default as if fast-forward was force toggled on.

On some ARM64 kernels CNTFRQ_EL0 is never initialized and reads 0. The emulog then shows ticks per frame: 0 and @@ANDROID_FPSCAP@@ interval_ticks=0. With freq=0, s_limiter_ticks_per_frame = freq / (fps*speed) = 0, so Throttle() never sleeps (always takes its too-slow branch every frame) and every speed control is dead. sDeltaTime / s_limiter_ticks_per_frame then evaluates to 0 (ARM64 integer division by zero returns 0 without trapping), so nothing crashes - pacing is simply gone.

### Suggested Testing Steps
1. Affected device (CNTFRQ=0): boot any game, check emulog.txt — before: ticks per frame: 0, after: ticks per frame: 16666666 (at 60Hz). Game paces at 100% speed, Frame Limit / Speed Limit / FPS cap now have effect. EE%/GS% perf metrics report non-zero.
2. Normal device (CNTFRQ valid, e.g. 19.2/24MHz, 1GHz with FEAT_ECV): no behavior change — ArchTimerUsable() stays on the CNTVCT path, verify ticks per frame still sane and frame pacing unchanged.
3. Spin hint: compare power/thermal on a sustained 60fps title before/after; no functional change expected, just fewer counter polls in the <1ms tail spin. 

### AI Assistance (optional)
This is all 100% AI generated. The code has also been built (on the PR repo via actions) and tested on the affected device to resolve the issue without any known regressions.