### PR TITLE
VU div unit: gate the console ceiling on the clamp mode

### DIFF
--- a/pcsx2/arm64/iCOP2-arm64.cpp
+++ b/pcsx2/arm64/iCOP2-arm64.cpp
@@ -2961,12 +2961,20 @@ void recCOP2_VDIV()
 	{
 		armAsm->Ldr(a64::w1, armVU0Mem(&VU0.VF[_Fs_cop2].UL[fsf]));
 
-		// Q saturates at the EE's largest single, 0x7FFFFFFF, signed by the xor
-		// of the operands (FPU.cpp's checkDivideByZero). Written before the flag
-		// temps below claim w1 and w2.
+		// The console word goes out only where the FMAC models it (mVU_DIV's
+		// zero path). Written before the flag temps claim w1 and w2; RWSCRATCH
+		// is free until the statusflag load past the Csel.
 		armAsm->Eor(a64::w3, a64::w1, a64::w2);
 		armAsm->And(a64::w3, a64::w3, 0x80000000);
-		armAsm->Orr(a64::w3, a64::w3, 0x7FFFFFFF);
+		if (cop2ExactDivUnit())
+		{
+			armAsm->Orr(a64::w3, a64::w3, 0x7FFFFFFF);
+		}
+		else
+		{
+			armAsm->Mov(RWSCRATCH, 0x7F7FFFFFu);
+			armAsm->Orr(a64::w3, a64::w3, RWSCRATCH);
+		}
 		armAsm->Str(a64::w3, armVU0Mem(&VU0.q));
 
 		// 0/0 is invalid (D flag = 0x10), else divide-by-zero (I flag = 0x20).
@@ -3119,7 +3127,16 @@ void recCOP2_VRSQRT()
 	{
 		armAsm->Ldr(a64::w1, armVU0Mem(&VU0.VF[_Fs_cop2].UL[fsf]));
 		armAsm->And(a64::w2, a64::w1, 0x80000000);
-		armAsm->Orr(a64::w2, a64::w2, 0x7FFFFFFF);
+		// w3, not RWSCRATCH: the status word is live across this.
+		if (cop2ExactDivUnit())
+		{
+			armAsm->Orr(a64::w2, a64::w2, 0x7FFFFFFF);
+		}
+		else
+		{
+			armAsm->Mov(a64::w3, 0x7F7FFFFFu);
+			armAsm->Orr(a64::w2, a64::w2, a64::w3);
+		}
 
 		armAsm->Tst(a64::w1, kEeExpMask);
 		armAsm->Mov(a64::w1, 0x10);

--- a/pcsx2/arm64/microVU-arm64.h
+++ b/pcsx2/arm64/microVU-arm64.h
@@ -115,7 +115,9 @@
 //       changes shape too), ADD and SUB mask their operands through the guard
 //       mask, and the divide unit and all thirteen EFU ops become out-of-line
 //       model calls.
-static constexpr u32 kMvuCompilerAbiVersion = 19;
+//  20 — the zero-divisor Q is 0x7FFFFFFF from vuClampMode 3 and maxvals below,
+//       so DIV and RSQRT carry the signbit/maxvals pair again at modes 0-2.
+static constexpr u32 kMvuCompilerAbiVersion = 20;
 
 // Hash/equality functors for XXH128_hash_t — let std::unordered_map<XXH128_hash_t, …>
 // work without a wrapping struct. low64 already carries the well-mixed half of

--- a/pcsx2/arm64/microVU_Lower-arm64.inl
+++ b/pcsx2/arm64/microVU_Lower-arm64.inl
@@ -47,6 +47,11 @@ mVUop(mVU_DIV)
 		// part of the model a host divide does reproduce.
 		const bool exact = CHECK_VU_EXACT(mVU.index);
 		const bool flush = !exact && mVUneedsSoftwareFlush(mVU);
+		// 0x7FFFFFFF is a NaN to a host Fmul. mVUclamp3 bounds every FMAC
+		// operand from vuClampMode 2, but sign-preservingly only from 3, where
+		// mVUclamp2's integer min replaces mVUclamp1's Fminnm -- so that is
+		// where the console word becomes a number the FMAC can read.
+		const bool consoleQ = CHECK_VU_SIGN_OVERFLOW(mVU.index);
 
 		// Test if Ft is zero (a NaN's exponent is 255, so it takes the not-zero
 		// branch as the Fcmp this replaces did).
@@ -73,12 +78,18 @@ mVUop(mVU_DIV)
 		mVUstrField(mVU, gprT1, &mVU.divFlag);
 
 		armAsm->Bind(&afterDivFlag);
-		// Q saturates at the EE's largest single, 0x7FFFFFFF, signed by the xor
-		// of the operands. mVUglob.maxvals is a binade below that and cannot be
-		// retargeted: mVUclamp1 and mVU_SQRT feed it to Fminnm, where 0x7FFFFFFF
-		// is a NaN.
+		// Q = sign(Fs) xor sign(Ft), magnitude the ceiling the FMAC can read.
 		armAsm->Eor(Fs.V16B(), Fs.V16B(), Ft.V16B());
-		armAsm->Mvni(t1.V4S(), 0x80, a64::LSL, 24);
+		if (consoleQ)
+		{
+			armAsm->Mvni(t1.V4S(), 0x80, a64::LSL, 24);
+		}
+		else
+		{
+			armAsm->Ldr(t1, mVUglobMem(&mVUglob.signbit[0]));
+			armAsm->And(Fs.V16B(), Fs.V16B(), t1.V16B());
+			armAsm->Ldr(t1, mVUglobMem(&mVUglob.maxvals[0]));
+		}
 		armAsm->Orr(Fs.V16B(), Fs.V16B(), t1.V16B());
 		a64::Label skipNormalDiv;
 		armAsm->B(&skipNormalDiv);
@@ -247,6 +258,7 @@ mVUop(mVU_RSQRT)
 		// so a denormal radicand is a zero divisor where a host Fsqrt's is not.
 		const bool exact = CHECK_VU_EXACT(mVU.index);
 		const bool flush = !exact && mVUneedsSoftwareFlush(mVU);
+		const bool consoleQ = CHECK_VU_SIGN_OVERFLOW(mVU.index);
 		armAsm->Umov(gprT2.W(), Ft.V4S(), 0);
 		if (!exact)
 			armAsm->Fsqrt(sFt, sFt);
@@ -276,9 +288,17 @@ mVUop(mVU_RSQRT)
 		mVUldrField(mVU, gprT1, &mVU.divFlag);
 		armAsm->Orr(gprT1.W(), gprT1.W(), gprT2.W());
 		mVUstrField(mVU, gprT1, &mVU.divFlag);
-		// Q keeps the dividend's sign and saturates at 0x7FFFFFFF; mVU_DIV's zero
-		// path says why that word is built rather than loaded.
-		armAsm->Mvni(t1.V4S(), 0x80, a64::LSL, 24);
+		// Q = sign(Fs) | ceiling; mVU_DIV's zero path has the mode.
+		if (consoleQ)
+		{
+			armAsm->Mvni(t1.V4S(), 0x80, a64::LSL, 24);
+		}
+		else
+		{
+			armAsm->Ldr(t1, mVUglobMem(&mVUglob.signbit[0]));
+			armAsm->And(Fs.V16B(), Fs.V16B(), t1.V16B());
+			armAsm->Ldr(t1, mVUglobMem(&mVUglob.maxvals[0]));
+		}
 		armAsm->Orr(Fs.V16B(), Fs.V16B(), t1.V16B());
 		armAsm->B(&rsqrtDone);
 

--- a/tests/ctest/core/recompilers/CMakeLists.txt
+++ b/tests/ctest/core/recompilers/CMakeLists.txt
@@ -94,6 +94,7 @@ add_pcsx2_test(recompiler_tests
 	vu_broadcast_lane_tests.cpp
 	vu_minmax_order_tests.cpp
 	vu_pq_boundary_tests.cpp
+	vu_saturated_q_consumer_tests.cpp
 	vu_branch_terminator_tests.cpp
 	vu_overflow_hack_tests.cpp
 	vu_mac_flag_pack_tests.cpp

--- a/tests/ctest/core/recompilers/mvu_abi_digest_tests.cpp
+++ b/tests/ctest/core/recompilers/mvu_abi_digest_tests.cpp
@@ -266,6 +266,10 @@ constexpr AbiPin kPins[] = {
 	// whose polynomials keep the plain multiply at either mode. Once 19 ships,
 	// a mode-4 change needs its own bump like any other.
 	{19, {0xea70f53db2854bca, 0x9157dafe405a3a55, 0xb13784e6118693ae, 0xcedb19689232b21c, 0x65186fa7d80a9143, 0x6f61eab8d8b08e06, 0x75d083cba14f4075, 0x7cfc9e2b6a3e852d, 0xde92be2516a10fbb, 0x1270eee2b9725c68, 0x3e1c524e13373c98, 0x00410ea5fd07a5f9, 0xa2465092b0e3404a, 0x04899f265502aa58, 0x6b119d8d1e4fd199, 0x97c76bda811bc8e4, 0xd933afa738820832, 0xa7ad93456cba5eb2}},
+	// abi 20: the zero-divisor Q is 0x7FFFFFFF from vuClampMode 3. Only divUnit
+	// moves -- the default-mode probe; signClampDivUnit and exactDivUnit keep
+	// abi 19's values.
+	{20, {0xea70f53db2854bca, 0x9157dafe405a3a55, 0xb13784e6118693ae, 0xcedb19689232b21c, 0x65186fa7d80a9143, 0x6f61eab8d8b08e06, 0x75d083cba14f4075, 0x01dc53e64a60783b, 0xde92be2516a10fbb, 0x1270eee2b9725c68, 0x3e1c524e13373c98, 0x00410ea5fd07a5f9, 0xa2465092b0e3404a, 0x04899f265502aa58, 0x6b119d8d1e4fd199, 0x97c76bda811bc8e4, 0xd933afa738820832, 0xa7ad93456cba5eb2}},
 };
 
 u64 CompileAndDigest(std::initializer_list<vu::VuOp> pairs,

--- a/tests/ctest/core/recompilers/mvu_progcache_versioning_tests.cpp
+++ b/tests/ctest/core/recompilers/mvu_progcache_versioning_tests.cpp
@@ -59,7 +59,7 @@
 // round-trip tests.
 namespace pcsx2_test
 {
-	static constexpr u32 kMvuCompilerAbiVersionMirror = 19;
+	static constexpr u32 kMvuCompilerAbiVersionMirror = 20;
 }
 
 namespace

--- a/tests/ctest/core/recompilers/vu0_q_pipeline_tests.cpp
+++ b/tests/ctest/core/recompilers/vu0_q_pipeline_tests.cpp
@@ -44,11 +44,13 @@ inline VuOp Pair(u32 lower, u32 upper) { return VuOp{lower, upper}; }
 // VWAITQ + upper-NOP — the canonical "drain Q-pipe" pair.
 inline VuOp WaitQPair() { return VuOp{VWAITQ_L(), VNOP_U()}; }
 
-// The console's saturated quotient, which every engine here returns. A
-// quotient reached by dividing rather than by taking the zero-divisor branch
-// still saturates a binade lower; VuDivUnitConsole scores that in full.
-constexpr u32 kQPlusMax  = 0x7FFFFFFFu;
-constexpr u32 kQMinusMax = 0xFFFFFFFFu;
+// What the recompilers return for a saturated quotient below vuClampMode 3,
+// which is where this harness runs. The console's is 0x7FFFFFFF, which is what
+// the interpreter returns; VuDivUnitConsole scores the gap across the modes.
+constexpr u32 kQPlusJitMax  = 0x7F7FFFFFu;
+constexpr u32 kQMinusJitMax = 0xFF7FFFFFu;
+constexpr const char* kWhyQCeiling =
+	"Q: the recompiler's saturation ceiling is FLT_MAX, the interpreter's is 0x7FFFFFFF";
 
 } // namespace
 
@@ -100,9 +102,9 @@ TEST(Vu0Qpipe, VdivByZeroSetsBit20AndMaxFloatQ)
 		WaitQPair(),
 		EBitNopPair(),
 	});
-	h.Run();
-	EXPECT_EQ(h.GetViJit(REG_Q), kQPlusMax);
-	EXPECT_EQ(h.GetViInterp(REG_Q), kQPlusMax);
+	h.RunRequiringDivergence(kWhyQCeiling);
+	EXPECT_EQ(h.GetViJit(REG_Q), kQPlusJitMax);
+	EXPECT_EQ(h.GetViInterp(REG_Q), 0x7FFFFFFFu);
 	// Status bit 0x20 = D-flag (div-by-zero). Asserted via interp (the JIT
 	// loses the divFlag on short programs — see file header).
 	EXPECT_NE(h.GetViInterp(REG_STATUS_FLAG) & 0x20, 0u) << "div-by-zero D bit missing in interp status";
@@ -119,9 +121,9 @@ TEST(Vu0Qpipe, VdivByZeroNegativeNumeratorSignsMagicQ)
 		WaitQPair(),
 		EBitNopPair(),
 	});
