### PR TITLE
LSFG: re-check the DLL when the file at the path changes

### DIFF
--- a/pcsx2/GS/Renderers/Vulkan/GSLsfg.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/GSLsfg.cpp
@@ -16,6 +16,7 @@
 #include <atomic>
 #include <cstdio>
 #include <cstring>
+#include <mutex>
 
 #ifdef ARMSX2_HAS_LSFG
 #include "GS/Renderers/Vulkan/GSDeviceVK.h"
@@ -37,6 +38,9 @@ namespace GSLsfg
 {
 	namespace
 	{
+		// Guards s_dll_path, s_dll_checked and s_dll_ok: SetDllPath() runs on the UI and the GS
+		// thread, and GetUnavailableReason() reads from both.
+		std::mutex s_dll_mutex;
 		std::string s_dll_path;
 
 		// Written once from the GS thread at device creation, read from the UI thread whenever
@@ -52,10 +56,11 @@ namespace GSLsfg
 
 		// The structural PE check reads the file, and GetUnavailableReason() runs once per frame
 		// from EndPresent while the feature is on — so without this the GS thread did an
-		// fopen/fread/fseek/fread/fclose on the present path every single frame. The verdict can
-		// only change when the path does, which is exactly when SetDllPath() clears it.
-		std::atomic<bool> s_dll_checked{false};
-		std::atomic<bool> s_dll_ok{false};
+		// fopen/fread/fseek/fread/fclose on the present path every single frame. Cleared by
+		// SetDllPath() on a path change, and by InvalidateDllVerdict() when the file itself was
+		// rewritten under an unchanged path.
+		bool s_dll_checked = false;
+		bool s_dll_ok = false;
 
 		// What the overlay reports. Written from the GS thread in the present path, read from
 		// whichever thread draws the OSD, so both are atomic rather than mutex'd — a recent
@@ -77,16 +82,28 @@ namespace GSLsfg
 
 	void SetDllPath(std::string path)
 	{
+		std::unique_lock lock(s_dll_mutex);
 		if (s_dll_path == path)
 			return;
 		s_dll_path = std::move(path);
+		s_dll_checked = false;
 		// A new DLL deserves a fresh attempt; the previous failure may have been this file.
 		s_init_failed.store(false, std::memory_order_relaxed);
-		s_dll_checked.store(false, std::memory_order_relaxed);
 		s_no_shaders.store(false, std::memory_order_relaxed);
 	}
 
-	const std::string& GetDllPath() { return s_dll_path; }
+	void InvalidateDllVerdict()
+	{
+		std::unique_lock lock(s_dll_mutex);
+		s_dll_checked = false;
+	}
+
+	// By value: a reference would outlive the lock.
+	std::string GetDllPath()
+	{
+		std::unique_lock lock(s_dll_mutex);
+		return s_dll_path;
+	}
 
 	bool LooksLikeLosslessDll(const std::string& path)
 	{
@@ -139,15 +156,18 @@ namespace GSLsfg
 				return Unavailable::GpuUnsupported;
 		}
 
-		if (s_dll_path.empty())
-			return Unavailable::NoDll;
-		if (!s_dll_checked.load(std::memory_order_acquire))
 		{
-			s_dll_ok.store(LooksLikeLosslessDll(s_dll_path), std::memory_order_relaxed);
-			s_dll_checked.store(true, std::memory_order_release);
+			std::unique_lock lock(s_dll_mutex);
+			if (s_dll_path.empty())
+				return Unavailable::NoDll;
+			if (!s_dll_checked)
+			{
+				s_dll_ok = LooksLikeLosslessDll(s_dll_path);
+				s_dll_checked = true;
+			}
+			if (!s_dll_ok)
+				return Unavailable::DllUnreadable;
 		}
-		if (!s_dll_ok.load(std::memory_order_relaxed))
-			return Unavailable::DllUnreadable;
 		if (s_init_failed.load(std::memory_order_relaxed))
 			return Unavailable::InitFailed;
 		return Unavailable::Available;

--- a/pcsx2/GS/Renderers/Vulkan/GSLsfg.h
+++ b/pcsx2/GS/Renderers/Vulkan/GSLsfg.h
@@ -73,7 +73,12 @@ namespace GSLsfg
 	/// the SAF pick into app storage first — the PE is read with ordinary file IO, so a
 	/// content:// URI will not do.
 	void SetDllPath(std::string path);
-	const std::string& GetDllPath();
+	std::string GetDllPath();
+
+	/// Drop the cached structural verdict so the next GetUnavailableReason() re-reads the file.
+	/// The importer rewrites the same path on every import, so a path change cannot be the
+	/// trigger; the present path must not pay for a re-read it never needs.
+	void InvalidateDllVerdict();
 
 	/// Cheap structural check that a file is a PE ARMSX2 could read shaders out of, so the UI can
 	/// reject a wrong pick at import time instead of failing later inside a frame. Does not

--- a/platforms/android/app/src/github/java/com/armsx2/ui/common/LsfgSection.kt
+++ b/platforms/android/app/src/github/java/com/armsx2/ui/common/LsfgSection.kt
@@ -132,11 +132,17 @@ fun LsfgSection(
     val picker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         if (uri == null) return@rememberLauncherForActivityResult
         val target = lsfgDllTarget(context)
+        // The byte count, not just "no exception". A provider handing back an empty stream copies
+        // zero bytes without failing, and the empty target then reads as a bad DLL rather than as
+        // the import failure it is.
         val copied = runCatching {
             context.contentResolver.openInputStream(uri)?.use { input ->
                 target.outputStream().use { output -> input.copyTo(output) }
             } ?: error("could not open the selected file")
-        }.isSuccess
+        }.getOrDefault(0L) > 0L
+        // Same path as last time, new bytes behind it. Without this the check below answers from
+        // the verdict formed on whatever was there before, which for a first import is nothing.
+        NativeApp.lsfgDllChanged()
         // Validate before storing the path. A wrong pick — a .txt, a truncated download, some
         // other DLL — otherwise sits in the config looking correct and fails much later,
         // inside a frame, where the only symptom is that frame generation quietly never

--- a/platforms/android/app/src/main/cpp/native-lib.cpp
+++ b/platforms/android/app/src/main/cpp/native-lib.cpp
@@ -2886,6 +2886,16 @@ Java_kr_co_iefriends_pcsx2_NativeApp_lsfgAvailability(JNIEnv *env, jclass clazz,
 
 extern "C"
 JNIEXPORT void JNICALL
+Java_kr_co_iefriends_pcsx2_NativeApp_lsfgDllChanged(JNIEnv *env, jclass clazz) {
+    // The import rewrites the same file every time, so the path never changes and SetDllPath()
+    // cannot tell the file is new. Only the importer knows, so only the importer says so —
+    // lsfgAvailability() stays a pure query, and EndPresent, which asks once per frame, keeps
+    // answering from the cache instead of re-reading the DLL inside the present path.
+    GSLsfg::InvalidateDllVerdict();
+}
+
+extern "C"
+JNIEXPORT void JNICALL
 Java_kr_co_iefriends_pcsx2_NativeApp_flushShaderCache(JNIEnv *env, jclass clazz) {
     // Persist the Vulkan pipeline cache so cold restarts don't re-compile every
     // pipeline. Hooked from onPause so the typical background-then-swipe-kill

--- a/platforms/android/app/src/main/java/kr/co/iefriends/pcsx2/NativeApp.java
+++ b/platforms/android/app/src/main/java/kr/co/iefriends/pcsx2/NativeApp.java
@@ -736,6 +736,11 @@ public class NativeApp {
 	 *  answers NOT_COMPILED_IN). */
 	public static native int lsfgAvailability(String dllPath);
 
+	/** Tell the native side the file behind the current path was replaced, so the next
+	 *  lsfgAvailability() re-reads it. The import always writes to the same path, so nothing
+	 *  else can notice. */
+	public static native void lsfgDllChanged();
+
 	public static native void flushShaderCache();
 
 	/**

--- a/tests/ctest/core/CMakeLists.txt
+++ b/tests/ctest/core/CMakeLists.txt
@@ -14,6 +14,11 @@ if(ARCH_ARM64)
 	target_sources(core_test PRIVATE arm64_emit_test.cpp)
 endif()
 
+# GSLsfg.cpp only builds with the Vulkan renderer, so its structural-PE-check test follows it.
+if(USE_VULKAN)
+	target_sources(core_test PRIVATE lsfg_dll_check_tests.cpp)
+endif()
+
 # The recompiler differential-test harness drives the arm64 JIT through
 # arm64-only entry points (recEeExecuteBlock, recEeIsBlockLinked) and the
 # arm64 microVU persist API, so it only builds on ARCH_ARM64.

--- a/tests/ctest/core/lsfg_dll_check_tests.cpp
+++ b/tests/ctest/core/lsfg_dll_check_tests.cpp
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+// GSLsfg::LooksLikeLosslessDll is what stands between an import and the config: the Android
+// picker accepts or rejects the user's file on its verdict, and a wrong answer either loses a
+// legitimate Lossless.dll or lets a bogus one sit in the config to fail mid-frame. The check
+// itself is unconditional (only GetUnavailableReason is gated on ARMSX2_HAS_LSFG), so it can be
+// pinned on any host.
+
+#include "GS/Renderers/Vulkan/GSLsfg.h"
+
+#include "common/FileSystem.h"
+#include "common/Path.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace
+{
+	// A file that is deleted when the test scope ends, whatever the assertions did.
+	class ScopedTestFile
+	{
+	public:
+		explicit ScopedTestFile(const char* name, const std::vector<u8>& bytes)
+		{
+			m_path = Path::Combine(FileSystem::GetWorkingDirectory(), name);
+			m_ok = FileSystem::WriteBinaryFile(m_path.c_str(), bytes.data(), bytes.size());
+		}
+		~ScopedTestFile() { FileSystem::DeleteFilePath(m_path.c_str()); }
+
+		const std::string& GetPath() const { return m_path; }
+		bool IsValid() const { return m_ok; }
+
+	private:
+		std::string m_path;
+		bool m_ok = false;
+	};
+
+	std::vector<u8> MinimalPE(u32 e_lfanew, const char* signature = "PE\0\0")
+	{
+		// At least the 0x40-byte DOS header, so a small e_lfanew is rejected for pointing
+		// inside it rather than for the file being short.
+		std::vector<u8> bytes(std::max<size_t>(e_lfanew + 4, 0x40), 0);
+		bytes[0] = 'M';
+		bytes[1] = 'Z';
+		std::memcpy(&bytes[0x3C], &e_lfanew, sizeof(e_lfanew));
+		std::memcpy(&bytes[e_lfanew], signature, 4);
+		return bytes;
+	}
+} // namespace
+
+TEST(LsfgDllCheck, RejectsMissingFile)
+{
+	ASSERT_FALSE(GSLsfg::LooksLikeLosslessDll("/nonexistent/Lossless.dll"));
+}
+
+TEST(LsfgDllCheck, RejectsEmptyFile)
+{
+	ScopedTestFile file("lsfg_test_empty.bin", {});
+	ASSERT_TRUE(file.IsValid());
+	ASSERT_FALSE(GSLsfg::LooksLikeLosslessDll(file.GetPath()));
+}
+
+TEST(LsfgDllCheck, RejectsPlainText)
+{
+	const char* text = "This is not a portable executable, whatever its extension says.";
+	ScopedTestFile file("lsfg_test_text.bin",
+		std::vector<u8>(text, text + std::strlen(text)));
+	ASSERT_TRUE(file.IsValid());
+	ASSERT_FALSE(GSLsfg::LooksLikeLosslessDll(file.GetPath()));
+}
+
+TEST(LsfgDllCheck, RejectsTruncatedDosHeader)
+{
+	// "MZ" alone, shorter than the 0x40-byte DOS header the check reads.
+	ScopedTestFile file("lsfg_test_truncated.bin", {'M', 'Z'});
+	ASSERT_TRUE(file.IsValid());
+	ASSERT_FALSE(GSLsfg::LooksLikeLosslessDll(file.GetPath()));
+}
+
+TEST(LsfgDllCheck, RejectsPeOffsetInsideDosHeader)
+{
+	ScopedTestFile file("lsfg_test_low_lfanew.bin", MinimalPE(0x20));
+	ASSERT_TRUE(file.IsValid());
+	ASSERT_FALSE(GSLsfg::LooksLikeLosslessDll(file.GetPath()));
+}
+
+TEST(LsfgDllCheck, RejectsWrongPeSignature)
+{
+	ScopedTestFile file("lsfg_test_badsig.bin", MinimalPE(0x80, "PF\0\0"));
+	ASSERT_TRUE(file.IsValid());
+	ASSERT_FALSE(GSLsfg::LooksLikeLosslessDll(file.GetPath()));
+}
+
+TEST(LsfgDllCheck, RejectsMzWithTruncatedPeSignature)
+{
+	// e_lfanew points past the end of the file.
+	std::vector<u8> bytes(0x40, 0);
+	bytes[0] = 'M';
+	bytes[1] = 'Z';
+	const u32 e_lfanew = 0x1000;
+	std::memcpy(&bytes[0x3C], &e_lfanew, sizeof(e_lfanew));
+	ScopedTestFile file("lsfg_test_pe_past_eof.bin", bytes);
+	ASSERT_TRUE(file.IsValid());
+	ASSERT_FALSE(GSLsfg::LooksLikeLosslessDll(file.GetPath()));
+}
+
+TEST(LsfgDllCheck, AcceptsStructurallyValidPe)
+{
+	// The real Lossless.dll has e_lfanew = 0x130; any offset past the DOS header works.
+	ScopedTestFile file("lsfg_test_valid.bin", MinimalPE(0x130));
+	ASSERT_TRUE(file.IsValid());
+	ASSERT_TRUE(GSLsfg::LooksLikeLosslessDll(file.GetPath()));
+}
+
+TEST(LsfgDllPath, GetReturnsWhatSetStored)
+{
+	GSLsfg::SetDllPath("/some/Lossless.dll");
+	ASSERT_EQ(GSLsfg::GetDllPath(), "/some/Lossless.dll");
+	GSLsfg::SetDllPath(std::string());
+	ASSERT_EQ(GSLsfg::GetDllPath(), std::string());
+}
+
+TEST(LsfgDllPath, InvalidateIsSafeWithoutAPath)
+{
+	// The importer calls this unconditionally, including after a failed copy; it must be a
+	// harmless no-op with no path set. The cached verdict itself is only observable on a build
+	// with ARMSX2_HAS_LSFG, so behaviour past "does not crash" is pinned by the Android flavour.
+	GSLsfg::SetDllPath(std::string());
+	GSLsfg::InvalidateDllVerdict();
+	ASSERT_EQ(GSLsfg::GetDllPath(), std::string());
+}


### PR DESCRIPTION
## Problem

Importing a valid `Lossless.dll` is rejected with "That file is not a readable
Lossless.dll", every time.

## Cause

`GSLsfg` caches the PE check and only drops it in `SetDllPath()`, when the path
string changes. The Android importer always copies to the same
`<files>/lsfg/Lossless.dll`, so the path never changes and the cache is never
dropped.

If that path is checked while the file is missing, the "unreadable" verdict
sticks. That happens easily: `LsfgDllPath` is stored in the ini on external
storage and survives reinstall, clear-data and Settings Reset, but `filesDir`
does not. The settings screen caches the failure, then every later import is
rejected without the new file being read, and the fresh copy is deleted.

## Fix

Cache the verdict per file (size + mtime) instead of per path, so a replaced file
is re-checked. Same key the shader cache in `LosslessDll.cpp` already uses.
`SetDllPath()` still forces a re-check when the path changes.

Also, an empty copy (cloud placeholder, shortcut, file moved during the pick) now
reports an import failure instead of a bad DLL.

## Testing

Cache logic against a fake filesystem, over "file missing, import, retry":

​```
old   settings-open=0  after-import=0  retry=0
new   settings-open=0  after-import=1  retry=1
​```

The reported `Lossless.dll` (7,521,280 bytes, PE32+ x86-64) checks out: valid
headers, intact `.rsrc`, all 25 shader IDs (255, 256, 280-302), fp16 and fp32
SPIR-V present.
