### PR TITLE
Libretro: fix the buildbot Linux jobs, and add macOS + Android

### DIFF
--- a/.github/workflows/scripts/android/build-dependencies.sh
+++ b/.github/workflows/scripts/android/build-dependencies.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# Builds the dependencies of the libretro core for Android, static and PIC,
+# into a local prefix. Everything comes from source: unlike the Linux jobs
+# there is no distribution behind the NDK to take png, jpeg, SDL and the rest
+# from, and unlike macOS there is no system Vulkan loader either.
+#
+# Usage: build-dependencies.sh <install-prefix>
+# Environment:
+#   ANDROID_NDK / ANDROID_NDK_HOME / ANDROID_NDK_ROOT - the NDK to build with
+#   ANDROID_ABI  - arm64-v8a (default) or x86_64
+#   ANDROID_API  - minimum platform level, default 28 (ASharedMemory is 26,
+#                  bionic's posix_spawn is 28)
+
+set -e
+
+if [ "$#" -ne 1 ]; then
+	echo "Syntax: $0 <install-prefix>"
+	exit 1
+fi
+
+PREFIX=$(realpath "$1")
+NPROCS="$(getconf _NPROCESSORS_ONLN)"
+
+NDK="${ANDROID_NDK:-${ANDROID_NDK_HOME:-${ANDROID_NDK_ROOT:-}}}"
+if [ -z "$NDK" ] || [ ! -f "$NDK/build/cmake/android.toolchain.cmake" ]; then
+	echo "No usable NDK: set ANDROID_NDK to one containing build/cmake/android.toolchain.cmake"
+	exit 1
+fi
+
+ABI="${ANDROID_ABI:-arm64-v8a}"
+API="${ANDROID_API:-28}"
+
+# Versions follow the Linux recipe (build-dependencies-runner.sh) so the two
+# cannot drift; the ones it does not build - jpeg, curl, the pcap headers - are
+# system packages there and only exist here.
+FREETYPE=VER-2-14-1
+LIBPNG=v1.6.51
+LIBWEBP=v1.6.0
+SDL=release-3.2.26
+LZ4=v1.10.0
+ZSTD=v1.5.7
+PLUTOVG=v1.3.2
+PLUTOSVG=v0.0.7
+JPEGTURBO=3.1.4.1
+CURL=curl-8_11_1
+LIBPCAP=libpcap-1.10.5
+SHADERC=v2025.4
+SHADERC_GLSLANG=7a47e2531cb334982b2a2dd8513dca0a3de4373d
+
+# c++_static: several of these end up inside one .so, and a shared STL would
+# have to be shipped next to the core for the frontend to find.
+TOOLCHAIN=(
+	"-DCMAKE_TOOLCHAIN_FILE=$NDK/build/cmake/android.toolchain.cmake"
+	"-DANDROID_ABI=$ABI"
+	"-DANDROID_PLATFORM=android-$API"
+	"-DANDROID_STL=c++_static"
+	"-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+	"-DCMAKE_INSTALL_PREFIX=$PREFIX"
+	"-DCMAKE_PREFIX_PATH=$PREFIX"
+	"-DCMAKE_FIND_ROOT_PATH=$PREFIX"
+	"-DCMAKE_BUILD_TYPE=Release"
+	"-DBUILD_SHARED_LIBS=OFF"
+)
+
+mkdir -p deps-build
+cd deps-build
+
+clone() {
+	# clone <url> <dir> <tag>
+	[ -d "$2" ] || git clone --depth 1 --branch "$3" --recursive "$1" "$2"
+}
+
+build() {
+	# build <source-dir> <build-dir> [extra cmake args...]
+	local src="$1" bld="$2"
+	shift 2
+	cmake -S "$src" -B "$bld" -G Ninja "${TOOLCHAIN[@]}" "$@"
+	cmake --build "$bld" --parallel "$NPROCS"
+	cmake --install "$bld"
+}
+
+# zlib comes with the NDK sysroot, so it is the one library not built here.
+
+clone https://github.com/pnggroup/libpng libpng "$LIBPNG"
+build libpng libpng/build -DPNG_SHARED=OFF -DPNG_STATIC=ON -DPNG_TESTS=OFF \
+	-DPNG_TOOLS=OFF -DPNG_FRAMEWORK=OFF
+
+clone https://github.com/libjpeg-turbo/libjpeg-turbo libjpeg-turbo "$JPEGTURBO"
+build libjpeg-turbo libjpeg-turbo/build -DENABLE_SHARED=OFF -DENABLE_STATIC=ON \
+	-DWITH_TURBOJPEG=OFF
+
+clone https://github.com/facebook/zstd zstd "$ZSTD"
+build zstd/build/cmake zstd/b -DZSTD_BUILD_SHARED=OFF -DZSTD_BUILD_STATIC=ON \
+	-DZSTD_BUILD_PROGRAMS=OFF -DZSTD_BUILD_TESTS=OFF
+
+clone https://github.com/lz4/lz4 lz4 "$LZ4"
+build lz4/build/cmake lz4/b -DLZ4_BUILD_CLI=OFF -DLZ4_BUILD_LEGACY_LZ4C=OFF
+
+clone https://github.com/webmproject/libwebp libwebp "$LIBWEBP"
+build libwebp libwebp/build -DWEBP_BUILD_ANIM_UTILS=OFF -DWEBP_BUILD_CWEBP=OFF \
+	-DWEBP_BUILD_DWEBP=OFF -DWEBP_BUILD_GIF2WEBP=OFF -DWEBP_BUILD_IMG2WEBP=OFF \
+	-DWEBP_BUILD_VWEBP=OFF -DWEBP_BUILD_WEBPINFO=OFF -DWEBP_BUILD_WEBPMUX=OFF \
+	-DWEBP_BUILD_EXTRAS=OFF
+
+# SDL is here for the input and audio sources the emulator compiles against.
+# Nothing in a libretro core opens an SDL window, so its Java side never runs.
+clone https://github.com/libsdl-org/SDL sdl3 "$SDL"
+build sdl3 sdl3/build -DSDL_SHARED=OFF -DSDL_STATIC=ON -DSDL_TESTS=OFF -DSDL_EXAMPLES=OFF
+
+clone https://github.com/freetype/freetype freetype "$FREETYPE"
+build freetype freetype/build -DFT_DISABLE_HARFBUZZ=ON -DFT_DISABLE_BROTLI=ON \
+	-DFT_DISABLE_PNG=ON -DFT_DISABLE_ZLIB=ON -DFT_DISABLE_BZIP2=ON
+
+clone https://github.com/sammycage/plutovg plutovg "$PLUTOVG"
+build plutovg plutovg/build -DPLUTOVG_BUILD_EXAMPLES=OFF
+
+clone https://github.com/sammycage/plutosvg plutosvg "$PLUTOSVG"
+build plutosvg plutosvg/build -DPLUTOSVG_ENABLE_FREETYPE=ON -DPLUTOSVG_BUILD_EXAMPLES=OFF
+
+# No TLS: the core does not talk to the achievement or update servers, and a
+# TLS stack would drag in OpenSSL for something nothing calls.
+clone https://github.com/curl/curl curl "$CURL"
+build curl curl/build -DCURL_ENABLE_SSL=OFF -DBUILD_CURL_EXE=OFF \
+	-DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON -DCURL_USE_LIBPSL=OFF \
+	-DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF
+
+# DEV9 links libpcap directly, so headers are not enough even though no Android
+# device will ever hand it a capture device. Everything optional is off: the
+# point is a linkable archive, not a working capture backend.
+clone https://github.com/the-tcpdump-group/libpcap libpcap "$LIBPCAP"
+build libpcap libpcap/build -DDISABLE_DBUS=ON -DDISABLE_RDMA=ON -DDISABLE_DAG=ON \
+	-DDISABLE_SEPTEL=ON -DDISABLE_SNF=ON -DDISABLE_TC=ON -DDISABLE_NETMAP=ON \
+	-DDISABLE_DPDK=ON -DDISABLE_BLUETOOTH=ON -DDISABLE_LINUX_USBMON=ON \
+	-DBUILD_WITH_LIBNL=OFF -DENABLE_REMOTE=OFF
+
+clone https://github.com/google/shaderc shaderc "$SHADERC"
+(cd shaderc && python3 utils/git-sync-deps)
+if [ "$(git -C shaderc/third_party/glslang rev-parse HEAD)" != "$SHADERC_GLSLANG" ]; then
+	git -C shaderc/third_party/glslang fetch --depth 1 origin "$SHADERC_GLSLANG"
+	git -C shaderc/third_party/glslang checkout --detach FETCH_HEAD
+fi
+cmake -S shaderc -B shaderc/b -G Ninja "${TOOLCHAIN[@]}" \
+	-DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+	-DSHADERC_SKIP_TESTS=ON -DSHADERC_SKIP_EXAMPLES=ON -DSHADERC_SKIP_COPYRIGHT_CHECK=ON
+cmake --build shaderc/b --parallel "$NPROCS" --target shaderc_combined
+mkdir -p "$PREFIX/lib" "$PREFIX/include"
+cp shaderc/b/libshaderc/libshaderc_combined.a "$PREFIX/lib/"
+cp -r shaderc/libshaderc/include/shaderc "$PREFIX/include/"
+
+echo "Android ($ABI, API $API) dependencies installed to $PREFIX"

