### PR TITLE
iOS: give CI builds the RetroAchievements client identity

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -169,6 +169,19 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode.app
 
+      # RetroAchievements grants hardcore on the client name and version in the HTTP user
+      # agent, and pcsx2/Host.cpp reads that version from a gitignored header. Only builds
+      # that reach players get it: a pull request artifact would be one more public copy of
+      # an identity that cannot be revoked without a release. Those keep the stock PCSX2
+      # agent and stay softcore, which is what a test build should be.
+      - name: Embed the RetroAchievements client identity
+        if: >-
+          github.repository == 'ARMSX2/ARMSX2' &&
+          github.event_name == 'push' && github.ref == 'refs/heads/master'
+        env:
+          IOS_RA_UA_VERSION: ${{ secrets.IOS_RA_UA_VERSION }}
+        run: bash .github/workflows/scripts/common/write-ra-ua-secret.sh
+
       - name: Configure (CMake, Xcode generator, real device SDK, no signing)
         working-directory: platforms/ios/app/src/main/cpp
         run: >
@@ -208,6 +221,21 @@ jobs:
 
           echo "IPA_NAME=$IPA_NAME" >> $GITHUB_ENV
           ls -lh "$IPA_NAME"
+
+      # Nothing on the client reports a rejected agent, so a master build that lost the
+      # identity looks healthy until a player loses an unlock. Fail here instead. Carries
+      # the same guard as the write step, or every pull request would fail this check.
+      - name: Verify the client identity reached the binary
+        if: >-
+          github.repository == 'ARMSX2/ARMSX2' &&
+          github.event_name == 'push' && github.ref == 'refs/heads/master'
+        working-directory: platforms/ios/app/src/main/cpp
+        env:
+          IOS_RA_UA_VERSION: ${{ secrets.IOS_RA_UA_VERSION }}
+        run: |
+          APP_PATH=$(find build -name "ARMSX2iOS.app" -type d | head -1)
+          bash "$GITHUB_WORKSPACE/.github/workflows/scripts/common/verify-ra-ua-agent.sh" \
+            "$APP_PATH/ARMSX2iOS"
 
       - name: Upload .ipa
         uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -293,8 +293,28 @@ jobs:
       - uses: actions/checkout@v7
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode.app
+
+      # RetroAchievements grants hardcore on the client name and version in the HTTP user
+      # agent, and pcsx2/Host.cpp reads that version from a gitignored header. Without this
+      # step the nightly identifies as stock PCSX2 and every unlock is softcore. Add the
+      # repo secret IOS_RA_UA_VERSION (the bare version, no leading v) to turn it on; the
+      # script warns and continues when it is absent.
+      - name: Embed the RetroAchievements client identity
+        env:
+          IOS_RA_UA_VERSION: ${{ secrets.IOS_RA_UA_VERSION }}
+        run: bash .github/workflows/scripts/common/write-ra-ua-secret.sh
+
       - name: Build unsigned IPA
         run: ./platforms/ios/scripts/build-ios-ipa.sh
+
+      # Nothing on the client reports a rejected agent, so a nightly that lost the identity
+      # looks healthy until a player loses an unlock. Fail here instead.
+      - name: Verify the client identity reached the binary
+        env:
+          IOS_RA_UA_VERSION: ${{ secrets.IOS_RA_UA_VERSION }}
+        run: >
+          bash .github/workflows/scripts/common/verify-ra-ua-agent.sh
+          platforms/ios/build-ios-xcode/Release-iphoneos/ARMSX2iOS.app/ARMSX2iOS
 
       - name: Upload IPA
         uses: actions/upload-artifact@v7

--- a/.github/workflows/scripts/common/verify-ra-ua-agent.sh
+++ b/.github/workflows/scripts/common/verify-ra-ua-agent.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Fail the build if the RetroAchievements client identity did not reach the binary.
+#
+# A reordered step, a stale build directory or a wrong path each produce a working IPA that
+# reports itself as stock PCSX2. Nothing on the client says so, and the first sign is a
+# player losing a hardcore unlock. Matching the exact version rather than the name also
+# catches a build that compiled an older header.
+
+set -euo pipefail
+
+BINARY="${1:-}"
+
+if [[ -z "$BINARY" ]]; then
+	echo "::error::usage: verify-ra-ua-agent.sh <path to the built binary>"
+	exit 1
+fi
+
+if [[ ! -f "$BINARY" ]]; then
+	echo "::error::$BINARY does not exist, so the build did not produce what this check reads."
+	exit 1
+fi
+
+VERSION="$(printf '%s' "${IOS_RA_UA_VERSION:-}" | tr -d '[:space:]')"
+
+if [[ -z "$VERSION" ]]; then
+	echo "no secret was supplied, so this build identifies as stock PCSX2. Nothing to verify."
+	exit 0
+fi
+
+# The trailing space comes from Host.cpp's format string and is load bearing: a stale 1.2.3
+# is a prefix of a current 1.2.345, so an unanchored match passes the build this exists to
+# catch. grep drains the stream instead of using -q, which exits on the first match and
+# SIGPIPEs strings, leaving pipefail to read a hit as a failed pipeline. Output is discarded
+# so the version never reaches the log.
+if strings -a "$BINARY" | grep -F "ARMSX2-iOS/v$VERSION " >/dev/null; then
+	echo "$BINARY carries the RetroAchievements client identity"
+	exit 0
+fi
+
+echo "::error::$BINARY does not carry the expected client identity, so this build would be softcore only."
+exit 1