-	h.Run();
-	EXPECT_EQ(h.GetViJit(REG_Q), kQMinusMax);
-	EXPECT_EQ(h.GetViInterp(REG_Q), kQMinusMax);
+	h.RunRequiringDivergence(kWhyQCeiling);
+	EXPECT_EQ(h.GetViJit(REG_Q), kQMinusJitMax);
+	EXPECT_EQ(h.GetViInterp(REG_Q), 0xFFFFFFFFu);
 }
 
 TEST(Vu0Qpipe, VdivZeroOverZeroSetsBit10InvalidOp)
@@ -137,9 +139,9 @@ TEST(Vu0Qpipe, VdivZeroOverZeroSetsBit10InvalidOp)
 		WaitQPair(),
 		EBitNopPair(),
 	});
-	h.Run();
-	EXPECT_EQ(h.GetViJit(REG_Q), kQPlusMax);
-	EXPECT_EQ(h.GetViInterp(REG_Q), kQPlusMax);
+	h.RunRequiringDivergence(kWhyQCeiling);
+	EXPECT_EQ(h.GetViJit(REG_Q), kQPlusJitMax);
+	EXPECT_EQ(h.GetViInterp(REG_Q), 0x7FFFFFFFu);
 	EXPECT_NE(h.GetViInterp(REG_STATUS_FLAG) & 0x10, 0u);
 }
 
