### PR TITLE
Android: fix the miscased GL include that breaks every APK build

### DIFF
--- a/platforms/android/app/src/main/cpp/savers/skyrocket/shockwave.cpp
+++ b/platforms/android/app/src/main/cpp/savers/skyrocket/shockwave.cpp
@@ -19,7 +19,7 @@
  */
 
 
-#include <gl/gl.h>
+#include <GL/gl.h>
 #include <math.h>
 
 #include "shockwave.h"


### PR DESCRIPTION
Every Android build has been failing since the screensavers landed. Nobody was told, because the
Android job is set to fail quietly, so the overall build kept showing green and no APK has been
uploaded since.

One file asks for `<gl/gl.h>`. The header it wants sits at `savers/compat/GL/gl.h`, with a capital
GL. macOS does not care about the capitals, so it builds fine on a developer machine. The Linux
build server does care, and it stops on "fatal error: 'gl/gl.h' file not found", taking the whole
APK down with it.

This changes that one character.

It is the only place in the target with the problem. All 742 includes under `savers/` were checked
against the real names on disk rather than by asking whether a file exists, because a Mac answers
yes to both spellings and would have hidden exactly this.

The line was redundant as well as wrong. `shockwave.cpp` is never built on its own.
`unit_shockwave.cpp` wraps it in a namespace and already includes the same header above it, so the
corrected line now meets the include guard and expands to nothing. The five files beside it carry
no GL include at all and rely on that wrapper. Removing the line would match them, but these
screensavers are vendored from upstream and deliberately kept close to it, so one character is the
smaller change.

## What this does not prove

That the Android build now finishes. This error has hidden everything after it for days, so a
second one may be waiting behind it. Unlike most one line fixes, the Android job on this pull
request is worth actually reading rather than glancing at, because it is the first thing that gets
to find out.

## Worth a separate look

The reason this sat unnoticed is that the Android job carries continue-on-error, added while the
collapsed core build was being stabilised. It has been doing that job a little too well. If the
Android build is dependable once this lands, the flag has outlived its purpose and hides more than
it helps.