--- a/.github/workflows/scripts/common/write-ra-ua-secret.sh
+++ b/.github/workflows/scripts/common/write-ra-ua-secret.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Write the RetroAchievements client identity that pcsx2/Host.cpp expects.
+#
+# Host.cpp includes "ra_ua_secret.h" behind __has_include and falls back to a stock PCSX2
+# agent when the macro is absent. RetroAchievements grants hardcore on the leading
+# Name/Version token of that agent, so a build without this header is softcore only. The
+# header is gitignored, which is why a runner has to write it.
+#
+# Holding the version in a repository secret stops a fork or a code-lift from inheriting a
+# live ARMSX2 identity. It hides nothing from anyone holding a build: the compiler bakes
+# the finished agent into the binary as a plain literal.
+
+set -euo pipefail
+
+HEADER="${GITHUB_WORKSPACE:-$PWD}/pcsx2/ra_ua_secret.h"
+
+# Whitespace pasted into the secret field would end up inside an HTTP header.
+VERSION="$(printf '%s' "${IOS_RA_UA_VERSION:-}" | tr -d '[:space:]')"
+
+if [[ -z "$VERSION" ]]; then
+	echo "::warning::IOS_RA_UA_VERSION is unset, so this build identifies as stock PCSX2 and RetroAchievements will allow softcore only."
+	exit 0
+fi
+
+# A refused agent behaves exactly like an unknown one on the client, so catch a version
+# RetroAchievements cannot order here rather than at a player's first hardcore unlock.
+if [[ ! "$VERSION" =~ ^[0-9]+([.-][0-9]+)*$ ]]; then
+	echo "::error::IOS_RA_UA_VERSION is not a numeric dotted version. RetroAchievements cannot order it and will treat the client as unknown."
+	exit 1
+fi
+
+if [[ ! -d "${HEADER%/*}" ]]; then
+	echo "::error::${HEADER%/*} does not exist. Run this from the repository checkout."
+	exit 1
+fi
+
+# Host.cpp's include is quoted, so one file beside it serves every platform building pcsx2/.
+printf '#pragma once\n#define ARMSX2_IOS_RA_UA_VERSION "%s"\n' "$VERSION" > "$HEADER"
+
+echo "wrote $HEADER"


### PR DESCRIPTION
Nightly and MoonStore builds have never had RetroAchievements hardcore mode. Only builds made
by hand on a Mac did. This makes the automated ones work the same way.

Nothing was actually broken. RetroAchievements decides whether a client may use hardcore by
reading the name and version the app writes into its HTTP user agent. Ours comes from a file
git deliberately ignores, so it lives on one machine and has never existed on a build server.
The code already handles that: when the file is missing it identifies as plain PCSX2, which the
server only ever grants softcore. The file was simply never there.

## What changed

A build step now writes that file from an encrypted repository secret, the same way the Android
job already writes its signing keystores. If the secret is missing the step says so and carries
on, because pull requests from forks never receive secrets, and a nightly that refuses to
publish is worse than one without hardcore.

If the secret is there but malformed, the build stops instead. RetroAchievements refuses a
version it cannot sort, and a refused client looks exactly like an unknown one from inside the
app, so nothing on screen tells you it happened. Better to fail on the build server.

Only the nightly and pushes to master embed the identity. Pull request builds keep the plain
PCSX2 name, so a throwaway test build is not another public copy of something that takes a
release to change.

## The check afterwards

A second step reads the finished app and fails if the version is not in it.

That failure is otherwise invisible. A reordered step or a stale build folder produces an app
that installs, runs, and quietly reports itself as plain PCSX2, and nobody finds out until a
player loses an unlock they earned.

Both iOS jobs are non blocking, so a failure there does not stop the rest of the build. It does
stop the steps after it, which skips the upload, and the nightly then publishes with no iOS file
rather than with a broken one. A missing download is obvious. A softcore build is not.

The check matches the version together with the space that follows it. Without that space, a
stale 1.2.3 in an old binary counts as a match for a current 1.2.345, and the check passes the
exact build it exists to catch.

## What this does not do

It does not keep the version private. The compiler writes the finished user agent into the app
as ordinary text, so anyone holding any build can read it out. That was already true of every
IPA handed to a tester.

What the ignored file prevents is a fork or a copied tree getting a working identity for free.
Worth being plain about, because the protection that actually works sits on RetroAchievements'
side: they ban clients caught wearing another emulator's name, and they can reject every version
below a number we choose. If ours ever leaks, the answer is a new version and a word with them.

## Testing

Both scripts were run against every path they have, including a valid version, a missing secret,
a malformed one, stray whitespace, injection attempts and a missing folder. Both are shellcheck
clean.

The verification step was run against a real build with the correct version and with a wrong
one, and behaves correctly either way.

The repository secret is already in place, so this takes effect as soon as it lands.

Worth knowing before merging: because the new steps only run on pushes to master, this pull
request's own build skips them. The workflow files parse and the scripts are linted, but the
first time either step actually runs will be the master build after this merges. If something
goes wrong, that is where it shows.