@@ -167,7 +169,7 @@ TEST(Vu0Qpipe, VdivByZeroSetsDBitInJitStatus)
 		WaitQPair(),
 		EBitNopPair(),
 	});
-	h.Run();
+	h.RunRequiringDivergence(kWhyQCeiling);
 	EXPECT_NE(h.GetViJit(REG_STATUS_FLAG) & 0x20u, 0u)
 		<< "JIT dropped the FDIV divide-by-zero (D) flag — mVUdivSet missing from doUpperOp?";
 	EXPECT_NE(h.GetViInterp(REG_STATUS_FLAG) & 0x20u, 0u); // oracle
@@ -188,7 +190,7 @@ TEST(Vu0Qpipe, VdivZeroOverZeroSetsIBitInJitStatus)
 		WaitQPair(),
 		EBitNopPair(),
 	});
-	h.Run();
+	h.RunRequiringDivergence(kWhyQCeiling);
 	EXPECT_NE(h.GetViJit(REG_STATUS_FLAG) & 0x10u, 0u)
 		<< "JIT dropped the FDIV invalid-op (I) flag (0/0)";
 	EXPECT_NE(h.GetViInterp(REG_STATUS_FLAG) & 0x10u, 0u);
@@ -227,7 +229,7 @@ TEST(Vu0Qpipe, VdivByZeroSetsDBitInJitStatusOnVu1)
 		WaitQPair(),
 		EBitNopPair(),
 	});
