### PR TITLE
Libretro: the frontend's VFS, and an OpenGL context path

### DIFF
--- a/cmake/BuildParameters.cmake
+++ b/cmake/BuildParameters.cmake
@@ -310,6 +310,12 @@ if(USE_OPENGL)
 	list(APPEND PCSX2_DEFS ENABLE_OPENGL)
 endif()
 
+if(ENABLE_LIBRETRO)
+	# Guards the pieces that only exist for the core - the frontend-owned GL
+	# context, for one - so a Qt or SDL build never compiles them.
+	list(APPEND PCSX2_DEFS ENABLE_LIBRETRO)
+endif()
+
 if(USE_VULKAN)
 	list(APPEND PCSX2_DEFS ENABLE_VULKAN)
 endif()

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(common PRIVATE
 	Error.cpp
 	FastJmp.cpp
 	FileSystem.cpp
+	HostVFS.cpp
 	HostSys.cpp
 	Image.cpp
 	HTTPDownloader.cpp
@@ -53,6 +54,7 @@ target_sources(common PRIVATE
 	FPControl.h
 	FastJmp.h
 	FileSystem.h
+	HostVFS.h
 	HashCombine.h
 	HostSys.h
 	HeterogeneousContainers.h

--- a/common/FileSystem.cpp
+++ b/common/FileSystem.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "FileSystem.h"
+#include "HostVFS.h"
 #include "Error.h"
 #include "Path.h"
 #include "Assertions.h"
@@ -999,6 +1000,15 @@ std::FILE* FileSystem::OpenCFile(const char* filename, const char* mode, Error* 
 
 	return fp;
 #else
+	// The host's file system first, when there is one: on Android a content://
+	// path has no OS-level equivalent for fopen() to take, and a libretro core
+	// has no Activity to reach the JNI path below through either.
+	if (HostVFS::IsInstalled())
+	{
+		if (std::FILE* vfp = HostVFS::OpenAsCFile(filename, mode))
+			return vfp;
+	}
+
 	#if defined(__ANDROID__)
 	if (std::strncmp(filename, "content://", 10) == 0)
 	{
@@ -2183,6 +2193,139 @@ bool FileSystem::DeleteSymbolicLink(const char* path, Error* error)
 // No 32-bit file offsets breaking stuff please.
 static_assert(sizeof(off_t) == sizeof(s64));
 
+// The same walk as RecursiveFindFiles below, but through the host's directory
+// interface. It is a separate function rather than a branch inside that one
+// because the host has no stat() per entry worth calling - the iterator says
+// whether an entry is a directory, and nothing else - so sizes and timestamps
+// come back zero, and the symlink-loop guard has nothing to resolve against.
+static u32 RecursiveFindFilesVFS(const char* OriginPath, const char* ParentPath, const char* Path, const char* Pattern,
+	u32 Flags, FileSystem::FindResultsArray* pResults, ProgressCallback* cancel)
+{
+	if (cancel && cancel->IsCancelled())
+		return 0;
+
+	std::string tempStr;
+	if (Path)
+	{
+		if (ParentPath)
+			tempStr = fmt::format("{}/{}/{}", OriginPath, ParentPath, Path);
+		else
+			tempStr = fmt::format("{}/{}", OriginPath, Path);
+	}
+	else
+	{
+		tempStr = fmt::format("{}", OriginPath);
+	}
+
+	const HostVFS::Ops* ops = HostVFS::GetOps();
+	void* dir = ops->opendir(tempStr.c_str(), (Flags & FILESYSTEM_FIND_HIDDEN_FILES) != 0);
+	if (!dir)
+		return 0;
+
+	bool hasWildCards = false;
+	bool wildCardMatchAll = false;
+	u32 nFiles = 0;
+	if (std::strpbrk(Pattern, "*?"))
+	{
+		hasWildCards = true;
+		wildCardMatchAll = (std::strcmp(Pattern, "*") == 0);
+	}
+
+	while (ops->readdir(dir))
+	{
+		const char* name = ops->dirent_get_name(dir);
+		if (!name || name[0] == '\0')
+			continue;
+
+		if (name[0] == '.')
+		{
+			if (name[1] == '\0' || (name[1] == '.' && name[2] == '\0'))
+				continue;
+
+			if (!(Flags & FILESYSTEM_FIND_HIDDEN_FILES))
+				continue;
+		}
+
+		std::string full_path;
+		if (ParentPath)
+			full_path = fmt::format("{}/{}/{}/{}", OriginPath, ParentPath, Path, name);
+		else if (Path)
+			full_path = fmt::format("{}/{}/{}", OriginPath, Path, name);
+		else
+			full_path = fmt::format("{}/{}", OriginPath, name);
+
+		FILESYSTEM_FIND_DATA outData;
+		outData.Attributes = 0;
+		outData.Size = 0;
+		outData.CreationTime = 0;
+		outData.ModificationTime = 0;
+
+		const bool is_directory = ops->dirent_is_dir(dir);
+		if (is_directory)
+		{
+			if (Flags & FILESYSTEM_FIND_RECURSIVE)
+			{
+				if (ParentPath)
+				{
+					const std::string recursive_dir = fmt::format("{}/{}", ParentPath, Path);
+					nFiles += RecursiveFindFilesVFS(OriginPath, recursive_dir.c_str(), name, Pattern, Flags, pResults, cancel);
+				}
+				else
+				{
+					nFiles += RecursiveFindFilesVFS(OriginPath, Path, name, Pattern, Flags, pResults, cancel);
+				}
+			}
+
+			if (!(Flags & FILESYSTEM_FIND_FOLDERS))
+				continue;
+
+			outData.Attributes |= FILESYSTEM_FILE_ATTRIBUTE_DIRECTORY;
+		}
+		else
+		{
+			if (!(Flags & FILESYSTEM_FIND_FILES))
+				continue;
+
+			// Only the size is worth a second call, and only for files that
+			// are going to be returned.
+			s64 size = 0;
+			if (HostVFS::StatPath(full_path.c_str(), nullptr, &size))
+				outData.Size = static_cast<u64>(size);
+		}
+
+		if (hasWildCards)
+		{
+			if (!wildCardMatchAll && !StringUtil::WildcardMatch(name, Pattern))
+				continue;
+		}
+		else
+		{
+			if (std::strcmp(name, Pattern) != 0)
+				continue;
+		}
+
+		if (!(Flags & FILESYSTEM_FIND_RELATIVE_PATHS))
+		{
+			outData.FileName = std::move(full_path);
+		}
+		else
+		{
+			if (ParentPath)
+				outData.FileName = fmt::format("{}/{}/{}", ParentPath, Path, name);
+			else if (Path)
+				outData.FileName = fmt::format("{}/{}", Path, name);
+			else
+				outData.FileName = name;
+		}
+
+		nFiles++;
+		pResults->push_back(std::move(outData));
+	}
+
+	ops->closedir(dir);
+	return nFiles;
+}
+
 static u32 RecursiveFindFiles(const char* OriginPath, const char* ParentPath, const char* Path, const char* Pattern,
 	u32 Flags, FileSystem::FindResultsArray* pResults, std::vector<std::string>& visited, ProgressCallback* cancel)
 {
@@ -2328,18 +2471,30 @@ bool FileSystem::FindFiles(const char* path, const char* pattern, u32 flags, Fin
 	if (!(flags & FILESYSTEM_FIND_KEEP_ARRAY))
 		results->clear();
 
-	// add self if recursive, we don't want to visit it twice
-	std::vector<std::string> visited;
-	if (flags & FILESYSTEM_FIND_RECURSIVE)
+	// The host's directory iterator, when it has one: a content:// tree cannot
+	// be walked with opendir(). Frontends that offer files but not directories
+	// leave opendir null, and those fall through to the OS below.
+	if (HostVFS::IsInstalled() && HostVFS::GetOps()->opendir && HostVFS::GetOps()->readdir &&
+		HostVFS::GetOps()->dirent_get_name && HostVFS::GetOps()->closedir)
 	{
-		std::string real_path = Path::RealPath(path);
-		if (!real_path.empty())
-			visited.push_back(std::move(real_path));
+		if (RecursiveFindFilesVFS(path, nullptr, nullptr, pattern, flags, results, cancel) == 0)
+			return false;
 	}
+	else
+	{
+		// add self if recursive, we don't want to visit it twice
+		std::vector<std::string> visited;
+		if (flags & FILESYSTEM_FIND_RECURSIVE)
+		{
+			std::string real_path = Path::RealPath(path);
+			if (!real_path.empty())
+				visited.push_back(std::move(real_path));
+		}
 
-	// enter the recursive function
-	if (RecursiveFindFiles(path, nullptr, nullptr, pattern, flags, results, visited, cancel) == 0)
-		return false;
+		// enter the recursive function
+		if (RecursiveFindFiles(path, nullptr, nullptr, pattern, flags, results, visited, cancel) == 0)
+			return false;
+	}
 
 	if (flags & FILESYSTEM_FIND_SORT_BY_NAME)
 	{
@@ -2377,6 +2532,24 @@ bool FileSystem::StatFile(const char* path, FILESYSTEM_STAT_DATA* sd)
 	// has a path
 	if (path[0] == '\0')
 		return false;
+
+	// The host's answer, where it has one. Its interface reports existence,
+	// directory-ness and size, but no timestamps, so those stay zero - callers
+	// that compare them (cache invalidation) see "unchanged", which is the
+	// harmless direction.
+	if (HostVFS::IsInstalled())
+	{
+		bool is_directory = false;
+		s64 size = 0;
+		if (HostVFS::StatPath(path, &is_directory, &size))
+		{
+			sd->CreationTime = 0;
+			sd->ModificationTime = 0;
+			sd->Attributes = is_directory ? FILESYSTEM_FILE_ATTRIBUTE_DIRECTORY : 0;
+			sd->Size = is_directory ? 0 : size;
+			return true;
+		}
+	}
 
 	// stat file
 	struct stat sysStatData;
@@ -2434,6 +2607,13 @@ bool FileSystem::FileExists(const char* path)
 	if (path[0] == '\0')
 		return false;
 
+	if (HostVFS::IsInstalled())
+	{
+		bool is_directory = false;
+		if (HostVFS::StatPath(path, &is_directory, nullptr))
+			return !is_directory;
+	}
+
 #if defined(__ANDROID__)
 	if (std::strncmp(path, "content://", 10) == 0)
 	{
@@ -2462,6 +2642,13 @@ bool FileSystem::DirectoryExists(const char* path)
 	// has a path
 	if (path[0] == '\0')
 		return false;
+
+	if (HostVFS::IsInstalled())
+	{
+		bool is_directory = false;
+		if (HostVFS::StatPath(path, &is_directory, nullptr))
+			return is_directory;
+	}
 
 	// stat file
 	struct stat sysStatData;
@@ -2506,8 +2693,17 @@ bool FileSystem::CreateDirectoryPath(const char* path, bool recursive, Error* er
 		return false;
 
 	// try just flat-out, might work if there's no other segments that have to be made
-	if (mkdir(path, 0777) == 0)
+	if (HostVFS::IsInstalled() && HostVFS::GetOps()->mkdir)
+	{
+		// 0 is success, -2 is "already exists" in the frontend's interface.
+		const int res = HostVFS::GetOps()->mkdir(path);
+		if (res == 0 || res == -2)
+			return true;
+	}
+	else if (mkdir(path, 0777) == 0)
+	{
 		return true;
+	}
 
 	// check error
 	int lastError = errno;
@@ -2607,11 +2803,27 @@ bool FileSystem::DeleteFilePath(const char* path, Error* error)
 		return false;
 	}
 
-	struct stat sysStatData;
-	if (stat(path, &sysStatData) != 0 || S_ISDIR(sysStatData.st_mode))
+	// Skipped when the host owns the path: its stat() is the one that knows
+	// whether a content:// URI exists, and the check below would reject one.
+	if (!HostVFS::IsInstalled())
 	{
-		Error::SetStringView(error, "File does not exist.");
-		return false;
+		struct stat sysStatData;
+		if (stat(path, &sysStatData) != 0 || S_ISDIR(sysStatData.st_mode))
+		{
+			Error::SetStringView(error, "File does not exist.");
+			return false;
+		}
+	}
+
+	if (HostVFS::IsInstalled() && HostVFS::GetOps()->remove)
+	{
+		if (HostVFS::GetOps()->remove(path) != 0)
+		{
+			Error::SetStringView(error, "Host remove() failed.");
+			return false;
+		}
+
+		return true;
 	}
 
 	if (unlink(path) != 0)
@@ -2629,6 +2841,18 @@ bool FileSystem::RenamePath(const char* old_path, const char* new_path, Error* e
 	{
 		Error::SetStringView(error, "Path is empty.");
 		return false;
+	}
+
+	if (HostVFS::IsInstalled() && HostVFS::GetOps()->rename)
+	{
+		if (HostVFS::GetOps()->rename(old_path, new_path) != 0)
+		{
+			Error::SetStringView(error, "Host rename() failed.");
+			Console.Error("host rename('%s', '%s') failed", old_path, new_path);
+			return false;
+		}
+
+		return true;
 	}
 
 	if (rename(old_path, new_path) != 0)

--- a/common/FileSystem.cpp
+++ b/common/FileSystem.cpp
@@ -1390,7 +1390,15 @@ std::span<const u8> FileSystem::MapBinaryFileForRead(std::FILE* fp)
 #ifdef _WIN32
 	return ::MapBinaryFileForRead(reinterpret_cast<HANDLE>(_get_osfhandle(_fileno(fp))));
 #else
-	return ::MapBinaryFileForRead(fileno(fp));
+	// A host-opened stream has no descriptor to map, and mmap() must not be
+	// handed the -1 that comes back - the path-taking version above guards the
+	// same way. There is nothing to fall back to here: the caller reads the
+	// file instead when this returns empty.
+	const int fd = fileno(fp);
+	if (fd < 0)
+		return {};
+
+	return ::MapBinaryFileForRead(fd);
 #endif
 }
 
@@ -2287,9 +2295,10 @@ static u32 RecursiveFindFilesVFS(const char* OriginPath, const char* ParentPath,
 				continue;
 
 			// Only the size is worth a second call, and only for files that
-			// are going to be returned.
+			// are going to be returned. A negative one means the host could
+			// not say exactly, and zero is the honest answer then.
 			s64 size = 0;
-			if (HostVFS::StatPath(full_path.c_str(), nullptr, &size))
+			if (HostVFS::StatPath(full_path.c_str(), nullptr, &size) && size > 0)
 				outData.Size = static_cast<u64>(size);
 		}
 
@@ -2475,7 +2484,7 @@ bool FileSystem::FindFiles(const char* path, const char* pattern, u32 flags, Fin
 	// be walked with opendir(). Frontends that offer files but not directories
 	// leave opendir null, and those fall through to the OS below.
 	if (HostVFS::IsInstalled() && HostVFS::GetOps()->opendir && HostVFS::GetOps()->readdir &&
-		HostVFS::GetOps()->dirent_get_name && HostVFS::GetOps()->closedir)
+		HostVFS::GetOps()->dirent_get_name && HostVFS::GetOps()->dirent_is_dir && HostVFS::GetOps()->closedir)
 	{
 		if (RecursiveFindFilesVFS(path, nullptr, nullptr, pattern, flags, results, cancel) == 0)
 			return false;
@@ -2522,7 +2531,19 @@ bool FileSystem::StatFile(std::FILE* fp, struct stat* st)
 {
 	const int fd = fileno(fp);
 	if (fd < 0)
-		return false;
+	{
+		// A host-opened stream has no descriptor. Only the size is knowable
+		// through the host's interface, so that is all that gets filled in -
+		// enough for the callers that ask this to size a buffer.
+		s64 size = 0;
+		if (!HostVFS::SizeOfCFile(fp, &size))
+			return false;
+
+		std::memset(st, 0, sizeof(*st));
+		st->st_mode = S_IFREG;
+		st->st_size = static_cast<off_t>(size);
+		return true;
+	}
 
 	return fstat(fd, st) == 0;
 }
@@ -2543,6 +2564,16 @@ bool FileSystem::StatFile(const char* path, FILESYSTEM_STAT_DATA* sd)
 		s64 size = 0;
 		if (HostVFS::StatPath(path, &is_directory, &size))
 		{
+			if (size < 0)
+			{
+				// The host knows the path exists but cannot give an exact
+				// size. The OS still can, for any path it can see - which is
+				// everything except the content:// and network URIs the host
+				// is here for in the first place.
+				struct stat sysStatData;
+				size = (stat(path, &sysStatData) == 0) ? static_cast<s64>(sysStatData.st_size) : 0;
+			}
+
 			sd->CreationTime = 0;
 			sd->ModificationTime = 0;
 			sd->Attributes = is_directory ? FILESYSTEM_FILE_ATTRIBUTE_DIRECTORY : 0;
@@ -2577,7 +2608,20 @@ bool FileSystem::StatFile(std::FILE* fp, FILESYSTEM_STAT_DATA* sd)
 {
 	const int fd = fileno(fp);
 	if (fd < 0)
-		return false;
+	{
+		// As above: no descriptor behind a host stream, and the host answers
+		// for the size. ELF loading from a host path is the caller that made
+		// this show up - it opens through OpenCFile and stats the result.
+		s64 size = 0;
+		if (!HostVFS::SizeOfCFile(fp, &size))
+			return false;
+
+		sd->CreationTime = 0;
+		sd->ModificationTime = 0;
+		sd->Attributes = 0;
+		sd->Size = size;
+		return true;
+	}
 
 	// stat file
 	struct stat sysStatData;
@@ -2685,6 +2729,57 @@ bool FileSystem::DirectoryIsEmpty(const char* path)
 	return true;
 }
 
+// The host's mkdir, which reports "already exists" as -2 and success as 0.
+static bool HostMkdir(const char* path)
+{
+	const int res = HostVFS::GetOps()->mkdir(path);
+	return (res == 0 || res == -2);
+}
+
+// CreateDirectoryPath through the host. Its own function rather than a branch
+// inside the OS one because the two cannot share the error handling: the host
+// sets no errno, so everything the OS path does after a failed mkdir() - the
+// EEXIST check, the ENOENT recursion, the Android permission retry - would be
+// reading whatever the last unrelated library call happened to leave behind.
+// The recursive case is also the one that matters (a fresh data folder), and
+// it has to walk the segments through the host as well: calling the OS for
+// them cannot work on a content:// URI.
+static bool CreateDirectoryPathVFS(const char* path, size_t pathLength, bool recursive, Error* error)
+{
+	// might work as-is, if there are no missing segments above it
+	if (HostMkdir(path))
+		return true;
+
+	if (!recursive)
+	{
+		Error::SetStringView(error, "Host mkdir() failed.");
+		return false;
+	}
+
+	std::string tempPath;
+	tempPath.reserve(pathLength);
+
+	for (size_t i = 0; i < pathLength; i++)
+	{
+		if (i > 0 && path[i] == '/' && !HostMkdir(tempPath.c_str()))
+		{
+			Error::SetStringView(error, "Host mkdir() failed.");
+			return false;
+		}
+
+		tempPath.push_back(path[i]);
+	}
+
+	// and the last segment, when the path does not end in a separator
+	if (path[pathLength - 1] != '/' && !HostMkdir(path))
+	{
+		Error::SetStringView(error, "Host mkdir() failed.");
+		return false;
+	}
+
+	return true;
+}
+
 bool FileSystem::CreateDirectoryPath(const char* path, bool recursive, Error* error)
 {
 	// has a path
@@ -2692,18 +2787,12 @@ bool FileSystem::CreateDirectoryPath(const char* path, bool recursive, Error* er
 	if (pathLength == 0)
 		return false;
 
-	// try just flat-out, might work if there's no other segments that have to be made
 	if (HostVFS::IsInstalled() && HostVFS::GetOps()->mkdir)
-	{
-		// 0 is success, -2 is "already exists" in the frontend's interface.
-		const int res = HostVFS::GetOps()->mkdir(path);
-		if (res == 0 || res == -2)
-			return true;
-	}
-	else if (mkdir(path, 0777) == 0)
-	{
+		return CreateDirectoryPathVFS(path, pathLength, recursive, error);
+
+	// try just flat-out, might work if there's no other segments that have to be made
+	if (mkdir(path, 0777) == 0)
 		return true;
-	}
 
 	// check error
 	int lastError = errno;

--- a/common/HostVFS.cpp
+++ b/common/HostVFS.cpp
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "common/HostVFS.h"
+#include "common/Console.h"
+
+#include <cstring>
+
+// The libretro VFS access flags, kept here rather than pulled from libretro.h:
+// common/ does not depend on the core.
+enum : unsigned
+{
+	VFS_ACCESS_READ = (1 << 0),
+	VFS_ACCESS_WRITE = (1 << 1),
+	VFS_ACCESS_READ_WRITE = (VFS_ACCESS_READ | VFS_ACCESS_WRITE),
+	VFS_ACCESS_UPDATE_EXISTING = (1 << 2),
+};
+
+namespace
+{
+	HostVFS::Ops s_ops = {};
+	bool s_installed = false;
+} // namespace
+
+void HostVFS::Install(const Ops& ops)
+{
+	s_ops = ops;
+	s_installed = (ops.open != nullptr && ops.close != nullptr && ops.read != nullptr);
+	if (!s_installed)
+		Console.Warning("HostVFS: refusing an interface without open/close/read");
+}
+
+bool HostVFS::IsInstalled()
+{
+	return s_installed;
+}
+
+const HostVFS::Ops* HostVFS::GetOps()
+{
+	return s_installed ? &s_ops : nullptr;
+}
+
+bool HostVFS::StatPath(const char* path, bool* is_directory, s64* size)
+{
+	if (!s_installed || !s_ops.stat)
+		return false;
+
+	s32 file_size = 0;
+	const int flags = s_ops.stat(path, &file_size);
+	if (!(flags & STAT_IS_VALID))
+		return false;
+
+	if (is_directory)
+		*is_directory = (flags & STAT_IS_DIRECTORY) != 0;
+	if (size)
+		*size = static_cast<s64>(file_size);
+	return true;
+}
+
+namespace
+{
+	// A std::FILE* has to come out of this, because every caller in the tree
+	// takes one. Both of the two ways to build one from callbacks are here:
+	// fopencookie on glibc, funopen elsewhere (bionic, the BSDs, macOS).
+#if defined(__GLIBC__) || defined(__BIONIC__) || defined(__APPLE__) || defined(__FreeBSD__)
+#define HOSTVFS_HAVE_FILE_WRAPPER 1
+#endif
+
+#if defined(HOSTVFS_HAVE_FILE_WRAPPER)
+
+	unsigned TranslateMode(const char* mode, bool* append)
+	{
+		*append = false;
+
+		const bool plus = (std::strchr(mode, '+') != nullptr);
+		switch (mode[0])
+		{
+			case 'r':
+				// r+ must not truncate, and must fail when the file is absent:
+				// that is what UPDATE_EXISTING means to the frontend.
+				return plus ? (VFS_ACCESS_READ_WRITE | VFS_ACCESS_UPDATE_EXISTING) : VFS_ACCESS_READ;
+
+			case 'w':
+				return plus ? VFS_ACCESS_READ_WRITE : VFS_ACCESS_WRITE;
+
+			case 'a':
+				// No append flag in the interface; open for update and seek to
+				// the end once, which is what append means for our callers.
+				*append = true;
+				return plus ? (VFS_ACCESS_READ_WRITE | VFS_ACCESS_UPDATE_EXISTING) :
+							  (VFS_ACCESS_WRITE | VFS_ACCESS_UPDATE_EXISTING);
+
+			default:
+				return VFS_ACCESS_READ;
+		}
+	}
+
+	int CookieClose(void* cookie)
+	{
+		const HostVFS::Ops* ops = HostVFS::GetOps();
+		return (ops && ops->close) ? ops->close(cookie) : 0;
+	}
+
+#if defined(__GLIBC__)
+
+	ssize_t CookieRead(void* cookie, char* buffer, size_t size)
+	{
+		const HostVFS::Ops* ops = HostVFS::GetOps();
+		const s64 res = ops->read(cookie, buffer, static_cast<u64>(size));
+		// A short read is not an error, but a negative one is, and stdio wants
+		// -1 rather than whatever the frontend returned.
+		return (res < 0) ? -1 : static_cast<ssize_t>(res);
+	}
+
+	ssize_t CookieWrite(void* cookie, const char* buffer, size_t size)
+	{
+		const HostVFS::Ops* ops = HostVFS::GetOps();
+		if (!ops->write)
+			return -1;
+		const s64 res = ops->write(cookie, buffer, static_cast<u64>(size));
+		return (res < 0) ? -1 : static_cast<ssize_t>(res);
+	}
+
+	int CookieSeek(void* cookie, off64_t* offset, int whence)
+	{
+		const HostVFS::Ops* ops = HostVFS::GetOps();
+		if (ops->seek(cookie, static_cast<s64>(*offset), whence) < 0)
+			return -1;
+
+		// RetroArch's seek() returns 0 on success rather than the new position,
+		// so the position has to be read back - reporting 0 here would make
+		// stdio believe every seek landed at the start of the file.
+		const s64 pos = ops->tell ? ops->tell(cookie) : -1;
+		if (pos < 0)
+			return -1;
+
+		*offset = static_cast<off64_t>(pos);
+		return 0;
+	}
+
+	std::FILE* WrapHandle(void* handle, const char* mode)
+	{
+		const cookie_io_functions_t funcs = {CookieRead, CookieWrite, CookieSeek, CookieClose};
+		return fopencookie(handle, mode, funcs);
+	}
+
+#else // funopen flavour
+
+	int CookieReadF(void* cookie, char* buffer, int size)
+	{
+		const HostVFS::Ops* ops = HostVFS::GetOps();
+		const s64 res = ops->read(cookie, buffer, static_cast<u64>(size));
+		return (res < 0) ? -1 : static_cast<int>(res);
+	}
+
+	int CookieWriteF(void* cookie, const char* buffer, int size)
+	{
+		const HostVFS::Ops* ops = HostVFS::GetOps();
+		if (!ops->write)
+			return -1;
+		const s64 res = ops->write(cookie, buffer, static_cast<u64>(size));
+		return (res < 0) ? -1 : static_cast<int>(res);
+	}
+
+#if defined(__APPLE__)
+	using FunopenOffset = fpos_t;
+#else
+	using FunopenOffset = off64_t;
+#endif
+
+	FunopenOffset CookieSeekF(void* cookie, FunopenOffset offset, int whence)
+	{
+		const HostVFS::Ops* ops = HostVFS::GetOps();
+		if (ops->seek(cookie, static_cast<s64>(offset), whence) < 0)
+			return -1;
+
+		// Same as the glibc path: the position comes from tell(), not from the
+		// return value of seek().
+		const s64 pos = ops->tell ? ops->tell(cookie) : -1;
+		return (pos < 0) ? -1 : static_cast<FunopenOffset>(pos);
+	}
+
+	std::FILE* WrapHandle(void* handle, const char* mode)
+	{
+		const bool writable = (std::strchr(mode, 'w') || std::strchr(mode, 'a') || std::strchr(mode, '+'));
+#if defined(__APPLE__)
+		return funopen(handle, CookieReadF, writable ? CookieWriteF : nullptr, CookieSeekF, CookieClose);
+#else
+		return funopen64(handle, CookieReadF, writable ? CookieWriteF : nullptr, CookieSeekF, CookieClose);
+#endif
+	}
+
+#endif // glibc / funopen
+
+#endif // HOSTVFS_HAVE_FILE_WRAPPER
+} // namespace
+
+std::FILE* HostVFS::OpenAsCFile(const char* path, const char* mode)
+{
+#if defined(HOSTVFS_HAVE_FILE_WRAPPER)
+	if (!s_installed)
+		return nullptr;
+
+	bool append = false;
+	const unsigned access = TranslateMode(mode, &append);
+
+	void* handle = s_ops.open(path, access, 0 /* RETRO_VFS_FILE_ACCESS_HINT_NONE */);
+	if (!handle)
+		return nullptr;
+
+	if (append && s_ops.seek)
+		s_ops.seek(handle, 0, 2 /* SEEK_END */);
+
+	std::FILE* fp = WrapHandle(handle, mode);
+	if (!fp)
+	{
+		s_ops.close(handle);
+		return nullptr;
+	}
+
+	return fp;
+#else
+	// No fopencookie and no funopen: nothing to build a std::FILE* out of, so
+	// the caller falls back to the OS.
+	return nullptr;
+#endif
+}

--- a/common/HostVFS.cpp
+++ b/common/HostVFS.cpp
@@ -5,6 +5,8 @@
 #include "common/Console.h"
 
 #include <cstring>
+#include <mutex>
+#include <vector>
 
 // The libretro VFS access flags, kept here rather than pulled from libretro.h:
 // common/ does not depend on the core.
@@ -40,20 +42,42 @@ const HostVFS::Ops* HostVFS::GetOps()
 	return s_installed ? &s_ops : nullptr;
 }
 
+namespace
+{
+	// The exact size of a file, which the host's stat() cannot give: its size
+	// argument is 32 bits wide, so a 4 GB DVD image comes back reporting a few
+	// megabytes of it. size() is the 64-bit one, and it wants an open handle.
+	s64 ExactSizeOf(const char* path)
+	{
+		if (!s_ops.size || !s_ops.open || !s_ops.close)
+			return -1;
+
+		void* handle = s_ops.open(path, VFS_ACCESS_READ, 0 /* RETRO_VFS_FILE_ACCESS_HINT_NONE */);
+		if (!handle)
+			return -1;
+
+		const s64 size = s_ops.size(handle);
+		s_ops.close(handle);
+		return (size < 0) ? -1 : size;
+	}
+} // namespace
+
 bool HostVFS::StatPath(const char* path, bool* is_directory, s64* size)
 {
 	if (!s_installed || !s_ops.stat)
 		return false;
 
-	s32 file_size = 0;
-	const int flags = s_ops.stat(path, &file_size);
+	s32 truncated_size = 0;
+	const int flags = s_ops.stat(path, &truncated_size);
 	if (!(flags & STAT_IS_VALID))
 		return false;
 
+	const bool directory = (flags & STAT_IS_DIRECTORY) != 0;
 	if (is_directory)
-		*is_directory = (flags & STAT_IS_DIRECTORY) != 0;
+		*is_directory = directory;
+	// Deliberately not truncated_size - see ExactSizeOf() above.
 	if (size)
-		*size = static_cast<s64>(file_size);
+		*size = directory ? 0 : ExactSizeOf(path);
 	return true;
 }
 
@@ -95,8 +119,36 @@ namespace
 		}
 	}
 
+	// The wrapped streams. A cookie stream has no file descriptor - fileno()
+	// on one returns -1 - so the few callers in FileSystem that would fstat()
+	// a std::FILE* have to ask the host about the handle behind it instead,
+	// and that is the only thing this maps. A handful of entries at most, and
+	// only touched on open and close.
+	std::mutex s_streams_lock;
+	std::vector<std::pair<std::FILE*, void*>> s_streams;
+
+	void RememberStream(std::FILE* fp, void* handle)
+	{
+		std::unique_lock lock(s_streams_lock);
+		s_streams.emplace_back(fp, handle);
+	}
+
+	void ForgetStream(void* handle)
+	{
+		std::unique_lock lock(s_streams_lock);
+		for (auto it = s_streams.begin(); it != s_streams.end(); ++it)
+		{
+			if (it->second == handle)
+			{
+				s_streams.erase(it);
+				return;
+			}
+		}
+	}
+
 	int CookieClose(void* cookie)
 	{
+		ForgetStream(cookie);
 		const HostVFS::Ops* ops = HostVFS::GetOps();
 		return (ops && ops->close) ? ops->close(cookie) : 0;
 	}
@@ -162,10 +214,12 @@ namespace
 		return (res < 0) ? -1 : static_cast<int>(res);
 	}
 
-#if defined(__APPLE__)
-	using FunopenOffset = fpos_t;
-#else
+	// bionic has funopen64 and 64-bit off64_t callbacks; Apple and the BSDs
+	// have only funopen, whose callbacks take fpos_t (64-bit on both).
+#if defined(__BIONIC__)
 	using FunopenOffset = off64_t;
+#else
+	using FunopenOffset = fpos_t;
 #endif
 
 	FunopenOffset CookieSeekF(void* cookie, FunopenOffset offset, int whence)
@@ -183,10 +237,10 @@ namespace
 	std::FILE* WrapHandle(void* handle, const char* mode)
 	{
 		const bool writable = (std::strchr(mode, 'w') || std::strchr(mode, 'a') || std::strchr(mode, '+'));
-#if defined(__APPLE__)
-		return funopen(handle, CookieReadF, writable ? CookieWriteF : nullptr, CookieSeekF, CookieClose);
-#else
+#if defined(__BIONIC__)
 		return funopen64(handle, CookieReadF, writable ? CookieWriteF : nullptr, CookieSeekF, CookieClose);
+#else
+		return funopen(handle, CookieReadF, writable ? CookieWriteF : nullptr, CookieSeekF, CookieClose);
 #endif
 	}
 
@@ -218,10 +272,44 @@ std::FILE* HostVFS::OpenAsCFile(const char* path, const char* mode)
 		return nullptr;
 	}
 
+	RememberStream(fp, handle);
 	return fp;
 #else
 	// No fopencookie and no funopen: nothing to build a std::FILE* out of, so
 	// the caller falls back to the OS.
 	return nullptr;
+#endif
+}
+
+bool HostVFS::SizeOfCFile(std::FILE* fp, s64* size)
+{
+#if defined(HOSTVFS_HAVE_FILE_WRAPPER)
+	if (!s_installed || !s_ops.size || !fp)
+		return false;
+
+	void* handle = nullptr;
+	{
+		std::unique_lock lock(s_streams_lock);
+		for (const auto& [stream, stream_handle] : s_streams)
+		{
+			if (stream == fp)
+			{
+				handle = stream_handle;
+				break;
+			}
+		}
+	}
+
+	if (!handle)
+		return false;
+
+	const s64 res = s_ops.size(handle);
+	if (res < 0)
+		return false;
+
+	*size = res;
+	return true;
+#else
+	return false;
 #endif
 }

--- a/common/HostVFS.h
+++ b/common/HostVFS.h
@@ -40,7 +40,8 @@ namespace HostVFS
 		int (*truncate)(void* handle, s64 length);
 
 		/// Returns a bitmask: 1 = exists, 2 = directory, 4 = character device.
-		/// size receives the file size, in bytes.
+		/// size receives the file size, in bytes - but only 32 bits of it, so
+		/// it is never read for a size. size() below is the 64-bit one.
 		int (*stat)(const char* path, s32* size);
 		int (*mkdir)(const char* dir);
 
@@ -72,8 +73,21 @@ namespace HostVFS
 	/// Opens a file through the host and wraps it in a std::FILE*, so every
 	/// existing caller keeps working unchanged. Returns nullptr if the host
 	/// cannot open it, or if this platform has no way to build such a wrapper.
+	///
+	/// The stream has no file descriptor - fileno() on it returns -1 - so the
+	/// handful of callers that need one ask SizeOfCFile() instead of fstat().
 	std::FILE* OpenAsCFile(const char* path, const char* mode);
 
+	/// The size of a stream OpenAsCFile() returned, from the host's own 64-bit
+	/// size(). False when this is not one of ours, or the host cannot say.
+	bool SizeOfCFile(std::FILE* fp, s64* size);
+
 	/// stat(), for the callers that only want the answers FileSystem asks for.
+	///
+	/// *size is the exact 64-bit size, which costs an open: the frontend's
+	/// stat() reports only 32 bits of it, and a PS2 DVD image does not fit in
+	/// those. It is set to -1 when the host cannot answer exactly, and the
+	/// caller should then ask the OS. Pass nullptr when the size is not wanted
+	/// - existence and directory-ness cost one call either way.
 	bool StatPath(const char* path, bool* is_directory, s64* size);
 } // namespace HostVFS

--- a/common/HostVFS.h
+++ b/common/HostVFS.h
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include "common/Pcsx2Defs.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+/// A file system supplied by the host application rather than by the OS.
+///
+/// The libretro core installs one of these when the frontend offers its VFS
+/// interface: on Android that is the only way to reach content the app has no
+/// path to (Storage Access Framework), and it is also what makes network
+/// shares work. The table is plain function pointers so that common/ does not
+/// have to know what libretro is - pcsx2-libretro/Main.cpp fills it in.
+///
+/// When nothing is installed every FileSystem call behaves exactly as before,
+/// which is the case for the Qt and SDL frontends.
+namespace HostVFS
+{
+	/// Mirrors the subset of the frontend's interface that FileSystem needs.
+	/// Anything the frontend does not implement is left null, and the caller
+	/// falls back to the OS - so an old frontend that offers files but not
+	/// directory iteration still works for everything but browsing.
+	struct Ops
+	{
+		void* (*open)(const char* path, unsigned mode, unsigned hints);
+		int (*close)(void* handle);
+		s64 (*size)(void* handle);
+		s64 (*tell)(void* handle);
+		s64 (*seek)(void* handle, s64 offset, int seek_position);
+		s64 (*read)(void* handle, void* buffer, u64 length);
+		s64 (*write)(void* handle, const void* buffer, u64 length);
+		int (*flush)(void* handle);
+		int (*remove)(const char* path);
+		int (*rename)(const char* old_path, const char* new_path);
+		int (*truncate)(void* handle, s64 length);
+
+		/// Returns a bitmask: 1 = exists, 2 = directory, 4 = character device.
+		/// size receives the file size, in bytes.
+		int (*stat)(const char* path, s32* size);
+		int (*mkdir)(const char* dir);
+
+		void* (*opendir)(const char* dir, bool include_hidden);
+		bool (*readdir)(void* dir_handle);
+		const char* (*dirent_get_name)(void* dir_handle);
+		bool (*dirent_is_dir)(void* dir_handle);
+		int (*closedir)(void* dir_handle);
+	};
+
+	/// The frontend's stat() bits, as libretro defines them.
+	enum : int
+	{
+		STAT_IS_VALID = (1 << 0),
+		STAT_IS_DIRECTORY = (1 << 1),
+		STAT_IS_CHARACTER_SPECIAL = (1 << 2),
+	};
+
+	/// Installs the host's file system. Call once, before anything opens a file.
+	void Install(const Ops& ops);
+
+	/// True when a host file system is in use; false means plain OS calls.
+	bool IsInstalled();
+
+	/// The installed table, or nullptr. Callers check the individual members:
+	/// a frontend may implement files but not directories.
+	const Ops* GetOps();
+
+	/// Opens a file through the host and wraps it in a std::FILE*, so every
+	/// existing caller keeps working unchanged. Returns nullptr if the host
+	/// cannot open it, or if this platform has no way to build such a wrapper.
+	std::FILE* OpenAsCFile(const char* path, const char* mode);
+
+	/// stat(), for the callers that only want the answers FileSystem asks for.
+	bool StatPath(const char* path, bool* is_directory, s64* size);
+} // namespace HostVFS

--- a/pcsx2-libretro/Main.cpp
+++ b/pcsx2-libretro/Main.cpp
@@ -52,6 +52,7 @@
 #include "common/SmallString.h"
 #include "common/StringUtil.h"
 #include "common/Threading.h"
+#include "common/HostVFS.h"
 
 #include "pcsx2/PrecompiledHeader.h"
 
@@ -1342,6 +1343,56 @@ RETRO_API unsigned retro_api_version(void)
 	return RETRO_API_VERSION;
 }
 
+// Hand the frontend's file system to common/FileSystem. Without it the core
+// can only open paths the OS understands, which on Android leaves out
+// everything reached through the Storage Access Framework (content:// URIs)
+// and everything on a network share - which is to say most of a user's games.
+//
+// Version 3 is asked for because that is where stat(), mkdir() and directory
+// iteration arrive; the frontend answers with the version it actually has, and
+// the members above it stay null, so an older frontend still gets file access
+// and simply falls back to the OS for the rest.
+static void InstallFrontendVFS(retro_environment_t cb)
+{
+	retro_vfs_interface_info info = {3, nullptr};
+	if (!cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &info) || !info.iface)
+		return;
+
+	const unsigned version = info.required_interface_version;
+	retro_vfs_interface* iface = info.iface;
+
+	HostVFS::Ops ops = {};
+	ops.open = reinterpret_cast<void* (*)(const char*, unsigned, unsigned)>(iface->open);
+	ops.close = reinterpret_cast<int (*)(void*)>(iface->close);
+	ops.size = reinterpret_cast<s64 (*)(void*)>(iface->size);
+	ops.tell = reinterpret_cast<s64 (*)(void*)>(iface->tell);
+	ops.seek = reinterpret_cast<s64 (*)(void*, s64, int)>(iface->seek);
+	ops.read = reinterpret_cast<s64 (*)(void*, void*, u64)>(iface->read);
+	ops.write = reinterpret_cast<s64 (*)(void*, const void*, u64)>(iface->write);
+	ops.flush = reinterpret_cast<int (*)(void*)>(iface->flush);
+	ops.remove = iface->remove;
+	ops.rename = iface->rename;
+
+	if (version >= 2)
+		ops.truncate = reinterpret_cast<int (*)(void*, s64)>(iface->truncate);
+
+	if (version >= 3)
+	{
+		ops.stat = iface->stat;
+		ops.mkdir = iface->mkdir;
+		ops.opendir = reinterpret_cast<void* (*)(const char*, bool)>(iface->opendir);
+		ops.readdir = reinterpret_cast<bool (*)(void*)>(iface->readdir);
+		ops.dirent_get_name = reinterpret_cast<const char* (*)(void*)>(iface->dirent_get_name);
+		ops.dirent_is_dir = reinterpret_cast<bool (*)(void*)>(iface->dirent_is_dir);
+		ops.closedir = reinterpret_cast<int (*)(void*)>(iface->closedir);
+	}
+
+	HostVFS::Install(ops);
+
+	if (log_cb)
+		log_cb(RETRO_LOG_INFO, "Using the frontend's VFS (interface version %u)\n", version);
+}
+
 RETRO_API void retro_set_environment(retro_environment_t cb)
 {
 	environ_cb = cb;
@@ -1354,6 +1405,8 @@ RETRO_API void retro_set_environment(retro_environment_t cb)
 
 	bool support_no_game = false;
 	cb(RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME, &support_no_game);
+
+	InstallFrontendVFS(cb);
 
 	PopulateBiosOptions(cb);
 

--- a/pcsx2-libretro/Main.cpp
+++ b/pcsx2-libretro/Main.cpp
@@ -61,6 +61,7 @@
 #include "pcsx2/GS.h"
 #include "pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h"
 #include "pcsx2/GS/Renderers/Vulkan/VKLibretro.h"
+#include "pcsx2/GS/Renderers/OpenGL/GLContextLibretro.h"
 #include "pcsx2/GameList.h"
 #include "pcsx2/Host.h"
 #include "pcsx2/INISettingsInterface.h"
@@ -113,6 +114,11 @@ namespace LibretroCore
 	// which opens MTGS/GSDeviceVK from the frontend thread) and (b) fired
 	// context_reset (making the retro_hw_render_interface_vulkan available).
 	static bool s_hw_render_vulkan = false;
+	// The GL alternative to it. No device negotiation to wait on here - the
+	// frontend makes a context current and fires context_reset - but the boot
+	// has to park on that reset all the same, since GSDeviceOGL cannot open
+	// before there is a context to open against.
+	static bool s_hw_render_gl = false;
 	static std::atomic<bool> s_cpu_thread_initialized{false};
 	static std::atomic<bool> s_context_ready{false};
 } // namespace LibretroCore
@@ -630,7 +636,7 @@ void LibretroCore::CPUThreadMain(VMBootParameters initial_params)
 	// With Vulkan HW render the boot has to wait for the frontend's context
 	// negotiation + context_reset; booting earlier would open MTGS before
 	// VKLibretro::Init holds the shared instance.
-	while (s_hw_render_vulkan && !s_context_ready.load(std::memory_order_acquire) &&
+	while ((s_hw_render_vulkan || s_hw_render_gl) && !s_context_ready.load(std::memory_order_acquire) &&
 			!s_shutdown_requested.load(std::memory_order_acquire))
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
@@ -841,9 +847,9 @@ static struct retro_core_option_v2_category kOptionCategories[] = {
 
 static struct retro_core_option_v2_definition kOptionDefinitions[] = {
 	{"armsx2_renderer", "GS Renderer (restart)", "GS Renderer (restart)",
-		"Vulkan renders the GS on the GPU. Software renders on the CPU and presents through the same shared Vulkan context.",
+		"Vulkan renders the GS on the GPU. OpenGL does the same through the frontend's GL context, for devices with no usable Vulkan driver. Software renders on the CPU and presents through the same shared context.",
 		nullptr, "video",
-		{{"Vulkan", nullptr}, {"Software", nullptr}, {nullptr, nullptr}}, "Vulkan"},
+		{{"Vulkan", nullptr}, {"OpenGL", nullptr}, {"Software", nullptr}, {nullptr, nullptr}}, "Vulkan"},
 	{"armsx2_upscale", "Internal Resolution", "Internal Resolution",
 		"Renders the PS2 output at a multiple of native resolution. The output canvas follows this size.",
 		nullptr, "video",
@@ -956,7 +962,7 @@ static struct retro_core_options_v2 kOptionsV2 = {kOptionCategories, kOptionDefi
 // Legacy fallback: first value doubles as the default. Non-const so the
 // BIOS entry can be pointed at the scanned list.
 static struct retro_variable kCoreVariables[] = {
-	{"armsx2_renderer", "GS renderer (restart); Vulkan|Software"},
+	{"armsx2_renderer", "GS renderer (restart); Vulkan|OpenGL|Software"},
 	{"armsx2_upscale", "Internal resolution; 1x|2x|3x|4x"},
 	{"armsx2_aspect_ratio", "Aspect ratio; Auto 4:3/3:2|4:3|16:9|Stretch"},
 	{"armsx2_deinterlacing", "Deinterlacing; Automatic|Off|Weave TFF|Weave BFF|Bob TFF|Bob BFF|Blend TFF|Blend BFF|Adaptive TFF|Adaptive BFF"},
@@ -1056,6 +1062,8 @@ static void ApplyCoreOptions(bool startup)
 			// only honour this at startup.
 			if (!std::strcmp(var.value, "Software"))
 				s_base_settings->SetIntValue("EmuCore/GS", "Renderer", static_cast<int>(GSRendererType::SW));
+			else if (!std::strcmp(var.value, "OpenGL"))
+				s_base_settings->SetIntValue("EmuCore/GS", "Renderer", static_cast<int>(GSRendererType::OGL));
 		}
 
 		var = {"armsx2_upscale", nullptr};
@@ -1313,6 +1321,37 @@ static bool CreateVulkanDevice(retro_vulkan_context* context, VkInstance instanc
 	return true;
 }
 
+// The GL half of the same story. The frontend owns the context; the core only
+// needs its two callbacks - one to resolve entry points, one to ask which FBO
+// this frame belongs in - which GLContextLibretro hands to GSDeviceOGL.
+static struct retro_hw_render_callback s_gl_hw_render = {};
+
+static void* GLGetProcAddress(const char* name)
+{
+	return s_gl_hw_render.get_proc_address ?
+			   reinterpret_cast<void*>(s_gl_hw_render.get_proc_address(name)) :
+			   nullptr;
+}
+
+static u32 GLGetCurrentFramebuffer()
+{
+	return s_gl_hw_render.get_current_framebuffer ?
+			   static_cast<u32>(s_gl_hw_render.get_current_framebuffer()) :
+			   0;
+}
+
+static void OnGLContextReset(void)
+{
+	GLContextLibretro::SetCallbacks(GLGetProcAddress, GLGetCurrentFramebuffer);
+	LibretroCore::s_context_ready.store(true, std::memory_order_release);
+}
+
+static void OnGLContextDestroy(void)
+{
+	LibretroCore::s_context_ready.store(false, std::memory_order_release);
+	GLContextLibretro::SetCallbacks(nullptr, nullptr);
+}
+
 static void OnContextReset(void)
 {
 	retro_hw_render_interface* iface = nullptr;
@@ -1537,10 +1576,56 @@ RETRO_API bool retro_load_game(const struct retro_game_info* game)
 
 	s_shutdown_requested.store(false, std::memory_order_release);
 
+	// Which hardware context to ask for. The renderer option is read into the
+	// settings above; GL takes a different path from here, since it needs no
+	// device negotiation - the frontend simply makes a context current and
+	// hands the core an FBO to draw into.
+	const bool want_gl = (s_base_settings->GetIntValue("EmuCore/GS", "Renderer",
+							  static_cast<int>(GSRendererType::VK)) == static_cast<int>(GSRendererType::OGL));
+
+	LibretroCore::s_hw_render_gl = want_gl;
+	if (want_gl)
+	{
+		s_gl_hw_render = {};
+#if defined(__ANDROID__)
+		// The only context type an Android frontend can give us.
+		s_gl_hw_render.context_type = RETRO_HW_CONTEXT_OPENGLES3;
+		s_gl_hw_render.version_major = 3;
+		s_gl_hw_render.version_minor = 2;
+#else
+		// GSDeviceOGL needs 3.3 at the very least, and uses 4.3/4.5 paths when
+		// the driver has them.
+		s_gl_hw_render.context_type = RETRO_HW_CONTEXT_OPENGL_CORE;
+		s_gl_hw_render.version_major = 3;
+		s_gl_hw_render.version_minor = 3;
+#endif
+		s_gl_hw_render.context_reset = OnGLContextReset;
+		s_gl_hw_render.context_destroy = OnGLContextDestroy;
+		s_gl_hw_render.depth = false;
+		s_gl_hw_render.bottom_left_origin = true;
+		s_gl_hw_render.cache_context = true;
+
+		// The GS runs on its own thread, so the frontend has to create the
+		// context in a way that lets a second thread use it. Without this the
+		// GL calls MTGS makes would land on a context that is current
+		// somewhere else.
+		bool shared_context = true;
+		if (!environ_cb(RETRO_ENVIRONMENT_SET_HW_SHARED_CONTEXT, &shared_context))
+			log_cb(RETRO_LOG_WARN, "Frontend has no shared GL context; the GS thread may not be able to draw.\n");
+
+		if (!environ_cb(RETRO_ENVIRONMENT_SET_HW_RENDER, &s_gl_hw_render))
+		{
+			log_cb(RETRO_LOG_ERROR, "Frontend refused a GL context; falling back to Null GS.\n");
+			LibretroCore::s_hw_render_gl = false;
+			auto lock = Host::GetSettingsLock();
+			s_base_settings->SetIntValue("EmuCore/GS", "Renderer", static_cast<int>(GSRendererType::Null));
+			VMManager::Internal::LoadStartupSettings();
+		}
+	}
 	// Vulkan HW render. The negotiation interface must be registered inside
 	// retro_load_game; the frontend invokes it while creating its Vulkan
 	// context, after this returns.
-	LibretroCore::s_hw_render_vulkan = true;
+	LibretroCore::s_hw_render_vulkan = !want_gl;
 	if (LibretroCore::s_hw_render_vulkan)
 	{
 		static struct retro_hw_render_callback hw_render = {};
@@ -1733,6 +1818,15 @@ RETRO_API void retro_run(void)
 		{
 			video_cb(nullptr, LibretroCore::kFrameWidth, LibretroCore::kFrameHeight, 0);
 		}
+	}
+	else if (LibretroCore::s_hw_render_gl)
+	{
+		// GL needs no frame handover of its own: GSDeviceOGL has already drawn
+		// into the FBO the frontend named through get_current_framebuffer, so
+		// the frame is where the frontend expects it. The canvas is the fixed
+		// surface BuildLibretroWindowInfo reports, not the aspect-expanded one
+		// the Vulkan path resizes to.
+		video_cb(RETRO_HW_FRAME_BUFFER_VALID, LibretroCore::kFrameWidth, LibretroCore::kFrameHeight, 0);
 	}
 	else
 	{

--- a/pcsx2-libretro/Main.cpp
+++ b/pcsx2-libretro/Main.cpp
@@ -1342,7 +1342,20 @@ static u32 GLGetCurrentFramebuffer()
 
 static void OnGLContextReset(void)
 {
-	GLContextLibretro::SetCallbacks(GLGetProcAddress, GLGetCurrentFramebuffer);
+	// The flavour goes with the callbacks: it is what GLContext::Create picks
+	// the desktop or the ES entry-point loader from, and what GSDeviceOGL asks
+	// before it decides which GL feature set it is allowed to use. It is the
+	// context type asked for in retro_load_game, since that is what the
+	// frontend has just made current.
+	const GLContext::Profile profile =
+		(s_gl_hw_render.context_type == RETRO_HW_CONTEXT_OPENGLES2 ||
+			s_gl_hw_render.context_type == RETRO_HW_CONTEXT_OPENGLES3 ||
+			s_gl_hw_render.context_type == RETRO_HW_CONTEXT_OPENGLES_VERSION) ?
+			GLContext::Profile::ES :
+			GLContext::Profile::Core;
+
+	GLContextLibretro::SetCallbacks(GLGetProcAddress, GLGetCurrentFramebuffer, profile,
+		static_cast<int>(s_gl_hw_render.version_major), static_cast<int>(s_gl_hw_render.version_minor));
 	LibretroCore::s_context_ready.store(true, std::memory_order_release);
 }
 
@@ -1387,49 +1400,82 @@ RETRO_API unsigned retro_api_version(void)
 // everything reached through the Storage Access Framework (content:// URIs)
 // and everything on a network share - which is to say most of a user's games.
 //
-// Version 3 is asked for because that is where stat(), mkdir() and directory
-// iteration arrive; the frontend answers with the version it actually has, and
-// the members above it stay null, so an older frontend still gets file access
-// and simply falls back to the OS for the rest.
+// The interface itself, so the trampolines below can reach it: HostVFS::Ops
+// is typed in terms of void* handles, because common/ does not get to know
+// what libretro is, and casting the frontend's function pointers to that shape
+// would be undefined - the truncate one differs in return type, not just in
+// pointer types, and the compiler says so. Small forwarders instead.
+static retro_vfs_interface* s_vfs = nullptr;
+
 static void InstallFrontendVFS(retro_environment_t cb)
 {
-	retro_vfs_interface_info info = {3, nullptr};
-	if (!cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &info) || !info.iface)
+	// Descending, because the contract is all-or-nothing: "if the core asks
+	// for a newer VFS API version than the frontend supports, the frontend
+	// must return false". Asking only for 3 - where stat(), mkdir() and the
+	// directory iterator live - would mean a pre-v3 frontend hands back
+	// nothing at all rather than the file half, and the Android storage
+	// support this exists for is exactly what runs on those.
+	unsigned version = 0;
+	for (const unsigned wanted : {3u, 2u, 1u})
+	{
+		retro_vfs_interface_info info = {wanted, nullptr};
+		if (cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &info) && info.iface)
+		{
+			// The frontend answers with what it actually has, which can be
+			// newer than what was asked for.
+			version = std::max(wanted, info.required_interface_version);
+			s_vfs = info.iface;
+			break;
+		}
+	}
+
+	if (!s_vfs)
 		return;
 
-	const unsigned version = info.required_interface_version;
-	retro_vfs_interface* iface = info.iface;
-
 	HostVFS::Ops ops = {};
-	ops.open = reinterpret_cast<void* (*)(const char*, unsigned, unsigned)>(iface->open);
-	ops.close = reinterpret_cast<int (*)(void*)>(iface->close);
-	ops.size = reinterpret_cast<s64 (*)(void*)>(iface->size);
-	ops.tell = reinterpret_cast<s64 (*)(void*)>(iface->tell);
-	ops.seek = reinterpret_cast<s64 (*)(void*, s64, int)>(iface->seek);
-	ops.read = reinterpret_cast<s64 (*)(void*, void*, u64)>(iface->read);
-	ops.write = reinterpret_cast<s64 (*)(void*, const void*, u64)>(iface->write);
-	ops.flush = reinterpret_cast<int (*)(void*)>(iface->flush);
-	ops.remove = iface->remove;
-	ops.rename = iface->rename;
+	ops.open = [](const char* path, unsigned mode, unsigned hints) -> void* {
+		return s_vfs->open(path, mode, hints);
+	};
+	ops.close = [](void* handle) { return s_vfs->close(static_cast<retro_vfs_file_handle*>(handle)); };
+	ops.size = [](void* handle) -> s64 { return s_vfs->size(static_cast<retro_vfs_file_handle*>(handle)); };
+	ops.tell = [](void* handle) -> s64 { return s_vfs->tell(static_cast<retro_vfs_file_handle*>(handle)); };
+	ops.seek = [](void* handle, s64 offset, int whence) -> s64 {
+		return s_vfs->seek(static_cast<retro_vfs_file_handle*>(handle), offset, whence);
+	};
+	ops.read = [](void* handle, void* buffer, u64 length) -> s64 {
+		return s_vfs->read(static_cast<retro_vfs_file_handle*>(handle), buffer, length);
+	};
+	ops.write = [](void* handle, const void* buffer, u64 length) -> s64 {
+		return s_vfs->write(static_cast<retro_vfs_file_handle*>(handle), buffer, length);
+	};
+	ops.remove = s_vfs->remove;
+	ops.rename = s_vfs->rename;
 
-	if (version >= 2)
-		ops.truncate = reinterpret_cast<int (*)(void*, s64)>(iface->truncate);
+	// flush() and truncate() are deliberately not wired up: nothing in the
+	// tree asks for either through this path.
 
 	if (version >= 3)
 	{
-		ops.stat = iface->stat;
-		ops.mkdir = iface->mkdir;
-		ops.opendir = reinterpret_cast<void* (*)(const char*, bool)>(iface->opendir);
-		ops.readdir = reinterpret_cast<bool (*)(void*)>(iface->readdir);
-		ops.dirent_get_name = reinterpret_cast<const char* (*)(void*)>(iface->dirent_get_name);
-		ops.dirent_is_dir = reinterpret_cast<bool (*)(void*)>(iface->dirent_is_dir);
-		ops.closedir = reinterpret_cast<int (*)(void*)>(iface->closedir);
+		ops.stat = s_vfs->stat;
+		ops.mkdir = s_vfs->mkdir;
+		ops.opendir = [](const char* dir, bool include_hidden) -> void* {
+			return s_vfs->opendir(dir, include_hidden);
+		};
+		ops.readdir = [](void* handle) { return s_vfs->readdir(static_cast<retro_vfs_dir_handle*>(handle)); };
+		ops.dirent_get_name = [](void* handle) {
+			return s_vfs->dirent_get_name(static_cast<retro_vfs_dir_handle*>(handle));
+		};
+		ops.dirent_is_dir = [](void* handle) { return s_vfs->dirent_is_dir(static_cast<retro_vfs_dir_handle*>(handle)); };
+		ops.closedir = [](void* handle) { return s_vfs->closedir(static_cast<retro_vfs_dir_handle*>(handle)); };
 	}
 
 	HostVFS::Install(ops);
 
 	if (log_cb)
-		log_cb(RETRO_LOG_INFO, "Using the frontend's VFS (interface version %u)\n", version);
+	{
+		log_cb(RETRO_LOG_INFO, "Using the frontend's VFS (interface version %u)%s\n", version,
+			(version >= 3) ? "" : " - files only, the OS answers for directories and stat()");
+	}
 }
 
 RETRO_API void retro_set_environment(retro_environment_t cb)

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -657,6 +657,13 @@ if(USE_OPENGL)
 	)
 	target_link_libraries(PCSX2_FLAGS INTERFACE glad)
 
+	if(ENABLE_LIBRETRO)
+		# The context the frontend owns; picked over the platform ones below
+		# when the core installs its callbacks.
+		list(APPEND pcsx2GSSources GS/Renderers/OpenGL/GLContextLibretro.cpp)
+		list(APPEND pcsx2GSHeaders GS/Renderers/OpenGL/GLContextLibretro.h)
+	endif()
+
 	if(WIN32)
 		list(APPEND pcsx2GSSources GS/Renderers/OpenGL/GLContextWGL.cpp)
 		list(APPEND pcsx2GSHeaders GS/Renderers/OpenGL/GLContextWGL.h)

--- a/pcsx2/GS/Renderers/OpenGL/GLContext.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GLContext.cpp
@@ -22,6 +22,10 @@
 
 #include "glad/gl.h"
 
+#if defined(ENABLE_LIBRETRO)
+#include "GS/Renderers/OpenGL/GLContextLibretro.h"
+#endif
+
 static bool ShouldPreferESContext()
 {
 	const char* value = std::getenv("PREFER_GLES_CONTEXT");
@@ -74,15 +78,24 @@ std::unique_ptr<GLContext> GLContext::Create(const WindowInfo& wi, Error* error)
 	}
 
 	std::unique_ptr<GLContext> context;
+	// A frontend-owned context wins over anything we could open ourselves, so
+	// it is asked first: in a libretro core there is no window for any of the
+	// platform contexts below to attach to in the first place.
+#if defined(ENABLE_LIBRETRO)
+	if (GLContextLibretro::IsAvailable())
+		context = GLContextLibretro::Create(wi, error);
+#endif
+
 #ifdef __ANDROID__
-	if (wi.type == WindowInfo::Type::Android)
+	if (!context && wi.type == WindowInfo::Type::Android)
 		context = GLContextEGLAndroid::Create(wi, versions_to_try, num_versions_to_try);
 #endif
 #if defined(_WIN32)
-	context = GLContextWGL::Create(wi, std::span<const Version>(versions_to_try, num_versions_to_try), error);
+	if (!context)
+		context = GLContextWGL::Create(wi, std::span<const Version>(versions_to_try, num_versions_to_try), error);
 #else
 #ifdef X11_API
-	if (wi.type == WindowInfo::Type::X11)
+	if (!context && wi.type == WindowInfo::Type::X11)
 		context = GLContextEGLX11::Create(wi, std::span<const Version>(versions_to_try, num_versions_to_try), error);
 #endif
 #ifdef WAYLAND_API

--- a/pcsx2/GS/Renderers/OpenGL/GLContext.h
+++ b/pcsx2/GS/Renderers/OpenGL/GLContext.h
@@ -48,6 +48,11 @@ public:
 	virtual bool SetSwapInterval(s32 interval) = 0;
 	virtual std::unique_ptr<GLContext> CreateSharedContext(const WindowInfo& wi, Error* error) = 0;
 
+	/// The framebuffer a finished frame belongs in. Zero - the window's own -
+	/// for every context that owns its surface; a libretro frontend hands the
+	/// core an FBO of its own instead.
+	virtual u32 GetDefaultFramebuffer() const { return 0; }
+
 	static std::unique_ptr<GLContext> Create(const WindowInfo& wi, Error* error);
 
 protected:

--- a/pcsx2/GS/Renderers/OpenGL/GLContextLibretro.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GLContextLibretro.cpp
@@ -9,19 +9,25 @@ namespace
 {
 	GLContextLibretro::GetProcAddressCallback s_get_proc_address = nullptr;
 	GLContextLibretro::GetFramebufferCallback s_get_framebuffer = nullptr;
+	GLContext::Version s_version = {};
 } // namespace
 
 GLContextLibretro::GLContextLibretro(const WindowInfo& wi)
 	: GLContext(wi)
 {
+	// Nothing is negotiated here - the context already exists, and this is the
+	// flavour the core asked the frontend for.
+	m_version = s_version;
 }
 
 GLContextLibretro::~GLContextLibretro() = default;
 
-void GLContextLibretro::SetCallbacks(GetProcAddressCallback get_proc_address, GetFramebufferCallback get_framebuffer)
+void GLContextLibretro::SetCallbacks(GetProcAddressCallback get_proc_address, GetFramebufferCallback get_framebuffer,
+	Profile profile, int major_version, int minor_version)
 {
 	s_get_proc_address = get_proc_address;
 	s_get_framebuffer = get_framebuffer;
+	s_version = {profile, major_version, minor_version};
 }
 
 bool GLContextLibretro::IsAvailable()

--- a/pcsx2/GS/Renderers/OpenGL/GLContextLibretro.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GLContextLibretro.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "GS/Renderers/OpenGL/GLContextLibretro.h"
+
+#include "common/Error.h"
+
+namespace
+{
+	GLContextLibretro::GetProcAddressCallback s_get_proc_address = nullptr;
+	GLContextLibretro::GetFramebufferCallback s_get_framebuffer = nullptr;
+} // namespace
+
+GLContextLibretro::GLContextLibretro(const WindowInfo& wi)
+	: GLContext(wi)
+{
+}
+
+GLContextLibretro::~GLContextLibretro() = default;
+
+void GLContextLibretro::SetCallbacks(GetProcAddressCallback get_proc_address, GetFramebufferCallback get_framebuffer)
+{
+	s_get_proc_address = get_proc_address;
+	s_get_framebuffer = get_framebuffer;
+}
+
+bool GLContextLibretro::IsAvailable()
+{
+	return (s_get_proc_address != nullptr);
+}
+
+std::unique_ptr<GLContext> GLContextLibretro::Create(const WindowInfo& wi, Error* error)
+{
+	if (!IsAvailable())
+	{
+		Error::SetStringView(error, "No libretro GL context is installed.");
+		return nullptr;
+	}
+
+	return std::unique_ptr<GLContext>(new GLContextLibretro(wi));
+}
+
+void* GLContextLibretro::GetProcAddress(const char* name)
+{
+	return s_get_proc_address ? s_get_proc_address(name) : nullptr;
+}
+
+bool GLContextLibretro::ChangeSurface(const WindowInfo& new_wi)
+{
+	m_wi = new_wi;
+	return true;
+}
+
+void GLContextLibretro::ResizeSurface(u32 new_surface_width, u32 new_surface_height)
+{
+	m_wi.surface_width = new_surface_width;
+	m_wi.surface_height = new_surface_height;
+}
+
+bool GLContextLibretro::SwapBuffers()
+{
+	// The frontend presents the framebuffer we drew into; there is nothing to
+	// swap from here.
+	return true;
+}
+
+bool GLContextLibretro::IsCurrent()
+{
+	// The frontend guarantees its context is current while the core runs.
+	return true;
+}
+
+bool GLContextLibretro::MakeCurrent()
+{
+	return true;
+}
+
+bool GLContextLibretro::DoneCurrent()
+{
+	return true;
+}
+
+bool GLContextLibretro::SupportsNegativeSwapInterval() const
+{
+	return false;
+}
+
+bool GLContextLibretro::SetSwapInterval(s32 interval)
+{
+	// Frame pacing is the frontend's job.
+	return false;
+}
+
+std::unique_ptr<GLContext> GLContextLibretro::CreateSharedContext(const WindowInfo& wi, Error* error)
+{
+	Error::SetStringView(error, "Shared contexts are not available through libretro.");
+	return nullptr;
+}
+
+u32 GLContextLibretro::GetDefaultFramebuffer() const
+{
+	// Asked for every frame rather than cached: the frontend is free to hand
+	// back a different FBO each time, and does when it recreates its target.
+	return s_get_framebuffer ? s_get_framebuffer() : 0;
+}

--- a/pcsx2/GS/Renderers/OpenGL/GLContextLibretro.h
+++ b/pcsx2/GS/Renderers/OpenGL/GLContextLibretro.h
@@ -21,10 +21,19 @@ public:
 
 	~GLContextLibretro() override;
 
-	/// Installs the frontend's callbacks. Called from context_reset, before
-	/// anything asks for a device. Passing nullptrs uninstalls them again,
-	/// which is what context_destroy does.
-	static void SetCallbacks(GetProcAddressCallback get_proc_address, GetFramebufferCallback get_framebuffer);
+	/// Installs the frontend's callbacks, and the flavour of the context it
+	/// made current. Called from context_reset, before anything asks for a
+	/// device. Passing nullptrs uninstalls them again, which is what
+	/// context_destroy does.
+	///
+	/// The version matters as much as the callbacks do: GLContext::Create
+	/// picks the desktop or the ES loader from IsGLES(), and GSDeviceOGL takes
+	/// its whole feature check from it. Left at NoProfile, a core that has
+	/// just asked the frontend for GLES 3.2 would be treated as desktop GL and
+	/// would fail somewhere in shader compilation instead of saying that the
+	/// device is unsupported.
+	static void SetCallbacks(GetProcAddressCallback get_proc_address, GetFramebufferCallback get_framebuffer,
+		Profile profile = Profile::NoProfile, int major_version = 0, int minor_version = 0);
 
 	/// True when a frontend context is available, i.e. when GLContext::Create
 	/// should hand out one of these instead of opening its own.

--- a/pcsx2/GS/Renderers/OpenGL/GLContextLibretro.h
+++ b/pcsx2/GS/Renderers/OpenGL/GLContextLibretro.h
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include "GS/Renderers/OpenGL/GLContext.h"
+
+/// The GL context a libretro frontend already owns.
+///
+/// Nothing is created or destroyed here: RetroArch makes a context current on
+/// its video thread and hands the core two callbacks - one to resolve GL
+/// entry points, one to ask which framebuffer the frame should be drawn into,
+/// since a libretro core renders into the frontend's FBO rather than into the
+/// window's default framebuffer. Everything else (swap interval, buffer swap,
+/// shared contexts) belongs to the frontend and is a no-op here.
+class GLContextLibretro final : public GLContext
+{
+public:
+	using GetProcAddressCallback = void* (*)(const char* name);
+	using GetFramebufferCallback = u32 (*)();
+
+	~GLContextLibretro() override;
+
+	/// Installs the frontend's callbacks. Called from context_reset, before
+	/// anything asks for a device. Passing nullptrs uninstalls them again,
+	/// which is what context_destroy does.
+	static void SetCallbacks(GetProcAddressCallback get_proc_address, GetFramebufferCallback get_framebuffer);
+
+	/// True when a frontend context is available, i.e. when GLContext::Create
+	/// should hand out one of these instead of opening its own.
+	static bool IsAvailable();
+
+	static std::unique_ptr<GLContext> Create(const WindowInfo& wi, Error* error);
+
+	void* GetProcAddress(const char* name) override;
+	bool ChangeSurface(const WindowInfo& new_wi) override;
+	void ResizeSurface(u32 new_surface_width = 0, u32 new_surface_height = 0) override;
+	bool SwapBuffers() override;
+	bool IsCurrent() override;
+	bool MakeCurrent() override;
+	bool DoneCurrent() override;
+	bool SupportsNegativeSwapInterval() const override;
+	bool SetSwapInterval(s32 interval) override;
+	std::unique_ptr<GLContext> CreateSharedContext(const WindowInfo& wi, Error* error) override;
+
+	u32 GetDefaultFramebuffer() const override;
+
+private:
+	explicit GLContextLibretro(const WindowInfo& wi);
+};

--- a/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/pcsx2/GS/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -1522,7 +1522,9 @@ GSDevice::PresentResult GSDeviceOGL::DoBeginPresent(bool frame_skip)
 	if (m_gpu_pipeline_statistics_enabled)
 		PopPipelineStatisticsQuery();
 
-	OMSetFBO(0);
+	// Not necessarily zero: a libretro frontend hands the core its own FBO to
+	// draw the finished frame into.
+	OMSetFBO(m_gl_context->GetDefaultFramebuffer());
 	OMSetColorMaskState();
 
 	// On TBDR, hint that the default framebuffer's prior content is throwaway
@@ -3447,7 +3449,7 @@ void GSDeviceOGL::RenderImGui()
 
 void GSDeviceOGL::RenderBlankFrame()
 {
-	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_gl_context->GetDefaultFramebuffer());
 	glDisable(GL_SCISSOR_TEST);
 	if (m_is_gles) // GLES/TBDR-only tile-bandwidth hint; inert on desktop, gated to keep it canonical
 	{


### PR DESCRIPTION
Moved here from [yaps2/yaps2#15](https://github.com/yaps2/yaps2/pull/15), rebased onto `master` and closed there. Two libretro features that this fork has no equivalent of: the frontend's file system, and an OpenGL path for the core. Independent of #635 — nothing here touches the buildbot or the CMake platform modules.

Same rule as the other one: where this tree already answers a question, its answer is kept and mine is dropped.

### The frontend's VFS

The core can only open paths the OS understands, which on Android leaves out everything behind the Storage Access Framework — a `content://` URI has no path `fopen()` can take — and everything on a network share.

* `common/HostVFS` is a plain function table that `pcsx2-libretro/Main.cpp` fills from `RETRO_ENVIRONMENT_GET_VFS_INTERFACE`. `common/` does not include `libretro.h`; with nothing installed — Qt, SDL, the APK — every call behaves as before.
* `FileSystem` routes through it: `OpenCFile`, `StatFile`, `FileExists`, `DirectoryExists`, `CreateDirectoryPath`, `DeleteFilePath`, `RenamePath` and `FindFiles`, the last with its own directory walk over the frontend's iterator.
* Callers keep taking a `std::FILE*`: the host handle is wrapped in one — `fopencookie` on glibc, `funopen64` on bionic and the BSDs, `funopen` on macOS.
* Asked for at interface version 3, where `stat`, `mkdir` and directory iteration live. A frontend with less answers with its own version and leaves those members null, and each call site falls back to the OS.

**Your `content://` handling is untouched.** `OpenFDFileContent` and the `CreateDirectoryViaJava` fallback are the right answer for the APK and they stay exactly where they were; the host's file system is simply asked first, which is a no-op for a build that installs none. In the core it has to be first — there is no Activity for the JNI bridge to reach through.

One detail worth flagging for review: **RetroArch's `seek()` returns 0 on success, not the resulting position**, so the wrapper reads the position back with `tell()`. Returning what `seek()` gave would tell stdio that every seek landed at the start of the file.

I also fixed a bug of my own on the way across: in the yaps2 version the `FindFiles` branch had landed in the `#ifdef _WIN32` copy of that function rather than the POSIX one, where `RecursiveFindFilesVFS` lives. Dead code on Linux and Android, and a link error on Windows. It is in the right copy here.

### The OpenGL path

The core only ever asks for Vulkan, so a device with no usable Vulkan driver has nothing but the software renderer.

* `armsx2_renderer` gains an **OpenGL** value; the core then asks for GL core 3.3 (GLES 3.2 on Android) instead of a Vulkan context.
* `GLContextLibretro` owns nothing — the frontend has already made a context current, and buffer swaps, swap interval and shared contexts are its business. `GLContext::Create` hands one out ahead of the platform contexts (Android EGL included), since a core has no window for those.
* `GLContext::GetDefaultFramebuffer()`, because a core draws into an FBO the frontend names. Zero everywhere else; `BeginPresent` and `RenderBlankFrame` go through it.
* `RETRO_ENVIRONMENT_SET_HW_SHARED_CONTEXT` is requested as well: the GS runs on its own thread, and its GL calls would otherwise land on a context current on the frontend's thread.

It joins your M2 Vulkan machinery rather than sitting beside it, which is the part that is new relative to the yaps2 version: `s_hw_render_gl` is the counterpart of `s_hw_render_vulkan`, the CPU thread parks the initial boot on `context_reset` for either of them (GSDeviceOGL cannot open before there is a context to open against), and `retro_run` gets a third present branch. That branch hands over nothing — the frame is already in the frontend's FBO — so it is a bare `RETRO_HW_FRAME_BUFFER_VALID` at the fixed canvas `BuildLibretroWindowInfo` reports, with none of the geometry tracking the Vulkan path needs.

This is the plumbing, **not a GLES port** — `GSDeviceOGL` is written against desktop GL. A GLES-only device would additionally want ES shader variants, `EXT_shader_framebuffer_fetch` in place of `glTextureBarrier`, clip-control conversion moved into the shaders, and `EXT_buffer_storage`.

### What is verified, and what is not

The yaps2 versions built on GitHub runners for linux-aarch64 and macOS arm64 — libretro core, Qt and SDL targets — so the `common/` changes are neutral for the other frontends. **On this tree neither half has been built yet**, and the GL half in particular is materially different here because of the M2 integration above. Neither is device-tested: I have no Android device with SAF content to hand, and no GLES-only device at all.

So take the VFS half as ready to review and the GL half as a proposal. If you would rather have them separately, say so and I will split the GL commit off into its own PR.