--- a/.github/workflows/scripts/macos/build-dependencies-slice.sh
+++ b/.github/workflows/scripts/macos/build-dependencies-slice.sh
@@ -1,0 +1,430 @@
+#!/bin/bash
+#
+# Builds the macOS dependency set for ONE architecture, for the libretro
+# buildbot. build-dependencies-universal.sh next to this one builds a fat
+# x86_64+arm64 set and is what the GitHub macOS workflow uses; the buildbot
+# produces a separate core per slice and never links Qt, so building both
+# slices - and Qt twice - would more than double a job that is already the
+# longest in the pipeline.
+#
+# So this one takes the slice from OSX_ARCH and every arch-dependent flag
+# follows it: CMAKE_OSX_ARCHITECTURES, CMAKE_APPLE_SILICON_PROCESSOR, the
+# ffmpeg cross-compile triple (plus --disable-x86asm on arm64) and MoltenVK's
+# VALID_ARCHS. BUILD_QT=0 skips Qt, QtApng and KDDockWidgets entirely.
+#
+# Dependency versions and checksums are kept in step with the universal script;
+# if you bump one there, bump it here too.
+
+set -e
+
+if [ "$#" -ne 1 ]; then
+    echo "Syntax: $0 <output directory>"
+    exit 1
+fi
+
+# The bundled ffmpeg has a lot of things disabled to reduce code size.
+# Users may want to use system ffmpeg for additional features
+: ${BUILD_FFMPEG:=1}
+
+# The libretro core links no Qt UI, so its buildbot job sets BUILD_QT=0 and
+# skips the (very long) Qt, QtApng and KDDockWidgets builds.
+: ${BUILD_QT:=1}
+
+# Which macOS slice to build. arm64 is the fork's native target; the libretro
+# buildbot also ships an Intel core, and cross-builds that x86_64 slice on the
+# Apple Silicon runner (the buildbot's own Intel Mac is 10.15/clang 12, far too
+# old for the C++20 here), so every arch-dependent flag below follows this.
+: ${OSX_ARCH:=arm64}
+
+export MACOSX_DEPLOYMENT_TARGET=11.0
+
+NPROCS="$(getconf _NPROCESSORS_ONLN)"
+SCRIPTDIR=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+INSTALLDIR="$1"
+if [ "${INSTALLDIR:0:1}" != "/" ]; then
+	INSTALLDIR="$PWD/$INSTALLDIR"
+fi
+
+QT=6.11.1
+QTAPNG=1.3.0
+
+FREETYPE=2.14.3
+SDL=SDL3-3.4.12
+HARFBUZZ=14.2.0
+ZSTD=1.5.7
+LZ4=1.10.0
+LIBPNG=1.6.58
+LIBJPEGTURBO=3.2.0
+LIBWEBP=1.6.0
+FFMPEG=8.1
+MOLTENVK=1.4.1
+KDDOCKWIDGETS=2.4.1
+PLUTOVG=1.3.2
+PLUTOSVG=0.0.7
+RAPIDYAML=0.12.1
+
+SHADERC=2026.2
+SHADERC_GLSLANG=275822a6261ee689aadb1da5f09a0ec2f058685c
+SHADERC_SPIRVHEADERS=58006c901d1d5c37dece6b6610e9af87fa951375
+SHADERC_SPIRVTOOLS=6337eb62cadd7d124ac6789bf39c0f71148f0a73
+
+mkdir -p deps-build
+cd deps-build
+
+export PKG_CONFIG_PATH="$INSTALLDIR/lib/pkgconfig:$PKG_CONFIG_PATH"
+export LDFLAGS="-L$INSTALLDIR/lib $LDFLAGS"
+export CFLAGS="-I$INSTALLDIR/include $CFLAGS"
+export CXXFLAGS="-I$INSTALLDIR/include $CXXFLAGS"
+CMAKE_COMMON=(
+	-DCMAKE_BUILD_TYPE=Release
+	-DCMAKE_SHARED_LINKER_FLAGS="-dead_strip -dead_strip_dylibs"
+	-DCMAKE_PREFIX_PATH="$INSTALLDIR"
+	-DCMAKE_INSTALL_PREFIX="$INSTALLDIR"
+	-DCMAKE_OSX_ARCHITECTURES="$OSX_ARCH"
+	-DCMAKE_APPLE_SILICON_PROCESSOR="$OSX_ARCH"
+	-DCMAKE_INSTALL_NAME_DIR='$<INSTALL_PREFIX>/lib'
+)
+
+grep . > SHASUMS <<EOF
+d9594a31228aa23ad6b531719a29b45f0f3989fe6c136d45767ea179f233c1ac  qtbase-everywhere-src-$QT.tar.xz
+b2bf6c6845ac175ed7f819145483ba4676f617aaa6a5012c8efee63c8bbac413  qtimageformats-everywhere-src-$QT.tar.xz
+7f3cf02f4824bf03c2c5859ea6db173bf1482a1daf24e6cdf7bc78cfa26a8a94  qtsvg-everywhere-src-$QT.tar.xz
+8e61835a679c93fa9c6065b142353c2071ba68e297898937c32a03777fcaf50d  qttools-everywhere-src-$QT.tar.xz
+37c02c81206594c7bb4edca85ac93e8e55a9836b70c960fde6cb0f8623ec5677  qttranslations-everywhere-src-$QT.tar.xz
+f1d3be3489f758efe1a8f12118a212febbe611aa670af32e0159fa3c1feab2a6  QtApng-$QTAPNG.tar.gz
+
+36bc4f1cc413335368ee656c42afca65c5a3987e8768cc28cf11ba775e785a5f  freetype-$FREETYPE.tar.xz
+f07b958a9ac5020fb7a44cadb957f658b2149c3c8abb4f63145fac9303249db7  $SDL.tar.gz
+c652d5d94971031654ab3989891a490a895d3e3f2b71171c62692b28e94b1b93  harfbuzz-$HARFBUZZ.tar.gz
+eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3  zstd-$ZSTD.tar.gz
+537512904744b35e232912055ccf8ec66d768639ff3abe5788d90d792ec5f48b  lz4-$LZ4.tar.gz
+28eb403f51f0f7405249132cecfe82ea5c0ef97f1b32c5a65828814ae0d34775  libpng-$LIBPNG.tar.xz
+e4ab7009bf0629fd11982d4c2aa83964cf244cffba7347ecd39019a9e38c4564  libwebp-$LIBWEBP.tar.gz
+eee7dea22ed502868017971c86c63c4ed1e6085de0baebfdcc3d3322f00f3eb0  libpng-$LIBPNG-apng.patch.gz
+6f30092cef9fb839779646608f4ee14ae3cbac989c47fa05e841b0841f09878e  libjpeg-turbo-$LIBJPEGTURBO.tar.gz
+b072aed6871998cce9b36e7774033105ca29e33632be5b6347f3206898e0756a  ffmpeg-$FFMPEG.tar.xz
+9985f141902a17de818e264d17c1ce334b748e499ee02fcb4703e4dc0038f89c  MoltenVK-$MOLTENVK.tar.gz
+5cd9495d9316cf6cc937bb328a7fd491c3248ef2469cfa42511f1039f6148aca  KDDockWidgets-$KDDOCKWIDGETS.tar.gz
+7bd4e79ce18b1d47517e7e91fbb7cf19d4f01942804a519bc7c0bf32b6325dd5  plutovg-$PLUTOVG.tar.gz
+78561b571ac224030cdc450ca2986b4de915c2ba7616004a6d71a379bffd15f3  plutosvg-$PLUTOSVG.tar.gz
+e9efcdd17f86287748793cf21d106e461fcad8d103a3e5a23632afe93828660d  rapidyaml-$RAPIDYAML-src.tgz
+
+f924178e75e3293082481b25ed64d5e48a795b479dac3bd3c83d23070855df42  shaderc-$SHADERC.tar.gz
+971848a1cc639ce8dc244e778b17efe0f690e32ac398a75e31d1c67ad06d3e0a  shaderc-glslang-$SHADERC_GLSLANG.tar.gz
+a6cb1b300bb8171795e116457e858e555334749f9cacaed8068ae0ef8681110c  shaderc-spirv-headers-$SHADERC_SPIRVHEADERS.tar.gz
+e156be0bd81c8812f1bff8e520422bfa9df61b3045587b9eb483185f1074a7b2  shaderc-spirv-tools-$SHADERC_SPIRVTOOLS.tar.gz
+EOF
+
+if ! shasum -sa 256 --check SHASUMS 2> /dev/null; then
+	curl -L \
+		-O "https://sourceforge.net/projects/freetype/files/freetype2/$FREETYPE/freetype-$FREETYPE.tar.xz" \
+		-O "https://github.com/harfbuzz/harfbuzz/archive/$HARFBUZZ/harfbuzz-$HARFBUZZ.tar.gz" \
+		-O "https://libsdl.org/release/$SDL.tar.gz" \
+		-O "https://github.com/facebook/zstd/releases/download/v$ZSTD/zstd-$ZSTD.tar.gz" \
+		-O "https://github.com/lz4/lz4/releases/download/v$LZ4/lz4-$LZ4.tar.gz" \
+		-O "https://downloads.sourceforge.net/project/libpng/libpng16/$LIBPNG/libpng-$LIBPNG.tar.xz" \
+		-O "https://download.sourceforge.net/libpng-apng/libpng-$LIBPNG-apng.patch.gz" \
+		-O "https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/$LIBJPEGTURBO/libjpeg-turbo-$LIBJPEGTURBO.tar.gz" \
+		-O "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-$LIBWEBP.tar.gz" \
+		-O "https://ffmpeg.org/releases/ffmpeg-$FFMPEG.tar.xz" \
+		-O "https://github.com/KhronosGroup/MoltenVK/archive/v$MOLTENVK/MoltenVK-$MOLTENVK.tar.gz" \
+		-O "https://download.qt.io/archive/qt/${QT%.*}/$QT/submodules/qtbase-everywhere-src-$QT.tar.xz" \
+		-O "https://download.qt.io/archive/qt/${QT%.*}/$QT/submodules/qtimageformats-everywhere-src-$QT.tar.xz" \
+		-O "https://download.qt.io/archive/qt/${QT%.*}/$QT/submodules/qtsvg-everywhere-src-$QT.tar.xz" \
+		-O "https://download.qt.io/archive/qt/${QT%.*}/$QT/submodules/qttools-everywhere-src-$QT.tar.xz" \
+		-O "https://download.qt.io/archive/qt/${QT%.*}/$QT/submodules/qttranslations-everywhere-src-$QT.tar.xz" \
+		-O "https://github.com/jurplel/QtApng/archive/$QTAPNG/QtApng-$QTAPNG.tar.gz" \
+		-O "https://github.com/google/shaderc/archive/v$SHADERC/shaderc-$SHADERC.tar.gz" \
+		-O "https://github.com/KhronosGroup/glslang/archive/$SHADERC_GLSLANG/shaderc-glslang-$SHADERC_GLSLANG.tar.gz" \
+		-O "https://github.com/KhronosGroup/SPIRV-Headers/archive/$SHADERC_SPIRVHEADERS/shaderc-spirv-headers-$SHADERC_SPIRVHEADERS.tar.gz" \
+		-O "https://github.com/KhronosGroup/SPIRV-Tools/archive/$SHADERC_SPIRVTOOLS/shaderc-spirv-tools-$SHADERC_SPIRVTOOLS.tar.gz" \
+		-O "https://github.com/KDAB/KDDockWidgets/archive/v$KDDOCKWIDGETS/KDDockWidgets-$KDDOCKWIDGETS.tar.gz" \
+		-O "https://github.com/sammycage/plutovg/archive/v$PLUTOVG/plutovg-$PLUTOVG.tar.gz" \
+		-O "https://github.com/sammycage/plutosvg/archive/v$PLUTOSVG/plutosvg-$PLUTOSVG.tar.gz" \
+		-O "https://github.com/biojppm/rapidyaml/releases/download/v$RAPIDYAML/rapidyaml-$RAPIDYAML-src.tgz"
+fi
+
+shasum -a 256 --check --strict SHASUMS
+
+echo "Installing SDL..."
+rm -fr "$SDL"
+tar xf "$SDL.tar.gz"
+cd "$SDL"
+cmake -B build "${CMAKE_COMMON[@]}" -DSDL_VIDEO=OFF -DSDL_POWER=OFF -DSDL_SENSOR=OFF -DSDL_DIALOG=OFF -DSDL_TRAY=OFF -DSDL_TEST_LIBRARY=OFF -DBUILD_SHARED_LIBS=ON
+make -C build "-j$NPROCS"
+make -C build install
+cd ..
+
+if [ "$BUILD_FFMPEG" -ne 0 ]; then
+	# The arm64 slice has no x86 assembler to feed; the x86_64 one keeps it.
+	if [ "$OSX_ARCH" = "arm64" ]; then FFMPEG_ASM_ARG="--disable-x86asm"; else FFMPEG_ASM_ARG=""; fi
+	echo "Installing FFmpeg..."
+	rm -fr "ffmpeg-$FFMPEG"
+	tar xf "ffmpeg-$FFMPEG.tar.xz"
+	cd "ffmpeg-$FFMPEG"
+	LDFLAGS="-dead_strip $LDFLAGS" CFLAGS="-Os $CFLAGS" CXXFLAGS="-Os $CXXFLAGS" \
+		./configure --prefix="$INSTALLDIR" \
+		--enable-cross-compile --arch="$OSX_ARCH" --cc="clang -arch $OSX_ARCH" --cxx="clang++ -arch $OSX_ARCH" $FFMPEG_ASM_ARG \
+		--disable-all --disable-autodetect --disable-static --enable-shared \
+		--enable-avcodec --enable-avformat --enable-avutil --enable-swresample --enable-swscale \
+		--enable-audiotoolbox --enable-videotoolbox \
+		--enable-encoder=ffv1,qtrle,pcm_s16be,pcm_s16le,*_at,*_videotoolbox \
+		--enable-muxer=avi,matroska,mov,mp3,mp4,wav \
+		--enable-protocol=file
+	make "-j$NPROCS"
+	make install
+	cd ..
+fi
+
+echo "Installing Zstd..."
+rm -fr "zstd-$ZSTD"
+tar xf "zstd-$ZSTD.tar.gz"
+cd "zstd-$ZSTD"
+cmake "${CMAKE_COMMON[@]}" -DBUILD_SHARED_LIBS=ON -DZSTD_BUILD_PROGRAMS=OFF -B build-dir build/cmake
+make -C build-dir "-j$NPROCS"
+make -C build-dir install
+cd ..
+
+echo "Installing LZ4..."
+rm -fr "lz4-$LZ4"
+tar xf "lz4-$LZ4.tar.gz"
+cd "lz4-$LZ4"
+cmake "${CMAKE_COMMON[@]}" -DBUILD_SHARED_LIBS=ON -DLZ4_BUILD_CLI=OFF -DLZ4_BUILD_LEGACY_LZ4C=OFF -B build-dir build/cmake
+make -C build-dir "-j$NPROCS"
+make -C build-dir install
+cd ..
+
+echo "Installing libpng..."
+rm -fr "libpng-$LIBPNG"
+tar xf "libpng-$LIBPNG.tar.xz"
+gzip -kd -f "libpng-$LIBPNG-apng.patch.gz"
+cd "libpng-$LIBPNG"
+patch -p1 < "../libpng-$LIBPNG-apng.patch"
+cmake "${CMAKE_COMMON[@]}" -DBUILD_SHARED_LIBS=ON -DPNG_TESTS=OFF -DPNG_FRAMEWORK=OFF -B build
+make -C build "-j$NPROCS"
+make -C build install
+cd ..
+
+echo "Installing libjpegturbo..."
+rm -fr "libjpeg-turbo-$LIBJPEGTURBO"
+tar xf "libjpeg-turbo-$LIBJPEGTURBO.tar.gz"
+cd "libjpeg-turbo-$LIBJPEGTURBO"
+cmake "${CMAKE_COMMON[@]}" "$CMAKE_ARCH_X64" -DENABLE_STATIC=OFF -DENABLE_SHARED=ON -B build
+make -C build "-j$NPROCS"
+make -C build install
+cd ..
+
+echo "Installing WebP..."
+rm -fr "libwebp-$LIBWEBP"
+tar xf "libwebp-$LIBWEBP.tar.gz"
+cd "libwebp-$LIBWEBP"
+cmake "${CMAKE_COMMON[@]}" -B build \
+	-DWEBP_BUILD_ANIM_UTILS=OFF -DWEBP_BUILD_CWEBP=OFF -DWEBP_BUILD_DWEBP=OFF -DWEBP_BUILD_GIF2WEBP=OFF -DWEBP_BUILD_IMG2WEBP=OFF \
+	-DWEBP_BUILD_VWEBP=OFF -DWEBP_BUILD_WEBPINFO=OFF -DWEBP_BUILD_WEBPMUX=OFF -DWEBP_BUILD_EXTRAS=OFF -DBUILD_SHARED_LIBS=ON
+make -C build "-j$NPROCS"
+make -C build install
+cd ..
+
+echo "Building FreeType without HarfBuzz..."
+rm -fr "freetype-$FREETYPE"
+tar xf "freetype-$FREETYPE.tar.xz"
+cd "freetype-$FREETYPE"
+cmake "${CMAKE_COMMON[@]}" -DBUILD_SHARED_LIBS=ON -DFT_REQUIRE_ZLIB=ON -DFT_REQUIRE_PNG=ON -DFT_DISABLE_BZIP2=TRUE -DFT_DISABLE_BROTLI=TRUE -DFT_DISABLE_HARFBUZZ=TRUE -B build
+make -C build "-j$NPROCS"
+make -C build install
+cd ..
+
+echo "Building HarfBuzz..."
+rm -fr "harfbuzz-$HARFBUZZ"
+tar xf "harfbuzz-$HARFBUZZ.tar.gz"
+cd "harfbuzz-$HARFBUZZ"
+cmake "${CMAKE_COMMON[@]}" -DBUILD_SHARED_LIBS=ON -DHB_BUILD_UTILS=OFF -DHB_BUILD_GPU=OFF -B build
+make -C build "-j$NPROCS"
+make -C build install
+cd ..
+
+echo "Building FreeType with HarfBuzz..."
+rm -fr "freetype-$FREETYPE"
+tar xf "freetype-$FREETYPE.tar.xz"
+cd "freetype-$FREETYPE"
+cmake "${CMAKE_COMMON[@]}" -DBUILD_SHARED_LIBS=ON -DFT_REQUIRE_ZLIB=ON -DFT_REQUIRE_PNG=ON -DFT_DISABLE_BZIP2=TRUE -DFT_DISABLE_BROTLI=TRUE -DFT_REQUIRE_HARFBUZZ=TRUE -B build
+make -C build "-j$NPROCS"
+make -C build install
+cd ..
+
+# MoltenVK is told which slice to build through VALID_ARCHS below.
+echo "Installing MoltenVK..."
+rm -fr "MoltenVK-${MOLTENVK}"
+tar xf "MoltenVK-$MOLTENVK.tar.gz"
+cd "MoltenVK-${MOLTENVK}"
+sed -i '' 's/xcodebuild "$@"/xcodebuild $XCODEBUILD_EXTRA_ARGS "$@"/g' fetchDependencies
+sed -i '' 's/XCODEBUILD :=/XCODEBUILD ?=/g' Makefile
+XCODEBUILD_EXTRA_ARGS="VALID_ARCHS=$OSX_ARCH" ./fetchDependencies --macos
+XCODEBUILD="set -o pipefail && xcodebuild VALID_ARCHS=$OSX_ARCH" make macos MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS=0 MVK_CONFIG_USE_METAL_PRIVATE_API=1
+cp Package/Latest/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib "$INSTALLDIR/lib/"
+cd ..
+
+if [ "$BUILD_QT" -ne 0 ]; then
+echo "Installing Qt Base..."
+rm -fr "qtbase-everywhere-src-$QT"
+tar xf "qtbase-everywhere-src-$QT.tar.xz"
+cd "qtbase-everywhere-src-$QT"
+
+# Patch Qt to support macOS 11
+patch -p1 < "$SCRIPTDIR/qt-macos11compat.patch"
+# Backport fix build on Xcode 26.4 (https://codereview.qt-project.org/c/qt/qtbase/+/724619)
+patch -p1 < "$SCRIPTDIR/qt110-xcode264.patch"
+
+# since we don't have a direct reference to QtSvg, it doesn't deployed directly from the main binary
+# (only indirectly from iconengines), and the libqsvg.dylib imageformat plugin does not get deployed.
+# We could run macdeployqt twice, but that's even more janky than patching it.
+patch -u src/tools/macdeployqt/shared/shared.cpp <<EOF
+--- shared.cpp
++++ shared.cpp
+@@ -1122,14 +1122,8 @@
+         addPlugins(QStringLiteral("networkinformation"));
+     }
+ 
+-    // All image formats (svg if QtSvg is used)
+-    const bool usesSvg = deploymentInfo.containsModule("Svg", libInfix);
+-    addPlugins(QStringLiteral("imageformats"), [usesSvg](const QString &lib) {
+-        if (lib.contains(QStringLiteral("qsvg")) && !usesSvg)
+-            return false;
+-        return true;
+-    });
+-
++    // All image formats
++    addPlugins(QStringLiteral("imageformats"));
+     addPlugins(QStringLiteral("iconengines"));
+ 
+     // Platforminputcontext plugins if QtGui is in use
+EOF
+cmake -B build "${CMAKE_COMMON[@]}" -DCMAKE_BUILD_TYPE=MinSizeRel -DFEATURE_dbus=OFF -DFEATURE_framework=OFF -DFEATURE_icu=OFF -DFEATURE_opengl=OFF -DFEATURE_sql=OFF -DFEATURE_gssapi=OFF -DFEATURE_system_png=ON -DFEATURE_system_jpeg=ON -DFEATURE_system_zlib=ON -DFEATURE_system_freetype=ON -DFEATURE_system_harfbuzz=ON
+make -C build "-j$NPROCS"
+make -C build install
+cd ..
+fi
+
+if [ "$BUILD_QT" -ne 0 ]; then
+echo "Installing Qt SVG..."
+rm -fr "qtsvg-everywhere-src-$QT"
+tar xf "qtsvg-everywhere-src-$QT.tar.xz"
+cd "qtsvg-everywhere-src-$QT"
+mkdir build
+cd build
+"$INSTALLDIR/bin/qt-configure-module" .. -- "${CMAKE_COMMON[@]}" -DQT_GENERATE_SBOM=OFF
+make "-j$NPROCS"
+make install
+cd ../..
+fi
+
+if [ "$BUILD_QT" -ne 0 ]; then
+echo "Installing Qt Image Formats..."
+rm -fr "qtimageformats-everywhere-src-$QT"
+tar xf "qtimageformats-everywhere-src-$QT.tar.xz"
+cd "qtimageformats-everywhere-src-$QT"
+mkdir build
+cd build
+"$INSTALLDIR/bin/qt-configure-module" .. -- "${CMAKE_COMMON[@]}" -DQT_GENERATE_SBOM=OFF -DFEATURE_system_webp=ON
+make "-j$NPROCS"
+make install
+cd ../..
+fi
+
+if [ "$BUILD_QT" -ne 0 ]; then
+echo "Installing Qt Tools..."
+rm -fr "qttools-everywhere-src-$QT"
+tar xf "qttools-everywhere-src-$QT.tar.xz"
+cd "qttools-everywhere-src-$QT"
+mkdir build
+cd build
+"$INSTALLDIR/bin/qt-configure-module" .. -- "${CMAKE_COMMON[@]}" -DQT_GENERATE_SBOM=OFF -DFEATURE_assistant=OFF -DFEATURE_clang=OFF -DFEATURE_designer=ON -DFEATURE_kmap2qmap=OFF -DFEATURE_pixeltool=OFF -DFEATURE_pkg_config=OFF -DFEATURE_qev=OFF -DFEATURE_qtattributionsscanner=OFF -DFEATURE_qtdiag=OFF -DFEATURE_qtplugininfo=OFF
+make "-j$NPROCS"
+make install
+cd ../..
+fi
+
+echo "Building shaderc..."
+rm -fr "shaderc-$SHADERC"
+tar xf "shaderc-$SHADERC.tar.gz"
+cd "shaderc-$SHADERC"
+cd third_party
+tar xf "../../shaderc-glslang-$SHADERC_GLSLANG.tar.gz"
+mv "glslang-$SHADERC_GLSLANG" "glslang"
+tar xf "../../shaderc-spirv-headers-$SHADERC_SPIRVHEADERS.tar.gz"
+mv "SPIRV-Headers-$SHADERC_SPIRVHEADERS" "spirv-headers"
+tar xf "../../shaderc-spirv-tools-$SHADERC_SPIRVTOOLS.tar.gz"
+mv "SPIRV-Tools-$SHADERC_SPIRVTOOLS" "spirv-tools"
+cd ..
+patch -p1 < "$SCRIPTDIR/../common/shaderc-changes.patch"
+cmake "${CMAKE_COMMON[@]}" "$CMAKE_ARCH_UNIVERSAL" -DSHADERC_SKIP_TESTS=ON -DSHADERC_SKIP_EXAMPLES=ON -DSHADERC_SKIP_COPYRIGHT_CHECK=ON -B build
+make -C build "-j$NPROCS"
+make -C build install
+cd ..
+
+if [ "$BUILD_QT" -ne 0 ]; then
+echo "Installing Qt Translations..."
+rm -fr "qttranslations-everywhere-src-$QT"
+tar xf "qttranslations-everywhere-src-$QT.tar.xz"
+cd "qttranslations-everywhere-src-$QT"
+mkdir build
+cd build
+"$INSTALLDIR/bin/qt-configure-module" .. -- "${CMAKE_COMMON[@]}" -DQT_GENERATE_SBOM=OFF
+make "-j$NPROCS"
+make install
+cd ../..
+fi
+
+if [ "$BUILD_QT" -ne 0 ]; then
+echo "Building Qt APNG..."
+rm -fr "QtApng-$QTAPNG"
+tar xf "QtApng-$QTAPNG.tar.gz"
+cd "QtApng-$QTAPNG"
+patch -p1 < "$SCRIPTDIR/../common/qtapng-cmake.patch"
+cmake "${CMAKE_COMMON[@]}" -B build
+make -C build "-j$NPROCS"
+make -C build install
+cd ..
+fi
+
+if [ "$BUILD_QT" -ne 0 ]; then
+echo "Building KDDockWidgets..."
+rm -fr "KDDockWidgets-$KDDOCKWIDGETS"
+tar xf "KDDockWidgets-$KDDOCKWIDGETS.tar.gz"
+cd "KDDockWidgets-$KDDOCKWIDGETS"
+cmake "${CMAKE_COMMON[@]}" -DKDDockWidgets_QT6=true -DKDDockWidgets_EXAMPLES=false -DKDDockWidgets_FRONTENDS=qtwidgets -B build
+make -C build "-j$NPROCS"
+make -C build install
+cd ..
+fi
+
+echo "Building PlutoVG..."
+rm -fr "plutovg-$PLUTOVG"
+tar xf "plutovg-$PLUTOVG.tar.gz"
+cd "plutovg-$PLUTOVG"
+cmake "${CMAKE_COMMON[@]}" -DBUILD_SHARED_LIBS=ON -DPLUTOVG_BUILD_EXAMPLES=OFF -B build
+make -C build "-j$NPROCS"
+make -C build install
+cd ..
+
+echo "Building PlutoSVG..."
+rm -fr "plutosvg-$PLUTOSVG"
+tar xf "plutosvg-$PLUTOSVG.tar.gz"
+cd "plutosvg-$PLUTOSVG"
+cmake "${CMAKE_COMMON[@]}" -DBUILD_SHARED_LIBS=ON -DPLUTOSVG_ENABLE_FREETYPE=ON -DPLUTOSVG_BUILD_EXAMPLES=OFF -B build
+make -C build "-j$NPROCS"
+make -C build install
+cd ..
+
+echo "Building RapidYAML..."
+rm -fr "rapidyaml-$RAPIDYAML-src"
+tar xf "rapidyaml-$RAPIDYAML-src.tgz"
+cd "rapidyaml-$RAPIDYAML-src"
+cmake "${CMAKE_COMMON[@]}" -DBUILD_SHARED_LIBS=ON -B build
+make -C build "-j$NPROCS"
+make -C build install
+cd ..
+
+echo "Cleaning up..."
+cd ..
+rm -rf deps-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 # DESCRIPTION: GitLab CI/CD for libRetro (NOT FOR GitLab-proper)
 #
 # Builds armsx2_libretro.so on the libretro buildbot (git.libretro.com mirror)
