### PR TITLE
iOS: fix the build the video capture removal left broken

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -159,8 +159,6 @@ jobs:
   ios:
     name: iOS (arm64, unsigned device IPA)
     runs-on: macos-26
-    # Non-blocking until the collapsed-core iOS build first goes green.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v7
         with:
@@ -246,8 +244,8 @@ jobs:
 
   # ---- Alert on a broken master build ------------------------------------
   # Fires only when a BLOCKING guardrail job (the PC arm64 builds) fails on a
-  # push to master -- never on PRs, and never on the non-blocking mobile jobs
-  # (they are continue-on-error, so they can't trip `failure()`). GitHub also
+  # push to master -- never on PRs, and never on the mobile jobs, which the
+  # `needs` below does not name and so cannot trip `failure()`. GitHub also
   # emails the pusher natively; this adds a Discord ping to the shared channel.
   notify-failure:
     name: Notify on master build failure

--- a/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
+++ b/platforms/ios/app/src/main/cpp/ARMSX2Bridge.mm
@@ -3990,7 +3990,6 @@ static void ARMSX2RollBackShaderPack(NSArray<NSURL*>* files, NSArray<NSURL*>* di
         EmuConfig.GS.OsdShowIndicators = indicators;
         EmuConfig.GS.OsdShowSettings = settings;
         EmuConfig.GS.OsdShowInputs = inputs;
-        EmuConfig.GS.OsdShowVideoCapture = false;
         EmuConfig.GS.OsdShowInputRec = false;
     });
 }

--- a/platforms/ios/app/src/main/cpp/ios_main.mm
+++ b/platforms/ios/app/src/main/cpp/ios_main.mm
@@ -868,7 +868,6 @@ void ARMSX2SetIOSOsdFlags(bool show_fps, bool show_vps, bool show_speed, bool sh
     EmuConfig.GS.OsdShowFrameTimes = show_frame_times;
     EmuConfig.GS.OsdShowVersion = show_version;
     EmuConfig.GS.OsdShowHardwareInfo = show_hardware_info;
-    EmuConfig.GS.OsdShowVideoCapture = false;
     EmuConfig.GS.OsdShowInputRec = false;
 }
 
@@ -890,7 +889,6 @@ void ARMSX2WriteIOSOsdFlagsToSettings()
     s_settings_interface->SetBoolValue("EmuCore/GS", "OsdShowFrameTimes", EmuConfig.GS.OsdShowFrameTimes);
     s_settings_interface->SetBoolValue("EmuCore/GS", "OsdShowVersion", EmuConfig.GS.OsdShowVersion);
     s_settings_interface->SetBoolValue("EmuCore/GS", "OsdShowHardwareInfo", EmuConfig.GS.OsdShowHardwareInfo);
-    s_settings_interface->SetBoolValue("EmuCore/GS", "OsdShowVideoCapture", false);
     s_settings_interface->SetBoolValue("EmuCore/GS", "OsdShowInputRec", false);
 }
 

--- a/platforms/ios/app/src/main/swift/Views/LicenseView.swift
+++ b/platforms/ios/app/src/main/swift/Views/LicenseView.swift
@@ -16,7 +16,6 @@ private let licenses: [LicenseEntry] = [
     LicenseEntry(name: "ARMSX2", license: "GPL v3", copyright: "Android port"),
     LicenseEntry(name: "SDL3", license: "zlib License", copyright: "© Sam Lantinga"),
     LicenseEntry(name: "VIXL", license: "BSD 3-Clause", copyright: "© ARM Ltd."),
-    LicenseEntry(name: "FFmpeg", license: "LGPL v2.1 / GPL v2", copyright: "© FFmpeg contributors"),
     LicenseEntry(name: "fmt", license: "MIT", copyright: "© Victor Zverovich"),
     LicenseEntry(name: "zlib", license: "zlib License", copyright: "© Jean-loup Gailly, Mark Adler"),
     LicenseEntry(name: "zstd", license: "BSD", copyright: "© Meta Platforms, Inc."),


### PR DESCRIPTION
* Fixes the iOS build, which has failed since d04052c442 removed video capture and the ffmpeg dependency with it
* That commit deleted the OsdShowVideoCapture bitfield from Pcsx2Config::GSOptions but left two assignments to it in the iOS tree, at ios_main.mm:871 and ARMSX2Bridge.mm:3993
* CI never reached ARMSX2Bridge.mm, since the target stops at the first failing translation unit, so fixing only the line the log names would have moved the error one file along
* Also drops a SetBoolValue on the same key at ios_main.mm:893, which still compiled but wrote a dead EmuCore/GS entry into the INI
* Every identifier that commit removed was grepped across platforms/ios, and these three lines are the only references left
* Verified with a real iphoneos build on Xcode 26.6 and the iPhoneOS 26.5 SDK, where both files compile, the target links, and nm on the result finds no avcodec, avformat or swscale symbols
* Turns the iOS job into a real gate by removing the flag that let it fail quietly, which is how run 33464488254 reported success with the leg red
* Corrects the comment on the failure notifier, which credited that flag for keeping the mobile jobs out of the Discord ping when the needs list is what actually does it
* Leaves the Android job alone, since that is a second gate on a second platform and belongs in its own change
* Removes the FFmpeg row from the iOS license screen, because the binary no longer contains any part of it