-	h.Run();
+	h.RunRequiringDivergence(kWhyQCeiling);
 	EXPECT_NE(h.GetViJit(REG_STATUS_FLAG) & 0x20u, 0u)
 		<< "VU1 JIT dropped the FDIV divide-by-zero (D) flag";
 }
@@ -307,9 +309,9 @@ TEST(Vu0Qpipe, VrsqrtByZeroNonZeroNumeratorMagicQ)
 		WaitQPair(),
 		EBitNopPair(),
 	});
-	h.Run();
-	EXPECT_EQ(h.GetViJit(REG_Q), kQPlusMax);
-	EXPECT_EQ(h.GetViInterp(REG_Q), kQPlusMax);
+	h.RunRequiringDivergence(kWhyQCeiling);
+	EXPECT_EQ(h.GetViJit(REG_Q), kQPlusJitMax);
+	EXPECT_EQ(h.GetViInterp(REG_Q), 0x7FFFFFFFu);
 }
 
 TEST(Vu0Qpipe, VrsqrtByZeroZeroNumeratorSaturatesAndRaisesInvalidOnly)
@@ -327,9 +329,9 @@ TEST(Vu0Qpipe, VrsqrtByZeroZeroNumeratorSaturatesAndRaisesInvalidOnly)
 		WaitQPair(),
 		EBitNopPair(),
 	});
-	h.Run();
-	EXPECT_EQ(h.GetViInterp(REG_Q), kQPlusMax);
-	EXPECT_EQ(h.GetViJit(REG_Q), kQPlusMax);
+	h.RunRequiringDivergence(kWhyQCeiling);
+	EXPECT_EQ(h.GetViInterp(REG_Q), 0x7FFFFFFFu);
+	EXPECT_EQ(h.GetViJit(REG_Q), kQPlusJitMax);
 	EXPECT_EQ(h.GetViInterp(REG_STATUS_FLAG) & 0x30, 0x10u);
 }
 

--- a/tests/ctest/core/recompilers/vu_divunit_console_conformance_tests.cpp
+++ b/tests/ctest/core/recompilers/vu_divunit_console_conformance_tests.cpp
@@ -29,9 +29,9 @@
 //   Q. Settled on the interpreters, which read the EE's divide-unit model and
 //   match every row. The recompilers run a host divide, so their two gaps --
 //   the ceiling and the arithmetic -- are pinned as exact tallies instead, for
-//   whoever emits the model there to move. Both engines' zero-divisor paths
-//   return the console's 0x7FFFFFFF; what still comes back a binade low is
-//   every quotient either engine reaches by dividing.
+//   whoever emits the model there to move. microVU's ceiling closes at
+//   vuClampMode 3 and the macro path's at 4; the arithmetic closes at 4 on
+//   both.
 
 #include <gtest/gtest.h>
 
@@ -240,12 +240,9 @@ TEST(VuDivUnitConsole, InterpreterQMatchesConsoleOnEveryRow)
 	EXPECT_EQ(micro, 422);
 }
 
-// The console's saturated quotient is the EE maximum 0x7FFFFFFF. Where a
-// recompiler writes that word outright -- the zero-divisor branch -- it can
-// carry it, and all four of recCOP2_VDIV, recCOP2_VRSQRT, mVU_DIV and mVU_RSQRT
-// do. Where it arrives by dividing, the ceiling is whatever the host clamp
-// holds -- FLT_MAX, one binade lower -- and that is all `sat` has left: the
-// same fourteen rows on either engine. The sign is not part of the
+// The console's saturated quotient is the EE maximum 0x7FFFFFFF. At the harness
+// default neither recompiler ceiling reaches it, the zero-divisor branch's
+// included, so `sat` is nearly every saturated row. The sign is not part of the
 // difference, so the class is defined with the sign carried over -- which is
 // what makes it a statement about the clamp and not a place for a sign bug to
 // hide. What is left over is the host divide's arithmetic.
@@ -260,15 +257,15 @@ TEST(VuDivUnitConsole, OnlyDividedQuotientsSaturateABinadeLowOfTheConsole)
 	// Rows that saturate on the console and come back as something other than
 	// the sign-matched ceiling fall in `unit` below rather than being counted as
 	// clamp misses.
-	EXPECT_EQ(mj.sat, 14);
-	EXPECT_EQ(uj.sat, 14);
+	EXPECT_EQ(mj.sat, 224);
+	EXPECT_EQ(uj.sat, 176);
 
 	// The arithmetic gap left once the ceiling is accounted for.
 	EXPECT_EQ(mj.unit, 86);
 	EXPECT_EQ(uj.unit, 82);
 
-	EXPECT_EQ(mj.ok, 402);
-	EXPECT_EQ(uj.ok, 326);
+	EXPECT_EQ(mj.ok, 192);
+	EXPECT_EQ(uj.ok, 164);
 
 	EXPECT_EQ(mj.ok + mj.sat + mj.unit, static_cast<int>(std::size(kVursCases)));
 	EXPECT_EQ(uj.ok + uj.sat + uj.unit, 422);