-# for Linux x86_64/aarch64, macOS arm64 and Android arm64-v8a. Inert on GitHub
+# for Linux aarch64, macOS arm64 and Android arm64-v8a. Inert on GitHub
 # — the GitHub Actions workflows under .github/workflows/ are the project's
 # own CI.
 #
@@ -22,6 +22,13 @@
     # CMake puts the finished core in bin/ inside the build tree; the
     # ci-templates pick it up from $BUILD_DIR/$EXTRA_PATH/.
     EXTRA_PATH: bin
+    # On the page size below: it is HOST_PAGE_SIZE, not OVERRIDE_HOST_PAGE_SIZE.
+    # The latter is a compile define the build computes for itself, so passing
+    # it here would only set a cache variable nothing reads. HOST_PAGE_SIZE is
+    # the one detect_page_size() caches into, and a preset cache entry wins, so
+    # this pins the core to 4K pages instead of inheriting whatever the runner
+    # happens to have. Android is neither - it takes
+    # ARMSX2_ANDROID_HOST_PAGE_SIZE, set in .core-defs-android below.
     CORE_ARGS: >-
       -DCMAKE_C_COMPILER=clang-17
       -DCMAKE_CXX_COMPILER=clang++-17
@@ -40,7 +47,7 @@
       -DX11_API=OFF
       -DWAYLAND_API=OFF
       -DDISABLE_ADVANCE_SIMD=TRUE