@@ -293,8 +290,12 @@ TEST(VuDivUnitConsole, TheDivideUnitsArithmeticLandsAtClampModeFour)
 
 		if (mode < 4)
 		{
-			EXPECT_EQ(s.macro.sat, 14);
-			EXPECT_EQ(s.micro.sat, 14);
+			// microVU's zero-divisor branch reaches the console word from mode 3,
+			// where mVUclamp2 bounds it back to a number sign-preservingly; the
+			// macro path's q-forms have no operand clamp, so its ceiling waits
+			// for the model.
+			EXPECT_EQ(s.macro.sat, 224);
+			EXPECT_EQ(s.micro.sat, mode < 3 ? 176 : 14);
 			EXPECT_EQ(s.macro.unit, 86);
 			EXPECT_EQ(s.micro.unit, 82);
 			continue;

--- a/tests/ctest/core/recompilers/vu_pq_boundary_tests.cpp
+++ b/tests/ctest/core/recompilers/vu_pq_boundary_tests.cpp
@@ -56,6 +56,11 @@ inline VuOp Nop() { return IBit(VuOp{VLitZero(), VNOP_U()}); }
 // DIV/SQRT latency is 7 cycles (microVU_Lower-arm64.inl, mVUanalyzeFDIV);
 // ESADD's EFU latency is 11. Padding by exactly the latency puts the
 // instance flip immediately before the branch, which is the state under test.
+// A zero divisor saturates to the console's 0x7FFFFFFF on the interpreter and,
+// below vuClampMode 3, to FLT_MAX in the recompiler; VuDivUnitConsole scores it.
+constexpr const char* kWhyQCeiling =
+	"Q: the recompiler's saturation ceiling is FLT_MAX, the interpreter's is 0x7FFFFFFF";
+
 constexpr int kDivLatency = 7;
 constexpr int kEsaddLatency = 11;
 
@@ -226,13 +231,13 @@ TEST(VuPqBoundary, DivByZeroFlagReachesStatusWhenProgramEndsInsideLatency)
 		EBitNopPair(),
 	});
 
-	h.Run();
+	h.RunRequiringDivergence(kWhyQCeiling);
 
 	EXPECT_NE(h.GetViJit(REG_STATUS_FLAG) & 0x20u, 0u)
 		<< "mVUendProgram must fold the pending divide-by-zero flag into STATUS "
 		   "when the program ends before the FDIV flag latency elapses";
 	// The quotient itself still has to be committed on the way out.
-	EXPECT_EQ(h.GetViJit(REG_Q), 0x7FFFFFFFu);
+	EXPECT_EQ(h.GetViJit(REG_Q), 0x7F7FFFFFu);
 }
 
 TEST(VuPqBoundary, DivInvalidFlagReachesStatusWhenProgramEndsInsideLatency)
@@ -248,12 +253,12 @@ TEST(VuPqBoundary, DivInvalidFlagReachesStatusWhenProgramEndsInsideLatency)
 		EBitNopPair(),
 	});
 
-	h.Run();
+	h.RunRequiringDivergence(kWhyQCeiling);
 
 	EXPECT_NE(h.GetViJit(REG_STATUS_FLAG) & 0x10u, 0u)
 		<< "mVUendProgram must fold the pending invalid-operation flag into "
 		   "STATUS when the program ends before the FDIV flag latency elapses";
-	EXPECT_EQ(h.GetViJit(REG_Q), 0x7FFFFFFFu);
+	EXPECT_EQ(h.GetViJit(REG_Q), 0x7F7FFFFFu);
 }
 
 // =========================================================================

--- a/tests/ctest/core/recompilers/vu_rsqrt_divisor_sign_tests.cpp
+++ b/tests/ctest/core/recompilers/vu_rsqrt_divisor_sign_tests.cpp
@@ -7,9 +7,9 @@
 // operand grid; this is the readable form, and it names which engine had each
 // case wrong.
 //
-// Q is the console's word and every engine is held to it directly; where a
-// quotient is instead reached by dividing, VuDivUnitConsole scores what the
-// host's ceiling leaves.
+// Q is the console's word. Below vuClampMode 3, where these harnesses run, the
+// recompilers saturate a binade low of it, which RecompilerQ() below states
+// once and VuDivUnitConsole scores across the modes.
 
 #include <gtest/gtest.h>
 
@@ -51,6 +51,13 @@ struct Row
 	u32 di; // expected STATUS & kDiMask
 	u32 q;  // the console's
 };
+
+// A saturated quotient reads back as FLT_MAX from either recompiler below
+// vuClampMode 3. Nothing else moves, so the rows below stay the console's and
+// this is the only place the deficit is spelled.
+constexpr bool Saturated(u32 q) { return (q & 0x7FFFFFFFu) == 0x7FFFFFFFu; }
+constexpr u32 RecompilerQ(u32 q) { return Saturated(q) ? ((q & 0x80000000u) | 0x7F7FFFFFu) : q; }
+constexpr const char* kWhyCeiling = "micro Q: the recompiler's ceiling is FLT_MAX, the interpreter's is 0x7FFFFFFF";
 
 // Every row is checked on all four engines. 0/0 goes to its own test below.
 constexpr Row kRows[] = {
@@ -123,7 +130,11 @@ TEST(VuRsqrtDivisorSign, InvalidComesFromTheDivisorSignBitAlone)
 
 		VuTestHarness m(0);
 		BuildMicro(m, r.fs, r.ft);
-		m.Run(); // also diffs micro JIT against micro interp
+		// also diffs micro JIT against micro interp
+		if (Saturated(r.q))
+			m.RunRequiringDivergence(kWhyCeiling);
+		else
+			m.Run();
 		EXPECT_EQ(m.GetViJit(REG_STATUS_FLAG) & kDiMask, r.di) << "[micro jit] STATUS";
 		EXPECT_EQ(m.GetViInterp(REG_STATUS_FLAG) & kDiMask, r.di) << "[micro interp] STATUS";
 	}
@@ -140,7 +151,7 @@ TEST(VuRsqrtDivisorSign, QuotientSignIsTheDividendsAlone)
 		EeRecTestHarness hj;
 		BuildMacro(hj, r.fs, r.ft);
 		hj.RunJitNoDiff();
-		EXPECT_EQ(hj.GetGprJit(kRQ), r.q) << "[macro jit] Q";
+		EXPECT_EQ(hj.GetGprJit(kRQ), RecompilerQ(r.q)) << "[macro jit] Q";
 
 		EeRecTestHarness hi;
 		BuildMacro(hi, r.fs, r.ft);
@@ -149,8 +160,11 @@ TEST(VuRsqrtDivisorSign, QuotientSignIsTheDividendsAlone)
 
 		VuTestHarness m(0);
 		BuildMicro(m, r.fs, r.ft);
-		m.Run();
-		EXPECT_EQ(m.GetViJit(REG_Q), r.q) << "[micro jit] Q";
+		if (Saturated(r.q))
+			m.RunRequiringDivergence(kWhyCeiling);
+		else
+			m.Run();
+		EXPECT_EQ(m.GetViJit(REG_Q), RecompilerQ(r.q)) << "[micro jit] Q";
 		EXPECT_EQ(m.GetViInterp(REG_Q), r.q) << "[micro interp] Q";
 
 		EXPECT_EQ(r.q & 0x80000000u, r.fs & 0x80000000u) << "quotient sign is the dividend's";
@@ -166,7 +180,8 @@ TEST(VuRsqrtDivisorSign, MatchesTheConsoleRowForOneOverNegativeZero)
 	h.RunJitNoDiff();
 	EXPECT_EQ(h.GetGprJit(kRStatus) & kDiMask, 0xC30u);
 	EXPECT_EQ(h.GetGprJit(kRQ) & 0x80000000u, 0x00000000u);
-	EXPECT_EQ(h.GetGprJit(kRQ), 0x7FFFFFFFu);
+	EXPECT_EQ(h.GetGprJit(kRQ), 0x7F7FFFFFu)
+		<< "console returned 0x7FFFFFFF; the magnitude is the VU clamp mode, the sign is not";
 }
 
 // Three of the four engines used to raise both causes here and return ±0.
@@ -187,7 +202,7 @@ TEST(VuRsqrtDivisorSign, ZeroOverZeroRaisesInvalidWithoutDivideByZero)
 		BuildMacro(hj, r.fs, r.ft);
 		hj.RunJitNoDiff();
 		EXPECT_EQ(hj.GetGprJit(kRStatus) & kDiMask, kI) << "[macro jit] STATUS";
-		EXPECT_EQ(hj.GetGprJit(kRQ), r.q) << "[macro jit] Q";
+		EXPECT_EQ(hj.GetGprJit(kRQ), RecompilerQ(r.q)) << "[macro jit] Q";
 
 		EeRecTestHarness hi;
 		BuildMacro(hi, r.fs, r.ft);
@@ -197,9 +212,9 @@ TEST(VuRsqrtDivisorSign, ZeroOverZeroRaisesInvalidWithoutDivideByZero)
 
 		VuTestHarness m(0);
 		BuildMicro(m, r.fs, r.ft);
-		m.Run();
+		m.RunRequiringDivergence(kWhyCeiling);
 		EXPECT_EQ(m.GetViJit(REG_STATUS_FLAG) & kDiMask, kI) << "[micro jit] STATUS";
-		EXPECT_EQ(m.GetViJit(REG_Q), r.q) << "[micro jit] Q";
+		EXPECT_EQ(m.GetViJit(REG_Q), RecompilerQ(r.q)) << "[micro jit] Q";
 		EXPECT_EQ(m.GetViInterp(REG_STATUS_FLAG) & kDiMask, kI) << "[micro interp] STATUS";
 		EXPECT_EQ(m.GetViInterp(REG_Q), r.q) << "[micro interp] Q";
 	}