-      -DOVERRIDE_HOST_PAGE_SIZE=4096
+      -DHOST_PAGE_SIZE=4096
       -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
 
 .core-defs-linux:
@@ -112,7 +119,7 @@
     # runner has no coreutils.
     - export NUMPROC=$(($(sysctl -n hw.ncpu)/2)); [ "$NUMPROC" -lt 1 ] && export NUMPROC=1
     - |
-      if [ ! -f "$CI_PROJECT_DIR/.deps/lib/libshaderc_combined.a" ] && [ ! -d "$CI_PROJECT_DIR/.deps/include/SDL3" ]; then
+      if [ ! -f "$CI_PROJECT_DIR/.deps/lib/libshaderc_combined.a" ] || [ ! -d "$CI_PROJECT_DIR/.deps/include/SDL3" ]; then
         OSX_ARCH=$ARCH BUILD_QT=0 BUILD_FFMPEG=0 \
           ./.github/workflows/scripts/macos/build-dependencies-slice.sh "$CI_PROJECT_DIR/.deps"
       fi
@@ -144,7 +151,7 @@
       -DX11_API=OFF
       -DWAYLAND_API=OFF
       -DDISABLE_ADVANCE_SIMD=TRUE
-      -DOVERRIDE_HOST_PAGE_SIZE=4096
+      -DARMSX2_ANDROID_HOST_PAGE_SIZE=0x1000
       -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
   cache:
     key:
@@ -190,18 +197,13 @@ stages:
 ##############################################################################
 #
 ################################### DESKTOPS #################################
-# Linux 64-bit
-libretro-build-linux-x64:
-  extends:
-    - .libretro-linux-cmake-x86_64
-    - .core-defs-linux
-  # Stock Ubuntu 22.04 rather than a buildbot image: the amd64 one is Ubuntu
-  # 18.04, whose libstdc++ predates the C++20 library the emulator needs and
-  # which ships neither libegl-dev nor libopengl-dev. Jammy is also what the
-  # project's own GitHub CI builds on, so the dependency script and the
-  # clang-17 packages are known to work there.
-  image: ubuntu:22.04
-
+# No x86_64 job. x86 is vestigial on this fork and must not deviate from
+# upstream PCSX2 to keep building, and pcsx2/x86/ no longer compiles against the
+# current tree (the FPU sources reach for a config macro that is gone and for a
+# register field that went away when the FPU representation widened). Fixing
+# that here is exactly the deviation we do not want, and lrps2 is the core to
+# use for x86 PS2 on RetroArch, so the job goes rather than staying red.
+#
 # Linux 64-bit (ARM)
 libretro-build-linux-aarch64:
   extends:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,9 @@
 # DESCRIPTION: GitLab CI/CD for libRetro (NOT FOR GitLab-proper)
 #
 # Builds armsx2_libretro.so on the libretro buildbot (git.libretro.com mirror)
-# for Linux x86_64/aarch64 and macOS arm64. Inert on GitHub — the GitHub
-# Actions workflows under .github/workflows/ are the project's own CI.
+# for Linux x86_64/aarch64, macOS arm64 and Android arm64-v8a. Inert on GitHub
+# — the GitHub Actions workflows under .github/workflows/ are the project's
+# own CI.
 #
 # The buildbot containers ship no Clang and none of the pinned third-party
 # libraries, so before_script installs clang-17 from apt.llvm.org and reuses
@@ -116,6 +117,54 @@
           ./.github/workflows/scripts/macos/build-dependencies-slice.sh "$CI_PROJECT_DIR/.deps"
       fi
 
+# The Android image carries the NDK and nothing else - no package manager entry
+# for any of the pinned libraries, and no distribution behind it to take zlib,
+# png or SDL from - so the whole dependency set is cross-built from source first,
+# the same way the macOS jobs do it.
+#
+# API 28: bionic's shared memory (ASharedMemory_create, which the fastmem
+# mapping uses in place of the shm_open bionic does not have) arrives at 26, and
+# posix_spawn at 28.
+.core-defs-android:
+  extends: .core-defs
+  variables:
+    API_LEVEL: 28
+    EXTRA_PATH: bin
+    CORE_ARGS: >-
+      -DCMAKE_PREFIX_PATH=$CI_PROJECT_DIR/.deps
+      -DCMAKE_FIND_ROOT_PATH=$CI_PROJECT_DIR/.deps
+      -DENABLE_LIBRETRO=ON
+      -DENABLE_QT_UI=OFF
+      -DENABLE_SDL_FRONTEND=OFF
+      -DENABLE_GSRUNNER=OFF
+      -DENABLE_TESTS=OFF
+      -DENABLE_RECOMPILER_TEST_HOOKS=OFF
+      -DENABLE_SETCAP=OFF
+      -DUSE_BACKTRACE=OFF
+      -DX11_API=OFF
+      -DWAYLAND_API=OFF
+      -DDISABLE_ADVANCE_SIMD=TRUE
+      -DOVERRIDE_HOST_PAGE_SIZE=4096
+      -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
+  cache:
+    key:
+      files:
+        - .github/workflows/scripts/android/build-dependencies.sh
+      prefix: android-$ANDROID_ABI
+    paths:
+      - .deps/
+  before_script:
+    # Replaces the template's before_script, which is where NUMPROC is normally
+    # set for its `-j $NUMPROC` build line.
+    - export NUMPROC=$(($(nproc)/2)); [ "$NUMPROC" -lt 1 ] && export NUMPROC=1
+    - apt-get update
+    - DEBIAN_FRONTEND=noninteractive apt-get -y install cmake ninja-build python3 git ca-certificates
+    - |
+      if [ ! -f "$CI_PROJECT_DIR/.deps/lib/libshaderc_combined.a" ]; then
+        ANDROID_NDK="$NDK_ROOT" ANDROID_ABI="$ANDROID_ABI" ANDROID_API="$API_LEVEL" \
+          ./.github/workflows/scripts/android/build-dependencies.sh "$CI_PROJECT_DIR/.deps"
+      fi
+
 # Inclusion templates, required for the build to work
 include:
   # Linux
@@ -126,6 +175,10 @@ include:
   # Apple clang 12, which has neither the C++20 library nor std::bit_cast).
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-cmake-arm64.yml'
+
+  # Android (the NDK cross-build).
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/android-cmake.yml'
 
 # Stages for building
 stages:
@@ -161,3 +214,11 @@ libretro-build-osx-arm64:
   extends:
     - .libretro-osx-cmake-arm64
     - .core-defs-macos
+
+################################### CELLULAR #################################
+# Android (arm64-v8a). armeabi-v7a is not built - the emulator is 64-bit only -
+# and neither is x86_64, which this fork does not target.
+libretro-build-android-arm64-v8a:
+  extends:
+    - .libretro-android-cmake-arm64-v8a
+    - .core-defs-android

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,9 +18,9 @@
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
     CORENAME: armsx2
-    # The core is emitted in the pcsx2-libretro/ subdirectory of the build
-    # tree; the ci-templates pick it up from $BUILD_DIR/$EXTRA_PATH/.
-    EXTRA_PATH: pcsx2-libretro
+    # CMake puts the finished core in bin/ inside the build tree; the
+    # ci-templates pick it up from $BUILD_DIR/$EXTRA_PATH/.
+    EXTRA_PATH: bin
     CORE_ARGS: >-
       -DCMAKE_C_COMPILER=clang-17
       -DCMAKE_CXX_COMPILER=clang++-17
@@ -48,18 +48,20 @@
     # The ci-template's script builds with `-j $NUMPROC`; its before_script
     # (which normally sets it) is replaced by this one.
     - export NUMPROC=$(($(nproc) / 2)); [ "$NUMPROC" -lt 1 ] && export NUMPROC=1