--- a/tests/ctest/core/recompilers/vu_saturated_q_consumer_tests.cpp
+++ b/tests/ctest/core/recompilers/vu_saturated_q_consumer_tests.cpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2026 ARMSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+// DIV by zero, then a multiply by Q. A ceiling the FMAC cannot read comes back
+// from the multiply as +FLT_MAX with the sign gone; Sly 3 drew the protagonist
+// white on that. Asserted on the product, not on Q, so the rows outlive a
+// change of ceiling. VuDivUnitConsole scores which ceiling each mode reaches.
+
+#include <gtest/gtest.h>
+
+#include "harness/EeRecTestHarness.h"
+#include "harness/MipsEncode.h"
+#include "harness/RecompilerTestEnvironment.h"
+#include "harness/VuEncode.h"
+#include "harness/VuTestHarness.h"
+
+#include "VU.h"
+
+namespace recompiler_tests
+{
+namespace
+{
+using namespace mips;
+using namespace mips::ee;
+
+constexpr u32 kFs = 1; // dividend
+constexpr u32 kFt = 2; // divisor, zero
+constexpr u32 kFm = 3; // multiplicand
+constexpr u32 kFd = 4; // product
+
+constexpr u32 kNegOne = 0xBF800000u; // -1.0
+constexpr u32 kZero   = 0x00000000u;
+constexpr u32 kTiny   = 0x0D800000u; // 2^-100
+
+constexpr u32 kMacroLanes = 0xF;            // COP2 takes the dest field unshifted
+constexpr u32 kMicroLanes = vu::mask::xyzw; // the micro encoder takes it in place
+
+// 2^-100 against either candidate ceiling lands in 2^27..2^29, so the exponent
+// bound clears both edges and does not say which ceiling ran.
+void ExpectProductKeptTheOperand(u32 bits, const char* who)
+{
+	const u32 exp = (bits >> 23) & 0xFFu;
+	EXPECT_EQ(bits & 0x80000000u, 0x80000000u)
+		<< who << ": quotient's sign lost (0x" << std::hex << bits << ")";
+	EXPECT_GT(exp, 0x80u) << who << ": product underflowed (0x" << std::hex << bits << ")";
+	EXPECT_LT(exp, 0xA0u)
+		<< who << ": product saturated, so the multiply read Q as a NaN (0x"
+		<< std::hex << bits << ")";
+}
+
+void RunMicro(VuTestHarness& h, u32 upper)
+{
+	h.SetVfBits(kFs, kNegOne, kNegOne, kNegOne, kNegOne);
+	h.SetVfBits(kFt, kZero, kZero, kZero, kZero);
+	h.SetVfBits(kFm, kTiny, kTiny, kTiny, kTiny);
+	h.LoadProgram({
+		vu::VuOp{vu::VDIV_L(kFs, 0, kFt, 0), vu::VNOP_U()},
+		vu::VuOp{vu::VWAITQ_L(), vu::VNOP_U()},
+		vu::IBit(vu::VuOp{vu::VLitZero(), upper}),
+		vu::EBitNopPair(),
+	});
+	h.RunNoDiff(); // the ceilings differ below mode 3, the claims do not
+}
+
+void BuildMacro(EeRecTestHarness& h, u32 op)
+{
+	h.EnableVu0Capture();
+	h.ExpectVu0Divergence(); // as RunMicro
+	h.SeedVu0VfBits(kFs, kNegOne, kNegOne, kNegOne, kNegOne);
+	h.SeedVu0VfBits(kFt, kZero, kZero, kZero, kZero);
+	h.SeedVu0VfBits(kFm, kTiny, kTiny, kTiny, kTiny);
+	h.SeedVu0AccBits(kZero, kZero, kZero, kZero); // so MADDq's sum is its product
+	h.LoadProgram({VDIV_C2(0, 0, kFs, kFt), VWAITQ_C2(), op});
+}
+} // namespace
+
+TEST(VuSaturatedQConsumer, MicroMultiplyKeepsTheSaturatedQuotient)
+{
+	for (int mode = 1; mode <= 4; ++mode)
+	{
+		SCOPED_TRACE(::testing::Message() << "vuClampMode " << mode);
+
+		VuTestHarness hm(0);
+		hm.SetVuClampMode(mode);
+		RunMicro(hm, vu::VMULq_U(kMicroLanes, kFd, kFm));
+		ExpectProductKeptTheOperand(hm.GetVfBitsJit(kFd, 'x'), "micro jit MULq");
+		ExpectProductKeptTheOperand(hm.GetVfBitsInterp(kFd, 'x'), "micro interp MULq");
+
+		VuTestHarness ha(0);
+		ha.SetVuClampMode(mode);
+		RunMicro(ha, vu::VMADDq_U(kMicroLanes, kFd, kFm));
+		ExpectProductKeptTheOperand(ha.GetVfBitsJit(kFd, 'x'), "micro jit MADDq");
+		ExpectProductKeptTheOperand(ha.GetVfBitsInterp(kFd, 'x'), "micro interp MADDq");
+	}
+}
+
+// VMADDq, not VMULq: MULq's Q goes through cop2ClampOperandInto, so the q-forms
+// that reach the arithmetic unbounded are MADDq, MSUBq, MADDAq, MSUBAq, ADDAq
+// and SUBAq. Mode 4 is the test below.
+TEST(VuSaturatedQConsumer, MacroAccumulateKeepsTheSaturatedQuotient)
+{
+	for (int mode = 1; mode <= 3; ++mode)
+	{
+		SCOPED_TRACE(::testing::Message() << "vu0ClampMode " << mode);
+
+		EeRecTestHarness h;
+		h.SetVu0ClampMode(mode);
+		BuildMacro(h, VMADDq_C2(kMacroLanes, kFd, kFm));
+		h.Run();
+
+		ExpectProductKeptTheOperand(h.GetVu0VfBitsJit(kFd, 'x'), "macro jit");
+		ExpectProductKeptTheOperand(h.GetVu0VfBitsInterp(kFd, 'x'), "macro interp");
+	}
+}
+
+// The macro accumulate has no ceiling model of its own and, at mode 4, no
+// operand clamp either. microVU's MADDq is held at the same mode above.
+TEST(VuSaturatedQConsumer, MacroAccumulateCannotHoldTheCeilingAtClampModeFour)
+{
+	EeRecTestHarness h;
+	h.SetVu0ClampMode(4);
+	BuildMacro(h, VMADDq_C2(kMacroLanes, kFd, kFm));
+	h.Run();
+
+	EXPECT_EQ(h.GetVu0VfBitsJit(kFd, 'x'), 0x7F7FFFFFu)
+		<< "the macro accumulate now holds the console ceiling";
+	ExpectProductKeptTheOperand(h.GetVu0VfBitsInterp(kFd, 'x'), "macro interp");
+}
+} // namespace recompiler_tests

--- a/tests/ctest/core/recompilers/vu_sticky_console_conformance_tests.cpp
+++ b/tests/ctest/core/recompilers/vu_sticky_console_conformance_tests.cpp
@@ -1103,6 +1103,12 @@ constexpr DivDenormCase kDivDenormCases[] = {
 
 constexpr u32 kDivDI = 0x30;
 
+// Below vuClampMode 3, where these harnesses run, a saturated quotient reads
+// back a binade low from either recompiler; the ceiling is not what these rows
+// are about (vu_saturated_q_consumer_tests.cpp).
+constexpr bool Saturated(u32 q) { return (q & 0x7FFFFFFFu) == 0x7FFFFFFFu; }
+constexpr u32 RecompilerQ(u32 q) { return Saturated(q) ? ((q & 0x80000000u) | 0x7F7FFFFFu) : q; }
+
 // `which` names the register the pipe under test actually runs under: COP2
 // macro ops execute on the EE thread under FPUFPCR, micro programs under the
 // per-unit VU0FPCR.
@@ -1139,7 +1145,7 @@ void RunMacroDivCase(const DivDenormCase& c)
 	});
 	h.Run();
 	EXPECT_EQ(h.GetVu0ViInterp(REG_Q), c.want_q) << "[interp] Q";
-	EXPECT_EQ(h.GetVu0ViJit(REG_Q), c.want_q) << "[jit] Q";
+	EXPECT_EQ(h.GetVu0ViJit(REG_Q), RecompilerQ(c.want_q)) << "[jit] Q";
 	EXPECT_EQ(h.GetVu0ViInterp(REG_STATUS_FLAG) & kDivDI, c.want_di) << "[interp] D/I";
 	EXPECT_EQ(h.GetVu0ViJit(REG_STATUS_FLAG) & kDivDI, c.want_di) << "[jit] D/I";
 }
@@ -1162,7 +1168,7 @@ void RunMicroDivCase(const DivDenormCase& c)
 	});
 	h.RunNoDiff();
 	EXPECT_EQ(h.GetViInterp(REG_Q), c.want_q) << "[interp] Q";
-	EXPECT_EQ(h.GetViJit(REG_Q), c.want_q) << "[jit] Q";
+	EXPECT_EQ(h.GetViJit(REG_Q), RecompilerQ(c.want_q)) << "[jit] Q";
 	EXPECT_EQ(h.GetViInterp(REG_STATUS_FLAG) & kDivDI, c.want_di) << "[interp] D/I";
 	EXPECT_EQ(h.GetViJit(REG_STATUS_FLAG) & kDivDI, c.want_di) << "[jit] D/I";
 }
@@ -1254,7 +1260,7 @@ TEST(VuStickyConsoleConformance, Arm64Cop2DivUnitReadsTheAddressedLane)
 							  : VRSQRT_C2(fsf, ftf, 4, 5),
 				});
 				h.Run();
-				EXPECT_EQ(h.GetVu0ViJit(REG_Q), h.GetVu0ViInterp(REG_Q)) << "Q";
+				EXPECT_EQ(h.GetVu0ViJit(REG_Q), RecompilerQ(h.GetVu0ViInterp(REG_Q))) << "Q";
 				EXPECT_EQ(h.GetVu0ViJit(REG_STATUS_FLAG) & kDivDI,
 					h.GetVu0ViInterp(REG_STATUS_FLAG) & kDivDI) << "D/I";
 			}
@@ -1287,7 +1293,7 @@ TEST(VuStickyMicroConsoleConformance, MicroDivUnitReadsTheAddressedLane)
 					vu::EBitNopPair(),
 				});
 				h.RunNoDiff();
-				EXPECT_EQ(h.GetViJit(REG_Q), h.GetViInterp(REG_Q)) << "Q";
+				EXPECT_EQ(h.GetViJit(REG_Q), RecompilerQ(h.GetViInterp(REG_Q))) << "Q";
 				EXPECT_EQ(h.GetViJit(REG_STATUS_FLAG) & kDivDI,
 					h.GetViInterp(REG_STATUS_FLAG) & kDivDI) << "D/I";
 			}


### PR DESCRIPTION
### Description of Changes
f1a5733b50 and e2b541b7d8 gave recCOP2_VDIV/VRSQRT and mVU_DIV/mVU_RSQRT the 0x7FFFFFFF the console leaves on a zero divisor, at every clamp mode. Sly 3 divides by zero per vertex on VU1, which its GameDB entry leaves at the default, and drew the protagonist in black and white.

Both engines build the console word at vuClampMode 4 and take FLT_MAX below.  mVU_DIV and mVU_RSQRT carry their signbit/maxvals pair again there, so the microVU ABI version moves with the shape.

The tests that had recorded that deficit spell it again, and vu_saturated_q_consumer_tests holds a saturated Q through a multiply.

### Rationale behind Changes
Bugfix

### Suggested Testing Steps
Play Sly 3.

### AI Assistance (optional)
Yes