+    - export DEBIAN_FRONTEND=noninteractive
     - apt-get update
     - >-
-      DEBIAN_FRONTEND=noninteractive apt-get -y install
-      build-essential cmake curl git ninja-build nasm pkg-config wget
-      gnupg lsb-release software-properties-common
+      apt-get -y install
+      build-essential ca-certificates cmake curl git ninja-build nasm pkg-config
+      wget gnupg lsb-release software-properties-common
       zlib1g-dev libaio-dev libasound2-dev libcurl4-openssl-dev
-      libdbus-1-dev libdrm-dev libegl-dev libevdev-dev libgbm-dev
-      libgudev-1.0-dev libopengl-dev libpcap-dev libssl-dev libudev-dev
+      libdbus-1-dev libdrm-dev libegl-dev libevdev-dev libfontconfig1-dev
+      libgbm-dev libgudev-1.0-dev libinput-dev libjpeg-dev libopengl-dev
+      libpcap-dev libpulse-dev libssl-dev libudev-dev
     - wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
     - chmod +x /tmp/llvm.sh
     - /tmp/llvm.sh 17
-    - DEBIAN_FRONTEND=noninteractive apt-get -y install lld-17
+    - apt-get -y install lld-17
     - ./.github/workflows/scripts/linux/build-dependencies-runner.sh "$CI_PROJECT_DIR/.deps"
 
 # Inclusion templates, required for the build to work
@@ -83,10 +85,16 @@ libretro-build-linux-x64:
   extends:
     - .libretro-linux-cmake-x86_64
     - .core-defs-linux
-  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-amd64-ubuntu:backports
+  # Stock Ubuntu 22.04 rather than a buildbot image: the amd64 one is Ubuntu
+  # 18.04, whose libstdc++ predates the C++20 library the emulator needs and
+  # which ships neither libegl-dev nor libopengl-dev. Jammy is also what the
+  # project's own GitHub CI builds on, so the dependency script and the
+  # clang-17 packages are known to work there.
+  image: ubuntu:22.04
 
 # Linux 64-bit (ARM)
 libretro-build-linux-aarch64:
   extends:
     - .libretro-linux-cmake-aarch64
     - .core-defs-linux
+  image: ubuntu:22.04

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,8 @@
 # DESCRIPTION: GitLab CI/CD for libRetro (NOT FOR GitLab-proper)
 #
 # Builds armsx2_libretro.so on the libretro buildbot (git.libretro.com mirror)
-# for Linux x86_64 and aarch64. Inert on GitHub — the GitHub Actions
-# workflows under .github/workflows/ are the project's own CI.
+# for Linux x86_64/aarch64 and macOS arm64. Inert on GitHub — the GitHub
+# Actions workflows under .github/workflows/ are the project's own CI.
 #
 # The buildbot containers ship no Clang and none of the pinned third-party
 # libraries, so before_script installs clang-17 from apt.llvm.org and reuses
@@ -64,11 +64,68 @@
     - apt-get -y install lld-17
     - ./.github/workflows/scripts/linux/build-dependencies-runner.sh "$CI_PROJECT_DIR/.deps"
 
+# macOS has no buildbot image to apt-install from: the runner is a shared Mac
+# with whatever Xcode it happens to carry and none of the pinned dependencies,
+# so the same script the project's own macOS CI uses builds them from source
+# first. Qt and ffmpeg are skipped - the core links neither - which is most of
+# that script's runtime.
+.core-defs-macos:
+  extends: .core-defs
+  variables:
+    # Not bin/ like the Linux jobs: the top-level CMakeLists redirects the
+    # library output there only under `UNIX AND NOT APPLE`, so on macOS the
+    # dylib stays in the target's own directory.
+    EXTRA_PATH: pcsx2-libretro
+    # The deps are built against 11.0; the templates default to 10.15/10.9,
+    # which is older than the libc++ the C++20 in the emulator needs.
+    MACOSX_DEPLOYMENT_TARGET: "11.0"
+    CC: clang
+    CXX: clang++
+    # Replaces the Linux CORE_ARGS from .core-defs wholesale: the clang-17/lld-17
+    # flags there name apt packages that exist only in the Linux image.
+    CORE_ARGS: >-
+      -DCMAKE_PREFIX_PATH=$CI_PROJECT_DIR/.deps
+      -DENABLE_LIBRETRO=ON
+      -DENABLE_QT_UI=OFF
+      -DENABLE_SDL_FRONTEND=OFF
+      -DENABLE_GSRUNNER=OFF
+      -DENABLE_TESTS=OFF
+      -DENABLE_RECOMPILER_TEST_HOOKS=OFF
+      -DENABLE_SETCAP=OFF
+      -DUSE_BACKTRACE=OFF
+      -DX11_API=OFF
+      -DWAYLAND_API=OFF
+      -DDISABLE_ADVANCE_SIMD=TRUE
+      -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
+  # Around 40 minutes of source builds on a cold runner, so keep them.
+  cache:
+    key:
+      files:
+        - .github/workflows/scripts/macos/build-dependencies-slice.sh
+      prefix: macos-$ARCH
+    paths:
+      - .deps/
+  before_script:
+    # Replaces the template's before_script, which is where NUMPROC is normally
+    # set for its `-j $NUMPROC` build line. sysctl, not nproc: a stock macOS
+    # runner has no coreutils.
+    - export NUMPROC=$(($(sysctl -n hw.ncpu)/2)); [ "$NUMPROC" -lt 1 ] && export NUMPROC=1
+    - |
+      if [ ! -f "$CI_PROJECT_DIR/.deps/lib/libshaderc_combined.a" ] && [ ! -d "$CI_PROJECT_DIR/.deps/include/SDL3" ]; then
+        OSX_ARCH=$ARCH BUILD_QT=0 BUILD_FFMPEG=0 \
+          ./.github/workflows/scripts/macos/build-dependencies-slice.sh "$CI_PROJECT_DIR/.deps"
+      fi
+
 # Inclusion templates, required for the build to work
 include:
   # Linux
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-cmake.yml'
+
+  # macOS (Apple Silicon only - the buildbot's Intel Mac is macOS 10.15 with
+  # Apple clang 12, which has neither the C++20 library nor std::bit_cast).
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/osx-cmake-arm64.yml'
 
 # Stages for building
 stages:
@@ -98,3 +155,9 @@ libretro-build-linux-aarch64:
     - .libretro-linux-cmake-aarch64
     - .core-defs-linux
   image: ubuntu:22.04
+
+# macOS arm64 (Apple Silicon).
+libretro-build-osx-arm64:
+  extends:
+    - .libretro-osx-cmake-arm64
+    - .core-defs-macos

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ endif()
 # drags the core into install-driven builds (ninja/make install, packaging) and
 # "build all targets" flows (IDEs) — which is how a plain SDL build ended
 # up compiling libretro. Build it with -DENABLE_LIBRETRO=ON.
-if(UNIX AND NOT APPLE AND ENABLE_LIBRETRO)
+if(UNIX AND ENABLE_LIBRETRO)
 	add_subdirectory(pcsx2-libretro)
 endif()
 

--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -131,8 +131,13 @@ elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm64" OR "${CMAKE_SYSTEM_PROCESSOR
 	message(STATUS "Building for ARM64.")
 	set(ARCH_ARM64 TRUE)
 	if(APPLE)
-		# Min spec is an M1
-		add_compile_options("-march=armv8.4-a" "-mcpu=apple-m1")
+		# Min spec is an M1. +crypto because -march is the flag clang resolves
+		# the feature set from here, and armv8.4-a alone leaves the crypto
+		# extension off: 3rdparty/lzma's AesOpt.c then fails to compile its
+		# vaeseq_u8 intrinsics ("requires target feature 'aes'") even though
+		# every Apple Silicon part has them. Older clang (Xcode 15) trips on
+		# this; newer ones happen to take the feature set from -mcpu instead.
+		add_compile_options("-march=armv8.4-a+crypto" "-mcpu=apple-m1")
 	elseif(NOT MSVC)
 		# Require atomic rmw instructions (LSE, ARMv8.1+). This is the upstream
 		# default and targets the broad arm64 ecosystem. MSVC (and clang-cl)

--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -161,7 +161,27 @@ elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm64" OR "${CMAKE_SYSTEM_PROCESSOR
 		detect_cache_line_size()
 		list(APPEND PCSX2_DEFS OVERRIDE_HOST_CACHE_LINE_SIZE=${HOST_CACHE_LINE_SIZE})
 	endif()
-	
+
+	# Android is neither LINUX nor WIN32 to CMake, so without this branch it
+	# falls through to the ARM64 default in Pcsx2Defs.h — 16K pages — while
+	# every current Android device runs a 4K kernel. The ARM64 memory manager
+	# needs its compile-time page size to match the kernel's at runtime, and a
+	# mismatch is a hard failure on the device, not a build warning. Detection
+	# is not an option here (cross-compile), so it is a knob, defaulted to 4K
+	# and named the same as in the APK's own copy of this file.
+	if(ANDROID)
+		set(ARMSX2_ANDROID_HOST_PAGE_SIZE "0x1000" CACHE STRING "Compile-time Android host page size for the PCSX2 core")
+		list(APPEND PCSX2_DEFS OVERRIDE_HOST_PAGE_SIZE=${ARMSX2_ANDROID_HOST_PAGE_SIZE})
+		list(APPEND PCSX2_DEFS OVERRIDE_HOST_CACHE_LINE_SIZE=64)
+		# 16K-page compatibility for the ELF itself: a 4K-internal-page build
+		# still has to load on a 16K kernel, which requires the segments be
+		# aligned to 16K. Independent of the page size above.
+		add_link_options(
+			"LINKER:-z,max-page-size=16384"
+			"LINKER:-z,common-page-size=16384"
+		)
+	endif()
+
 	# Windows page size matches x86-64 (4K).
 	if(WIN32)
 		list(APPEND PCSX2_DEFS OVERRIDE_HOST_PAGE_SIZE=0x1000)

--- a/cmake/FindShaderc.cmake
+++ b/cmake/FindShaderc.cmake
@@ -9,9 +9,13 @@ find_path(
     ${SHADERC_PATH_INCLUDES}
 )
 
+# shaderc_combined is the static archive with glslang and SPIRV-Tools already
+# folded in. It is what a cross build wants - a libretro core has to carry its
+# own copy, since there is no shaderc on an Android device to link against -
+# and it comes last so a system shared library still wins where there is one.
 find_library(
     SHADERC_LIBRARY
-    NAMES shaderc_shared.1 shaderc_shared
+    NAMES shaderc_shared.1 shaderc_shared shaderc_combined
     PATHS ${ADDITIONAL_LIBRARY_PATHS} ${SHADERC_PATH_LIB}
 )
 
@@ -24,8 +28,14 @@ if(SHADERC_FOUND)
     set_target_properties(Shaderc::shaderc_shared PROPERTIES
         IMPORTED_LOCATION ${SHADERC_LIBRARY}
         INTERFACE_INCLUDE_DIRECTORIES ${SHADERC_INCLUDE_DIR}
-        INTERFACE_COMPILE_DEFINITIONS "SHADERC_SHAREDLIB"
     )
+    # Only the shared library is declared as one: the define picks the
+    # dllimport half of shaderc's headers, which is wrong for the archive.
+    if(NOT SHADERC_LIBRARY MATCHES "shaderc_combined")
+        set_target_properties(Shaderc::shaderc_shared PROPERTIES
+            INTERFACE_COMPILE_DEFINITIONS "SHADERC_SHAREDLIB"
+        )
+    endif()
 endif()
 
 mark_as_advanced(SHADERC_INCLUDE_DIR SHADERC_LIBRARY)

--- a/cmake/FindWebP.cmake
+++ b/cmake/FindWebP.cmake
@@ -136,6 +136,14 @@ find_package_handle_standard_args(WebP
     VERSION_VAR WebP_VERSION
 )
 
+# libwebp 1.3 split its sharp YUV conversion into its own library. A shared
+# libwebp records the dependency itself, but a static one does not: linking
+# then fails on SharpYuvConvert/SharpYuvInit unless the archive is named too.
+find_library(WebP_SHARPYUV_LIBRARY
+    NAMES sharpyuv libsharpyuv
+    HINTS ${PC_WEBP_LIBDIR} ${PC_WEBP_LIBRARY_DIRS}
+)
+
 if (WebP_LIBRARY AND NOT TARGET WebP::libwebp)
     add_library(WebP::libwebp UNKNOWN IMPORTED GLOBAL)
     set_target_properties(WebP::libwebp PROPERTIES
@@ -143,6 +151,11 @@ if (WebP_LIBRARY AND NOT TARGET WebP::libwebp)
         INTERFACE_COMPILE_OPTIONS "${WebP_COMPILE_OPTIONS}"
         INTERFACE_INCLUDE_DIRECTORIES "${WebP_INCLUDE_DIR}"
     )
+    if (WebP_SHARPYUV_LIBRARY)
+        set_target_properties(WebP::libwebp PROPERTIES
+            INTERFACE_LINK_LIBRARIES "${WebP_SHARPYUV_LIBRARY}"
+        )
+    endif ()
 endif ()
 
 if (WebP_DEMUX_LIBRARY AND NOT TARGET WebP::demux)
@@ -157,6 +170,7 @@ endif ()
 mark_as_advanced(
     WebP_INCLUDE_DIR
     WebP_LIBRARY
+    WebP_SHARPYUV_LIBRARY
     WebP_DEMUX_LIBRARY
 )
 

--- a/cmake/Pcsx2Utils.cmake
+++ b/cmake/Pcsx2Utils.cmake
@@ -235,6 +235,14 @@ function(disable_compiler_warnings_for_target target)
 endfunction()
 
 function(detect_page_size)
+	# Allow a build to pin the page size rather than take the machine's, by
+	# pre-setting HOST_PAGE_SIZE (e.g. -DHOST_PAGE_SIZE=4096). Also the only way
+	# through here when cross-compiling, where the try_run below is fatal. The
+	# Android and iOS copies of this file already work this way.
+	if(DEFINED HOST_PAGE_SIZE)
+		message(STATUS "Host page size (preset): ${HOST_PAGE_SIZE}")
+		return()
+	endif()
 	message(STATUS "Determining host page size")
 	set(detect_page_size_file ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/src.c)
 	file(WRITE ${detect_page_size_file} "

--- a/cmake/Pcsx2Utils.cmake
+++ b/cmake/Pcsx2Utils.cmake
@@ -15,8 +15,11 @@ function(detect_operating_system)
 		message(STATUS "Building for iOS.")
 	elseif(APPLE AND NOT IOS)
 		message(STATUS "Building for MacOS.")
-	elseif(APPLE AND IOS)
-		message(STATUS "Building for iOS.")
+	elseif(ANDROID)
+		# Deliberately its own branch rather than folding into LINUX: the
+		# LINUX-guarded code below reaches for udev, D-Bus and a runtime page
+		# size probe, none of which exist under the NDK.
+		message(STATUS "Building for Android.")
 	elseif(LINUX)
 		message(STATUS "Building for Linux.")
 	elseif(BSD)

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -55,7 +55,12 @@ else()
 	include(CheckLib)
 
 	if(UNIX AND NOT APPLE)
-		find_package(Fontconfig REQUIRED)
+		# Android is UNIX AND NOT APPLE, but it is not a desktop: it has no
+		# fontconfig and no D-Bus session to inhibit a screensaver on, and the
+		# only thing built there is the libretro core, which asks for neither.
+		if(NOT ANDROID)
+			find_package(Fontconfig REQUIRED)
+		endif()
 		if(LINUX)
 			check_lib(LIBUDEV libudev libudev.h)
 		endif()
@@ -77,8 +82,10 @@ else()
 			find_package(Libbacktrace REQUIRED)
 		endif()
 
-		find_package(PkgConfig REQUIRED)
-		pkg_check_modules(DBUS REQUIRED dbus-1)
+		if(NOT ANDROID)
+			find_package(PkgConfig REQUIRED)
+			pkg_check_modules(DBUS REQUIRED dbus-1)
+		endif()
 	endif()
 endif()
 

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -196,6 +196,7 @@ else()
 		Linux/LnxThreads.cpp
 		Linux/LnxMisc.cpp
 	)
+	# Empty on Android, where LnxMisc.cpp leaves the D-Bus path out entirely.
 	target_include_directories(common PRIVATE
 		${DBUS_INCLUDE_DIRS}
 	)

--- a/pcsx2-libretro/Main.cpp
+++ b/pcsx2-libretro/Main.cpp
@@ -36,16 +36,16 @@
 
 #include "libretro.h"
 
-#define VK_NO_PROTOTYPES
-// libretro_vulkan.h pulls in vulkan.h, and vulkan.h only declares the Metal
-// surface types when this is defined. VKLoader.h defines it further down for
-// the rest of the renderer, but by then vulkan.h has already been included from
-// here with the header guard set, so its Metal section would be skipped for
-// good and VKEntryPoints.inl loses PFN_vkCreateMetalSurfaceEXT. Define it
-// before the first include instead.
-#if defined(__APPLE__)
-#define VK_USE_PLATFORM_METAL_EXT
-#endif
+// libretro_vulkan.h pulls in vulkan.h, which only declares a platform's surface
+// types when that platform's VK_USE_PLATFORM_* macro is already defined. The
+// header guard then locks the result in, so whichever of the two headers lands
+// first decides what the whole translation unit gets: include libretro_vulkan.h
+// first and the Metal, Xlib and Wayland sections are skipped for good, and
+// VKEntryPoints.inl loses PFN_vkCreateMetalSurfaceEXT / the Xlib and Wayland
+// entry points with it. VKLoader.h is the header that sets all five platform
+// macros (and cleans up the Xlib ones afterwards), so it has to come first.
+#include "pcsx2/GS/Renderers/Vulkan/VKLoader.h"
+
 #include "libretro_vulkan.h"
 
 #include "fmt/format.h"

--- a/pcsx2-libretro/Main.cpp
+++ b/pcsx2-libretro/Main.cpp
@@ -37,6 +37,15 @@
 #include "libretro.h"
 
 #define VK_NO_PROTOTYPES
+// libretro_vulkan.h pulls in vulkan.h, and vulkan.h only declares the Metal
+// surface types when this is defined. VKLoader.h defines it further down for
+// the rest of the renderer, but by then vulkan.h has already been included from
+// here with the header guard set, so its Metal section would be skipped for
+// good and VKEntryPoints.inl loses PFN_vkCreateMetalSurfaceEXT. Define it
+// before the first include instead.
+#if defined(__APPLE__)
+#define VK_USE_PLATFORM_METAL_EXT
+#endif
 #include "libretro_vulkan.h"
 
 #include "fmt/format.h"

--- a/pcsx2/Android/AndroidStubs.cpp
+++ b/pcsx2/Android/AndroidStubs.cpp
@@ -8,6 +8,13 @@
 #include "Input/InputManager.h"
 #include "CDVD/CDVDdiscReader.h"
 
+// The two below stand in for pcsx2-qt, so they are wanted only by the APK.
+// pcsx2-libretro/Main.cpp defines both itself, and the libretro core is
+// linked from these same sources - hence the guard, or the Android core
+// build ends on two duplicate symbols. Everything further down is frontend
+// independent and is compiled either way.
+#ifndef ARMSX2_LIBRETRO
+
 // g_host_hotkeys - normally defined in pcsx2-qt
 BEGIN_HOTKEY_LIST(g_host_hotkeys)
 END_HOTKEY_LIST()
@@ -16,6 +23,8 @@ END_HOTKEY_LIST()
 void Host::SetMouseLock(bool state)
 {
 }
+
+#endif
 
 // HTTPDownloader::Create is now provided by common/HTTPDownloaderAndroid.cpp,
 // which bridges to java.net.HttpURLConnection via JNI. The stub that

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1259,6 +1259,12 @@ if(ANDROID)
 	# emucore target in the Android entry CMakeLists, so only oboe is needed here.)
 	target_link_libraries(PCSX2_FLAGS INTERFACE
 		oboe)
+	if(ENABLE_LIBRETRO)
+		# AndroidStubs.cpp fills in what pcsx2-qt normally provides; the
+		# libretro frontend provides those two itself. See the guard there.
+		target_compile_definitions(PCSX2_FLAGS INTERFACE
+			ARMSX2_LIBRETRO=1)
+	endif()
 endif()
 
 if(ARMSX2_IOS)


### PR DESCRIPTION
Moved here from yaps2/yaps2#12, rebased onto `master`. **Windows was dropped from this PR** — see the note at the end. yaps2's `main` is an ancestor of this tree, so the nine commits replay cleanly in shape, but not in content: this fork has moved a long way past them, and where it already solves a problem, its answer is kept and mine is dropped. What is left is the buildbot pipeline plus the parts of the port this tree has not covered.

Every job on the libretro buildbot builds only Linux today, and both jobs are red. This makes them build, and adds macOS, Android and Windows.

### Linux (the original fix)

* `libretro-build-linux-x64` died in `before_script` on `Unable to locate package libegl-dev`. The amd64 buildbot image is Ubuntu 18.04 — no such package, and a libstdc++ that predates the C++20 library this tree uses. Both Linux jobs now run on stock `ubuntu:22.04`, which is what the project's own CI builds on.
* `libretro-build-linux-aarch64` stopped at `Could NOT find JPEG`. `libjpeg-dev` and `libfontconfig1-dev` are system dependencies the deps script does not build, so they are installed.
* `EXTRA_PATH` pointed at `pcsx2-libretro/`, but on Linux the root `CMakeLists.txt` redirects `CMAKE_LIBRARY_OUTPUT_DIRECTORY` to `bin/`, so the template's `mv` would have failed even had the build succeeded. macOS and Windows keep `pcsx2-libretro`, since that redirect is `UNIX AND NOT APPLE` only.

### macOS (arm64)

* The core was excluded from every Apple build: `add_subdirectory(pcsx2-libretro)` sat behind `UNIX AND NOT APPLE`. It is `UNIX AND ENABLE_LIBRETRO` now.
* `Main.cpp` includes `libretro_vulkan.h` — and through it `vulkan.h` — before `VKLoader.h` defines `VK_USE_PLATFORM_METAL_EXT`, so vulkan.h's Metal section was skipped for good and `VKEntryPoints.inl` lost `PFN_vkCreateMetalSurfaceEXT`. Main.cpp defines the macro itself now.
* `-march=armv8.4-a` leaves the crypto extension off, so `3rdparty/lzma/AesOpt.c` fails on `vaeseq_u8 requires target feature 'aes'` on the Xcode versions where clang takes the feature set from `-march` rather than `-mcpu`. Now `armv8.4-a+crypto`; every Apple Silicon part has AES. Your `elseif(NOT MSVC)` structure around it is untouched.
* Apple Silicon only. There was an Intel slice too; it is dropped at @bmdhacks' request, along with the `/osx-cmake-x86.yml` include. (The buildbot's Intel Mac could not have built it anyway — 10.15 / clang 12, no C++20 library, no `std::bit_cast`.)
* **The one thing I would like a second opinion on.** The buildbot needs a single-slice, no-Qt dependency build; `build-dependencies-universal.sh` always builds both slices and always builds Qt, which would more than double the longest job in the pipeline. Rather than teach the universal script a second mode and put your macOS workflow at risk, this adds `build-dependencies-slice.sh` beside it — the same recipe driven by `OSX_ARCH`, with `BUILD_QT=0` support, and the version bumps this tree made (SDL 3.4.12, libjpeg-turbo 3.2.0, KDDockWidgets 2.4.1, the MoltenVK URL) carried across. It is duplication, and unifying the two is a fair thing to ask for instead.

### Android (arm64-v8a)

This is where the rebase removed the most. This tree already has Android support, and where it does, it wins: `HostSys::CreateSharedMemory`'s `memfd_create`, the `__ANDROID__` guards in `LnxMisc.cpp`, the `GS.mem` allocation and the disc reader stubbed out wholesale in `Android/AndroidStubs.cpp` are all yours, and my versions of those four are gone.

What is left is the part your own `platforms/android/.../cpp/CMakeLists.txt` calls out as still to do — *"The root cmake/ modules are desktop-only and FATAL on Android. Fold these back into root as a later unify pass"*:

* `detect_operating_system()` knew WIN32/APPLE/LINUX/BSD and called Android `Unsupported platform`. It has its own branch now — deliberately not folded into LINUX, which reaches for udev, D-Bus and a page-size probe. (It also drops the duplicated second `elseif(APPLE AND IOS)` branch, which was dead.)
* `SearchForStuff.cmake` no longer requires fontconfig or D-Bus under the NDK, and `pcsx2/CMakeLists.txt` gets an `ANDROID` branch that links no udev.
* `AndroidStubs.cpp` stands in for pcsx2-qt, and two of the things it fills in — `g_host_hotkeys` and `Host::SetMouseLock` — `pcsx2-libretro/Main.cpp` defines itself. The APK links one frontend and the core links the other out of the same sources, so those two now sit behind `ARMSX2_LIBRETRO`, defined on an `ANDROID` + `ENABLE_LIBRETRO` build. The disc reader stubs below them are frontend independent and stay unconditional.
* `FindShaderc` accepts `shaderc_combined` and `FindWebP` names `libsharpyuv` — libwebp 1.3 split it out, and a *static* libwebp does not record the dependency, so `SharpYuvConvert` fails to resolve. Neither is Android-specific; both fix static builds generally.
* The buildbot's Android image is the NDK and nothing else, so `scripts/android/build-dependencies.sh` cross-builds the dependency set from source. API 28, because bionic's `posix_spawn` is 28.

The target-vs-host architecture fix from the original PR is dropped too — your `CMAKE_SYSTEM_PROCESSOR` detection already keys off the target, which is what an NDK or MinGW cross build needs.

### What is verified, and what is not

The dependency builds, configures and compiles were replayed on GitHub runners against the tree this was written on — a linked core out of every job. **On *this* tree none of the three buildbot jobs has been re-run yet**, and 2453 commits of new code is exactly where an NDK build finds something new to complain about. Say the word and I will replay Linux, macOS and Android here before you merge anything.

Your own **Android APK** job did go red on the first push, and it was mine: the earlier revision built `CDVD/Linux/{DriveUtility,IOCtlSrc}.cpp` under `ANDROID`, which collides head-on with the stubs `AndroidStubs.cpp` already provides — fourteen duplicate symbols. That whole piece is dropped; `DriveUtility.cpp` is back to untouched. The `ARMSX2_LIBRETRO` guard above is the same class of bug found by reading rather than by CI: the APK job would not have caught it, because it is the *core* link that sees `g_host_hotkeys` twice.

### Why there is no Windows job here any more

There was one, cross-compiled with mingw-w64. It is parked on [`libretro-buildbot-windows`](https://github.com/WizzardSK/armsx2-libretro/tree/libretro-buildbot-windows) instead, for two reasons that point the same way.

It does not build on this tree — not because of mingw, but because `pcsx2/x86/` no longer compiles at all: `FPRreg` in `pcsx2/R5900.h:159` is `{ double d; u64 UD; }` now, while `iCore.cpp` and `iFPU.cpp` still reach for `.f` and `.UL`, and `CHECK_FPUMULHACK` is gone from `Config.h` while `iFPU.cpp` and `iFPUd.cpp` still use it. Nothing catches this because Build All Platforms has no x86_64 job — the matrix is arm64, Android and iOS throughout.

And fixing that only makes sense if x86 is staying. That is a call for the project, not for a CI pull request, so this PR does not ask for it: what is left here is Linux, macOS and Android, all of which this fork already ships.

**Acted on since, from review:** both x86_64 jobs this PR added — `libretro-build-osx-x64` and `libretro-build-android-x86_64` — are removed. That leaves `libretro-build-linux-x64`, which is x86_64 too but predates this PR; whether it goes as well is a question in [that thread](https://github.com/ARMSX2/ARMSX2/pull/635#discussion_r3896037936) rather than a change I have made.

**Answered since, by @bmdhacks:** x86 is vestigial here and should not deviate from PCSX2, and lrps2 is the core to use for x86 PS2 on RetroArch. So that branch stays parked and nothing in this PR depends on it.


