### PR TITLE
Mode 3's divide unit becomes exact in some cases a game can observe

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -23734,8 +23734,6 @@ SLES-53523:
 SLES-53524:
   name: "Mortal Kombat - Shaolin Monks"
   region: "PAL-M5"
-  roundModes:
-    eeDivRoundMode: 2 # Fixes elongated text on the menu screen.
   clampModes:
     eeClampMode: 3 # Full EE clamp — fixes geometry/effects.
   gsHWFixes:
@@ -23744,8 +23742,6 @@ SLES-53524:
 SLES-53525:
   name: "Mortal Kombat - Shaolin Monks"
   region: "PAL-G"
-  roundModes:
-    eeDivRoundMode: 2 # Fixes elongated text on the menu screen.
   clampModes:
     eeClampMode: 3 # Full EE clamp — fixes geometry/effects.
   gsHWFixes:
@@ -70197,8 +70193,6 @@ SLUS-21087:
   name: "Mortal Kombat - Shaolin Monks"
   region: "NTSC-U"
   compat: 5
-  roundModes:
-    eeDivRoundMode: 2 # Fixes elongated text on the menu screen.
   clampModes:
     eeClampMode: 3 # Full EE clamp — fixes geometry/effects.
   gsHWFixes:

--- a/pcsx2/arm64/iFPUd-arm64.cpp
+++ b/pcsx2/arm64/iFPUd-arm64.cpp
@@ -20,6 +20,7 @@
 // counterpart.
 
 #include "arm64/iR5900-arm64.h"
+#include "arm64/EeFpuModelCall-arm64.h"
 
 #include <cfloat>
 
@@ -898,8 +899,8 @@ static void SetMaxValueSlot(int dstidx, int srcidx)
 // model above eeSrtDigit; this is the call into it.
 //
 // Only mode 4 pays for it. Modes 1 to 3 keep the host instruction and the
-// FPUDivFPCR swap, which is right on most operands and one ULP out on the rest;
-// Mode 3 also takes it, from the integer guards below.
+// FPUDivFPCR swap, which is right on most operands and one ULP out on the rest.
+// Mode 3's guards call the same models through emitDivideUnitModelCall.
 //
 // Silicon composes RSQRT.S out of the other two with an ordinary single in
 // between, so this does as well; the intermediate crosses the sqrt's call
@@ -952,6 +953,25 @@ static void emitDivideUnitIsland(DivUnitOp op, int dstidx, int fsslotidx, int ft
 	armEmitEeFprWiden(armDRegister(dstidx), RWSCRATCH, RXSCRATCH);
 }
 
+// The guards' body, emitted after the block: no allocator frame.
+static void emitDivideUnitModelCall(DivUnitOp op, int dstidx, int fsslotidx, int ftslotidx)
+{
+	if (op == DivUnitOp::Sqrt)
+	{
+		armEmitEeFprNarrow(RXARG1, armDRegister(ftslotidx), RXSCRATCH);
+	}
+	else
+	{
+		armEmitEeFprNarrow(RXARG1, armDRegister(fsslotidx), RXSCRATCH);
+		armEmitEeFprNarrow(RXARG2, armDRegister(ftslotidx), RXSCRATCH);
+	}
+	const void* fn = op == DivUnitOp::Divide ? reinterpret_cast<const void*>(&EeFpuModel::Divide) :
+	                 op == DivUnitOp::Sqrt   ? reinterpret_cast<const void*>(&EeFpuModel::SqrtBits) :
+	                                           reinterpret_cast<const void*>(&EeFpuModel::RecipSqrt);
+	armEmitEeFpuModelCall(fn);
+	armEmitEeFprWiden(armDRegister(dstidx), RWARG1, RXSCRATCH);
+}
+
 // Mode 3 keeps the host quotient unless the divide unit's word truncates to a
 // different integer. The unit's word is the host's or the adjacent word on the
 // side the host rounded away from (FPU.cpp, eeDivideCap); the sign of
@@ -980,9 +1000,7 @@ static void emitDivideIntegerGuard(int sreg, int areg, int treg, int qreg, int s
 	armAsm->Fmov(armDRegister(treg), RXARG1);
 	armAsm->Fcvtzs(RWARG1, armDRegister(treg));
 	armAsm->Cmp(RWSCRATCH, RWARG1);
-	armAsm->B(&same, a64::eq);
-
-	emitDivideUnitIsland(DivUnitOp::Divide, sreg, srcS, srcT);
+	recEmitColdIslandBranch(a64::ne, [=]() { emitDivideUnitModelCall(DivUnitOp::Divide, sreg, srcS, srcT); });
 	armAsm->Bind(&same);
 }
 
@@ -1007,11 +1025,9 @@ static void emitSqrtIntegerGuard(int sreg, int xreg, int qreg, int srcT)
 	armAsm->Fmov(armDRegister(xreg), RXARG1);
 	armAsm->Fcvtzs(RWARG1, armDRegister(xreg));
 	armAsm->Cmp(RWSCRATCH, RWARG1);
-	armAsm->B(&same, a64::eq);
-
 	_freeNEONreg(xreg);
 	_freeNEONreg(qreg);
-	emitDivideUnitIsland(DivUnitOp::Sqrt, sreg, srcT, srcT);
+	recEmitColdIslandBranch(a64::ne, [=]() { emitDivideUnitModelCall(DivUnitOp::Sqrt, sreg, srcT, srcT); });
 	armAsm->Bind(&same);
 }
 
@@ -1036,9 +1052,7 @@ static void emitRsqrtIntegerGuard(int sreg, int qreg, int srcS, int srcT)
 	armAsm->Fmov(armDRegister(qreg), RXARG2);
 	armAsm->Fcvtzs(RWARG1, armDRegister(qreg));
 	armAsm->Cmp(RWSCRATCH, RWARG1);
-	armAsm->B(&same, a64::eq);
-
-	emitDivideUnitIsland(DivUnitOp::RecipSqrt, sreg, srcS, srcT);
+	recEmitColdIslandBranch(a64::ne, [=]() { emitDivideUnitModelCall(DivUnitOp::RecipSqrt, sreg, srcS, srcT); });
 	armAsm->Bind(&same);
 }
 

--- a/pcsx2/arm64/iFPUd-arm64.cpp
+++ b/pcsx2/arm64/iFPUd-arm64.cpp
@@ -899,7 +899,7 @@ static void SetMaxValueSlot(int dstidx, int srcidx)
 //
 // Only mode 4 pays for it. Modes 1 to 3 keep the host instruction and the
 // FPUDivFPCR swap, which is right on most operands and one ULP out on the rest;
-// Mode 3 also takes it, from the integer guard below.
+// Mode 3 also takes it, from the integer guards below.
 //
 // Silicon composes RSQRT.S out of the other two with an ordinary single in
 // between, so this does as well; the intermediate crosses the sqrt's call
@@ -983,6 +983,62 @@ static void emitDivideIntegerGuard(int sreg, int areg, int treg, int qreg, int s
 	armAsm->B(&same, a64::eq);
 
 	emitDivideUnitIsland(DivUnitOp::Divide, sreg, srcS, srcT);
+	armAsm->Bind(&same);
+}
+
+// The unit's root is the nearest single or one word below it, and nearest
+// whenever the host rounded down or the root was exact
+// (TheUnitsRootIsNearestOrTheWordBelow). Only a rounded-up root is tested.
+//
+// xreg: |ft|, qreg: the root, at value scale, both freed here. sreg: the slot;
+// the island overwrites it.
+static void emitSqrtIntegerGuard(int sreg, int xreg, int qreg, int srcT)
+{
+	a64::Label same;
+
+	armAsm->Fmsub(armDRegister(xreg), armDRegister(qreg), armDRegister(qreg), armDRegister(xreg));
+	armAsm->Fcmp(armDRegister(xreg), 0.0);
+	armAsm->B(&same, a64::ge);
+
+	armAsm->Fcvtzs(RWSCRATCH, armDRegister(qreg));
+	armAsm->Fmov(RXARG1, armDRegister(qreg));
+	armAsm->Mov(RXARG2, static_cast<u64>(1) << 29);
+	armAsm->Sub(RXARG1, RXARG1, RXARG2);
+	armAsm->Fmov(armDRegister(xreg), RXARG1);
+	armAsm->Fcvtzs(RWARG1, armDRegister(xreg));
+	armAsm->Cmp(RWSCRATCH, RWARG1);
+	armAsm->B(&same, a64::eq);
+
+	_freeNEONreg(xreg);
+	_freeNEONreg(qreg);
+	emitDivideUnitIsland(DivUnitOp::Sqrt, sreg, srcT, srcT);
+	armAsm->Bind(&same);
+}
+
+// The unit's RSQRT.S word lies within 2 words below the host's and 4 above
+// (RsqrtSAtFullModeStaysInsideTheWindow). The guard tests whether an integer
+// boundary falls inside that window. A zero quotient is skipped.
+//
+// qreg: q at value scale, clobbered. sreg: the slot; the island overwrites it.
+static void emitRsqrtIntegerGuard(int sreg, int qreg, int srcS, int srcT)
+{
+	a64::Label same;
+
+	armAsm->Fabs(armDRegister(qreg), armDRegister(qreg));
+	armAsm->Fmov(RXARG1, armDRegister(qreg));
+	armAsm->Cbz(RXARG1, &same);
+	armAsm->Mov(RXARG2, static_cast<u64>(2) << 29);
+	armAsm->Sub(RXARG2, RXARG1, RXARG2);
+	armAsm->Fmov(armDRegister(qreg), RXARG2);
+	armAsm->Fcvtzs(RWSCRATCH, armDRegister(qreg));
+	armAsm->Mov(RXARG2, static_cast<u64>(4) << 29);
+	armAsm->Add(RXARG2, RXARG1, RXARG2);
+	armAsm->Fmov(armDRegister(qreg), RXARG2);
+	armAsm->Fcvtzs(RWARG1, armDRegister(qreg));
+	armAsm->Cmp(RWSCRATCH, RWARG1);
+	armAsm->B(&same, a64::eq);
+
+	emitDivideUnitIsland(DivUnitOp::RecipSqrt, sreg, srcS, srcT);
 	armAsm->Bind(&same);
 }
 
@@ -1104,16 +1160,22 @@ void recSQRT_S_xmm(int info)
 	}
 	else
 	{
-		armAsm->Fsqrt(armDRegister(treg), armDRegister(treg));
+		// Temps, not EEREC_D: it may be EEREC_T, which the island reads.
+		const int qreg = _allocTempNEONreg();
+		const int sreg = _allocTempNEONreg();
+		armAsm->Fsqrt(armDRegister(qreg), armDRegister(treg));
 		// A root cannot leave the in-range band, so the narrowing is the plain
 		// Fcvt with none of ToPS2FPU_Full's arms around it: the largest operand
 		// is a shade under 2^129 and roots to under 2^65, the smallest one FZ
 		// does not flush is 2^-126 and roots to 2^-63, and both sit inside
 		// [2^-126, 2^128). The one result outside it is a zero, which the
 		// underflow arm would have flushed to the same zero.
-		armAsm->Fcvt(armSRegister(treg), armDRegister(treg));
-		SingleToSlot(EEREC_D, treg);
-		_freeNEONreg(treg);
+		armAsm->Fcvt(armSRegister(qreg), armDRegister(qreg));
+		SingleToSlot(sreg, qreg);
+		armAsm->Fcvt(armDRegister(qreg), armSRegister(qreg));
+		emitSqrtIntegerGuard(sreg, treg, qreg, EEREC_T);
+		armAsm->Fmov(armDRegister(EEREC_D), armDRegister(sreg));
+		_freeNEONreg(sreg);
 	}
 
 	if (swapFpcr)
@@ -1174,7 +1236,9 @@ void recRSQRT_S_xmm(int info)
 		armAsm->Fsqrt(armDRegister(treg), armDRegister(treg));
 		armAsm->Fdiv(armDRegister(sreg), armDRegister(sreg), armDRegister(treg));
 		ToPS2FPU_Full(sreg, false, treg, false, false);
+		armAsm->Fcvt(armDRegister(treg), armSRegister(sreg));
 		SingleToSlot(sreg, sreg);
+		emitRsqrtIntegerGuard(sreg, treg, EEREC_S, EEREC_T);
 	}
 
 	armAsm->Bind(&done);

--- a/pcsx2/arm64/iFPUd-arm64.cpp
+++ b/pcsx2/arm64/iFPUd-arm64.cpp
@@ -898,7 +898,8 @@ static void SetMaxValueSlot(int dstidx, int srcidx)
 // model above eeSrtDigit; this is the call into it.
 //
 // Only mode 4 pays for it. Modes 1 to 3 keep the host instruction and the
-// FPUDivFPCR swap, which is right on most operands and one ULP out on the rest.
+// FPUDivFPCR swap, which is right on most operands and one ULP out on the rest;
+// Mode 3 also takes it, from the integer guard below.
 //
 // Silicon composes RSQRT.S out of the other two with an ordinary single in
 // between, so this does as well; the intermediate crosses the sqrt's call
@@ -951,16 +952,53 @@ static void emitDivideUnitIsland(DivUnitOp op, int dstidx, int fsslotidx, int ft
 	armEmitEeFprWiden(armDRegister(dstidx), RWSCRATCH, RXSCRATCH);
 }
 
+// Mode 3 keeps the host quotient unless the divide unit's word truncates to a
+// different integer. The unit's word is the host's or the adjacent word on the
+// side the host rounded away from (FPU.cpp, eeDivideCap); the sign of
+// |fs| - q*|ft| gives that side, zero means exact. Computed at value scale: in
+// slot scale it can underflow under FZ.
+//
+// areg, treg, qreg: fs, ft, q at value scale, clobbered; the caller owns them.
+// sreg: the slot; the island overwrites it.
+static void emitDivideIntegerGuard(int sreg, int areg, int treg, int qreg, int srcS, int srcT)
+{
+	a64::Label same;
+
+	armAsm->Fabs(armDRegister(areg), armDRegister(areg));
+	armAsm->Fabs(armDRegister(treg), armDRegister(treg));
+	armAsm->Fabs(armDRegister(qreg), armDRegister(qreg));
+	armAsm->Fmsub(armDRegister(areg), armDRegister(qreg), armDRegister(treg), armDRegister(areg));
+	armAsm->Fcmp(armDRegister(areg), 0.0);
+	armAsm->B(&same, a64::eq);
+
+	// Csneg reads the Fcmp's flags.
+	armAsm->Fcvtzs(RWSCRATCH, armDRegister(qreg));
+	armAsm->Fmov(RXARG1, armDRegister(qreg));
+	armAsm->Mov(RXARG2, static_cast<u64>(1) << 29); // one word of the single
+	armAsm->Csneg(RXARG2, RXARG2, RXARG2, a64::gt);
+	armAsm->Add(RXARG1, RXARG1, RXARG2);
+	armAsm->Fmov(armDRegister(treg), RXARG1);
+	armAsm->Fcvtzs(RWARG1, armDRegister(treg));
+	armAsm->Cmp(RWSCRATCH, RWARG1);
+	armAsm->B(&same, a64::eq);
+
+	emitDivideUnitIsland(DivUnitOp::Divide, sreg, srcS, srcT);
+	armAsm->Bind(&same);
+}
+
 // x86 recDIVhelper1 (FPU_FLAGS_ID == 1 unconditionally): divide-by-zero
 // flag/result shape, otherwise the quotient -- from the recurrence under mode 4
-// and in double below it. sreg/treg are write-only temps, srcS/srcT the guest
-// slots; the result lands in sreg as a slot on both arms. treg is -1 under
-// mode 4, which has no double to hold.
+// and in double below it, guarded at mode 3. sreg/treg/areg/qreg are write-only
+// temps the caller allocated before anything was emitted -- an allocation can
+// evict, and an eviction's writeback emitted inside the normal arm is skipped
+// by every divide by zero -- srcS/srcT the guest slots; the result lands in
+// sreg as a slot on both arms. treg, areg and qreg are -1 under mode 4, which
+// has no double to hold.
 // The Fcmp-with-zero runs under the EE FPCR whose FZ bit flushes denormal
 // inputs — same divisor-is-zero net as x86's DAZ'd CMPEQ.SS. The double
 // quotient of two in-range PS2 values is always finite (max magnitude
 // ~2^255), so ToPS2FPU_Full's finite-only contract holds.
-static void recDIVhelper1(int sreg, int treg, int srcS, int srcT)
+static void recDIVhelper1(int sreg, int treg, int areg, int qreg, int srcS, int srcT)
 {
 	ClearIDFlags();
 
@@ -994,11 +1032,13 @@ static void recDIVhelper1(int sreg, int treg, int srcS, int srcT)
 	}
 	else
 	{
-		SlotToDouble(sreg, srcS);
+		SlotToDouble(areg, srcS);
 		SlotToDouble(treg, srcT);
-		armAsm->Fdiv(armDRegister(sreg), armDRegister(sreg), armDRegister(treg));
+		armAsm->Fdiv(armDRegister(sreg), armDRegister(areg), armDRegister(treg));
 		ToPS2FPU_Full(sreg, false, treg, false, false);
+		armAsm->Fcvt(armDRegister(qreg), armSRegister(sreg));
 		SingleToSlot(sreg, sreg);
+		emitDivideIntegerGuard(sreg, areg, treg, qreg, srcS, srcT);
 	}
 
 	armAsm->Bind(&done);
@@ -1015,11 +1055,17 @@ void recDIV_S_xmm(int info)
 	// both, so the result is built in a temp.
 	const int sreg = _allocTempNEONreg();
 	const int treg = CHECK_FPU_EXACT ? -1 : _allocTempNEONreg();
-	recDIVhelper1(sreg, treg, EEREC_S, EEREC_T);
+	const int areg = CHECK_FPU_EXACT ? -1 : _allocTempNEONreg();
+	const int qreg = CHECK_FPU_EXACT ? -1 : _allocTempNEONreg();
+	recDIVhelper1(sreg, treg, areg, qreg, EEREC_S, EEREC_T);
 	armAsm->Fmov(armDRegister(EEREC_D), armDRegister(sreg));
 	_freeNEONreg(sreg);
 	if (!CHECK_FPU_EXACT)
+	{
 		_freeNEONreg(treg);
+		_freeNEONreg(areg);
+		_freeNEONreg(qreg);
+	}
 
 	if (swapFpcr)
 		emitLoadFPCRImm(EmuConfig.Cpu.FPUFPCR.bitmask);

--- a/pcsx2/arm64/iR5900-arm64.cpp
+++ b/pcsx2/arm64/iR5900-arm64.cpp
@@ -9,6 +9,7 @@
 #include <cfloat>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>
@@ -1609,6 +1610,37 @@ a64::Label* recSuperblockAddSideExit(u32 branch_target, bool need_delay_slot)
 // patched toward the outlined exit body once the cold session has emitted it.
 static u8* s_sideExitIslands[kMaxContSites];
 
+// A conditional call-out outlined like a side exit: B.cond to a one-word island
+// after the tail, body in the cold arena at block end, B back to the site. The
+// body is emitted after the block, so it must not touch allocator state.
+struct ColdIsland
+{
+	std::unique_ptr<a64::Label> label;
+	u8* island;
+	u8* resume;
+	u8* cold;
+	std::function<void()> body;
+};
+static std::vector<ColdIsland> s_coldIslands;
+
+#ifdef PCSX2_RECOMPILER_TESTS
+static u32 s_coldIslandBodiesEmitted = 0;
+u32 recTestColdIslandBodiesEmitted()
+{
+	return s_coldIslandBodiesEmitted;
+}
+#endif
+
+void recEmitColdIslandBranch(a64::Condition cond, std::function<void()> body)
+{
+	ColdIsland x;
+	x.label = std::make_unique<a64::Label>();
+	x.body = std::move(body);
+	armAsm->B(x.label.get(), cond);
+	x.resume = armGetCurrentCodePointer();
+	s_coldIslands.push_back(std::move(x));
+}
+
 // Emit the per-exit islands after the block tail (still inside the hot
 // emission session — they are part of the block and count in x86size).
 // The mainline pc/size/recRAMCopy bookkeeping ran before this — pc is dead.
@@ -1621,6 +1653,13 @@ static void recEmitSideExitIslands()
 		a64::SingleEmissionCheckScope guard(armAsm);
 		s_sideExitIslands[k] = armGetCurrentCodePointer();
 		armAsm->b(int64_t{0}); // placeholder; patched to the cold exit body
+	}
+	for (ColdIsland& x : s_coldIslands)
+	{
+		armAsm->Bind(x.label.get());
+		a64::SingleEmissionCheckScope guard(armAsm);
+		x.island = armGetCurrentCodePointer();
+		armAsm->b(int64_t{0}); // placeholder; patched to the cold body
 	}
 }
 
@@ -1676,7 +1715,7 @@ static void recEmitColdSideExits()
 {
 	const int n = s_numSideExits;
 	s_numSideExits = 0;
-	if (n == 0)
+	if (n == 0 && s_coldIslands.empty())
 		return;
 
 	const u8* coldStart[kMaxContSites];
@@ -1697,6 +1736,16 @@ static void recEmitColdSideExits()
 		recEmitSideExitTail(x.branchTo);
 		x.label.reset();
 	}
+	for (ColdIsland& x : s_coldIslands)
+	{
+		x.cold = armGetCurrentCodePointer();
+		x.body();
+		armEmitJmp(x.resume);
+		x.label.reset();
+#ifdef PCSX2_RECOMPILER_TESTS
+		++s_coldIslandBodiesEmitted;
+#endif
+	}
 	pxAssert(armGetCurrentCodePointer() < SysMemory::GetEERecEnd());
 	s_coldPtr = armEndBlock();
 
@@ -1705,6 +1754,9 @@ static void recEmitColdSideExits()
 	// MTVU emit window in Legacy mode on its way out.
 	for (int k = 0; k < n; k++)
 		recPatchIslandB(s_sideExitIslands[k], coldStart[k]);
+	for (const ColdIsland& x : s_coldIslands)
+		recPatchIslandB(x.island, x.cold);
+	s_coldIslands.clear();
 
 	g_branch = 1;
 }
@@ -4258,6 +4310,7 @@ StartRecomp:
 		// SL-03: sweep side-exit residue the same way (recEmitPendingSideExits
 		// drains the list on every completed compile).
 		s_numSideExits = 0;
+		s_coldIslands.clear();
 
 		// SL-1 candidacy: a resident self-loop is a block whose terminal branch
 		// targets its own startpc. Wait-loop-FF blocks keep the fast-forward

--- a/pcsx2/arm64/iR5900-arm64.h
+++ b/pcsx2/arm64/iR5900-arm64.h
@@ -9,6 +9,7 @@
 #include "VU.h"
 #include "arm64/iCore-arm64.h"
 
+#include <functional>
 #include <string>
 #include <string_view>
 
@@ -707,6 +708,12 @@ void LoadBranchState();
 // emits the normal flush + event-check + linked-B tail.
 bool recSuperblockIsContSite(u32 branch_pc);
 vixl::aarch64::Label* recSuperblockAddSideExit(u32 branch_target, bool need_delay_slot);
+
+// B.cond to an island whose body is emitted in the cold arena at block end.
+void recEmitColdIslandBranch(vixl::aarch64::Condition cond, std::function<void()> body);
+#ifdef PCSX2_RECOMPILER_TESTS
+u32 recTestColdIslandBodiesEmitted();
+#endif
 
 void recompileNextInstruction(bool delayslot, bool swapped_delay_slot);
 

--- a/tests/ctest/core/recompilers/ee_rec_fpu_divunit_rounding_tests.cpp
+++ b/tests/ctest/core/recompilers/ee_rec_fpu_divunit_rounding_tests.cpp
@@ -1179,6 +1179,33 @@ TEST(EeRecFpuDivUnitRounding, FullModeTruncatesTheReciprocalRootLikeTheUnit)
 	EXPECT_GT(guard_answered, 0) << "liveness: the guard never fired";
 }
 
+u32 recTestColdIslandBodiesEmitted(); // iR5900-arm64.cpp
+
+TEST(EeRecFpuDivUnitRounding, GuardIslandsAreOutlined)
+{
+	constexpr u32 kLnSixtyFour = 0x40851590u, kLnTwo = 0x3F317216u;
+
+	const auto run = [&](int divides) {
+		std::vector<u32> prog;
+		for (int i = 0; i < divides; ++i)
+			prog.push_back(ee::DIV_S(3, 1, 2));
+		prog.push_back(ee::CVT_W_S(3, 3));
+		const u32 before = recTestColdIslandBodiesEmitted();
+		EeRecTestHarness h;
+		h.EnableCop1();
+		h.EnableFpuFullMode();
+		h.SetFprBits(1, kLnSixtyFour);
+		h.SetFprBits(2, kLnTwo);
+		h.LoadProgram(prog);
+		h.RunJitNoDiff();
+		EXPECT_EQ(h.GetFprBitsJit(3), 6u) << divides << " divides: the last one's integer is not the unit's";
+		return recTestColdIslandBodiesEmitted() - before;
+	};
+
+	EXPECT_EQ(run(1), 1u) << "the guard's island was not outlined";
+	EXPECT_EQ(run(19), 19u) << "every guard in a block gets its own body";
+}
+
 // ---------------------------------------------------------------------------
 // A temp allocated inside a runtime arm. _allocTempNEONreg evicts when the pool
 // is full, and an eviction writes the evicted guest register back at the point

--- a/tests/ctest/core/recompilers/ee_rec_fpu_divunit_rounding_tests.cpp
+++ b/tests/ctest/core/recompilers/ee_rec_fpu_divunit_rounding_tests.cpp
@@ -39,6 +39,7 @@
 #include "common/FPControl.h"
 
 #include <algorithm>
+#include <bit>
 #include <cmath>
 
 #include <gtest/gtest.h>
@@ -521,4 +522,309 @@ TEST(EeRecFpuDivUnitRounding, ArithmeticStillChopsUnderTheAmbientMode)
 		EXPECT_EQ(run(false), kRounded)
 			<< "[interp] control is DEAD -- see above";
 	}
+}
+
+// ---------------------------------------------------------------------------
+// What the one ULP is worth.
+//
+// Mortal Kombat: Shaolin Monks derives a texture's log2 dimension the usual
+// way, at EE 0x0026b1c4 and 0x0026b1d8:
+//
+//     lhu     v0, 8(s1)          ; the dimension, 64
+//     cvt.s.w f12, f12
+//     jal     logf
+//     lwc1    f20, ln2
+//     div.s   f0, f0, f20        ; log2(n) = ln(n) / ln(2)
+//     cvt.w.s f1, f0             ; truncate
+//
+// ln(64) and ln(2) are singles, so their quotient is not 6: it is
+// 5.99999965603464, and nearest rounding keeps it under 6 while the divide
+// unit's A<B branch takes it up to exactly 6.0. cvt.w.s then truncates, and the
+// gap between the engines stops being one ULP of a float and becomes a whole
+// integer -- the game builds its dialog panel a power of two too small and the
+// message overruns the border it is drawn inside.
+//
+// Both the quotient and its cvt.w.s are asserted. Mode 3 returns the unit's
+// word on this row.
+// ---------------------------------------------------------------------------
+namespace {
+
+enum class Tier { Fast, Full, Exact };
+
+const char* TierName(Tier t)
+{
+	switch (t)
+	{
+		case Tier::Fast: return "fast path";
+		case Tier::Full: return "eeClampMode 3";
+		default: return "eeClampMode 4";
+	}
+}
+
+void EnableTier(EeRecTestHarness& h, Tier t)
+{
+	if (t == Tier::Full)
+		h.EnableFpuFullMode();
+	else if (t == Tier::Exact)
+		h.EnableFpuExactMode();
+}
+
+} // namespace
+
+TEST(EeRecFpuDivUnitRounding, ATruncatedLog2NeedsTheUnitsOwnRoundUp)
+{
+	constexpr u32 kLnSixtyFour = 0x40851590u; // logf(64.0f) as the game computes it
+	constexpr u32 kLnTwo = 0x3F317216u;
+	constexpr u32 kConsole = 0x40C00000u; // 6.0
+	constexpr u32 kRounded = 0x40BFFFFFu; // 5.9999995
+
+	const auto run = [](bool jit, Tier tier, bool truncate) {
+		EeRecTestHarness h;
+		h.EnableCop1();
+		if (jit)
+			EnableTier(h, tier);
+		h.SetFprBits(1, kLnSixtyFour);
+		h.SetFprBits(2, kLnTwo);
+		if (truncate)
+			h.LoadProgram({ee::DIV_S(3, 1, 2), ee::CVT_W_S(3, 3)});
+		else
+			h.LoadProgram({ee::DIV_S(3, 1, 2)});
+		if (jit)
+		{
+			h.RunJitNoDiff();
+			return h.GetFprBitsJit(3);
+		}
+		h.RunInterpOnly();
+		return h.GetFprBitsInterp(3);
+	};
+
+	EXPECT_EQ(run(false, Tier::Fast, false), kConsole) << "interp";
+	EXPECT_EQ(run(true, Tier::Exact, false), kConsole) << "jit, " << TierName(Tier::Exact);
+	EXPECT_EQ(run(true, Tier::Full, false), kConsole)
+		<< "jit, " << TierName(Tier::Full) << ": the integer guard fires on this row";
+	EXPECT_EQ(run(true, Tier::Fast, false), kRounded)
+		<< "the fast path is the nearest-rounding engine and this operand is "
+		   "one of the rows where that is not what the console returns";
+
+	EXPECT_EQ(run(false, Tier::Fast, true), 6u) << "interp, truncated";
+	EXPECT_EQ(run(true, Tier::Exact, true), 6u) << "jit " << TierName(Tier::Exact) << ", truncated";
+	EXPECT_EQ(run(true, Tier::Full, true), 6u) << "jit " << TierName(Tier::Full) << ", truncated";
+	EXPECT_EQ(run(true, Tier::Fast, true), 5u)
+		<< "fast path, truncated: 6 means the operand no longer witnesses the deficit";
+}
+
+// ---------------------------------------------------------------------------
+// At mode 3 the quotient's cvt.w.s integer must be the unit's. The pool puts
+// quotients on or one word beside an integer: n times a divisor with a short
+// significand is an exact single, and the word either side of it divided by
+// the same divisor is one ULP off n. Register aliasing is varied.
+// ---------------------------------------------------------------------------
+namespace {
+
+struct DivIntCase
+{
+	u32 fs, ft;
+	u32 fd, fi; // fd: the quotient's register; fi: the integer's
+	const char* what;
+};
+
+// n = m * 2^j and ft = mb * 2^k, m and mb sharing 24 bits so n * ft is exact;
+// fs is that product or the word either side of it.
+DivIntCase MakeDivIntCase(Lcg& r)
+{
+	const u32 mbits = 1u + r.next() % 22u;
+	const u32 m = (1u << (mbits - 1)) | (r.next() & ((1u << (mbits - 1)) - 1u));
+	// n from 2^-2 (its integer is 0) up past 2^33 (its cvt.w.s saturates)
+	const int j = -2 - static_cast<int>(mbits - 1) + static_cast<int>(r.next() % 36u);
+	const u32 dbits = 2u + r.next() % (23u - mbits); // 2..24-mbits: never a power of two
+	const u32 mb = (1u << (dbits - 1)) | (r.next() & ((1u << (dbits - 1)) - 1u));
+	const int k = -30 + static_cast<int>(r.next() % 61u);
+
+	// product = m * mb * 2^(j + k), normalised to a 24-bit significand
+	u64 pm = static_cast<u64>(m) * mb;
+	int pe = j + k;
+	while (pm < (1ull << 23)) { pm <<= 1; --pe; }
+	// exponent field of a single whose significand is pm (in [2^23, 2^24)) and value pm * 2^pe
+	const int field = pe + 23 + 127;
+	if (field < 1 || field > 254)
+		return MakeDivIntCase(r); // out of range: draw again
+
+	const u32 sign_s = (r.next() & 1u) << 31;
+	const u32 sign_t = (r.next() & 1u) << 31;
+	u32 fs = sign_s | (static_cast<u32>(field) << 23) | (static_cast<u32>(pm) & 0x7FFFFFu);
+	switch (r.next() % 3u)
+	{
+		case 0: break;          // exact: the quotient is n itself
+		case 1: fs += 1u; break; // one word up the magnitude
+		default: fs -= 1u; break;
+	}
+	// ft: mb normalised the same way
+	u64 tm = mb;
+	int te = k;
+	while (tm < (1ull << 23)) { tm <<= 1; --te; }
+	const int tfield = te + 23 + 127;
+	if (tfield < 1 || tfield > 254)
+		return MakeDivIntCase(r);
+	const u32 ft = sign_t | (static_cast<u32>(tfield) << 23) | (static_cast<u32>(tm) & 0x7FFFFFu);
+
+	DivIntCase c{fs, ft, 3, 4, "fd, fs, ft distinct"};
+	switch (r.next() % 4u)
+	{
+		case 0: break;
+		case 1: c.fd = 1; c.what = "fd == fs"; break;
+		case 2: c.fd = 2; c.what = "fd == ft"; break;
+		default: c.fi = 3; c.what = "fi == fd"; break;
+	}
+	return c;
+}
+
+u32 TruncateLikeCvtWS(u32 w)
+{
+	const int e = static_cast<int>((w >> 23) & 0xFFu) - 127;
+	if (e < 0)
+		return 0;
+	if (e >= 31)
+		return (w & 0x80000000u) ? 0x80000000u : 0x7FFFFFFFu;
+	const u32 mag = (0x800000u | (w & 0x7FFFFFu)) >> (23 - e);
+	return (w & 0x80000000u) ? static_cast<u32>(-static_cast<s32>(mag)) : mag;
+}
+
+} // namespace
+
+TEST(EeRecFpuDivUnitRounding, FullModeTruncatesTheQuotientLikeTheUnit)
+{
+	RequireDistinctDivideRoundingMode();
+	Lcg r{0x1D1E5C7A5E1D1E5Cull};
+	int fast_int_gaps = 0, full_word_gaps = 0, guard_answered = 0, exact_rows = 0;
+	for (u32 iter = 0; iter < 1200; ++iter)
+	{
+		// Every fourth row is an arbitrary pair.
+		DivIntCase c = (iter % 4u == 3u)
+			? DivIntCase{fuzzOperand(r), fuzzOperand(r), 3, 4, "arbitrary"}
+			: MakeDivIntCase(r);
+		const u32 pre = (r.next() % 4u == 0u) ? (kSI | kSD) : 0u;
+		SCOPED_TRACE(::testing::Message()
+			<< "iter=" << iter << " Fs=" << std::hex << c.fs << " Ft=" << c.ft
+			<< " fd=" << c.fd << " fi=" << c.fi << " (" << c.what << ") pre=" << pre);
+
+		u32 word[3] = {}, integer[3] = {}, fcr[3] = {};
+		for (int engine = 0; engine < 3; ++engine) // interp, jit full, jit fast
+		{
+			EeRecTestHarness h;
+			h.EnableCop1();
+			if (engine == 1)
+				h.EnableFpuFullMode();
+			h.SetFprBits(1, c.fs);
+			h.SetFprBits(2, c.ft);
+			h.SetFcr31(pre);
+			h.LoadProgram({ee::DIV_S(c.fd, 1, 2), ee::CVT_W_S(c.fi, c.fd)});
+			if (engine == 0)
+			{
+				h.RunInterpOnly();
+				word[0] = h.GetFprBitsInterp(c.fd);
+				integer[0] = h.GetFprBitsInterp(c.fi);
+				fcr[0] = h.InterpSnapshot().fprs.fprc[31];
+			}
+			else
+			{
+				h.RunJitNoDiff();
+				word[engine] = h.GetFprBitsJit(c.fd);
+				integer[engine] = h.GetFprBitsJit(c.fi);
+				fcr[engine] = h.JitSnapshot().fprs.fprc[31];
+			}
+		}
+		// fi == fd overwrites the quotient.
+		const bool word_visible = c.fi != c.fd;
+
+		EXPECT_EQ(integer[1], integer[0])
+			<< "mode 3's cvt.w.s integer is not the unit's: interp word=" << std::hex
+			<< word[0] << " jit word=" << word[1];
+		if (word_visible)
+		{
+			if (word[1] != word[0])
+			{
+				++full_word_gaps;
+				EXPECT_TRUE(IsOneUlpApart(word[0], word[1]))
+					<< "mode 3 word is not adjacent to the unit's; interp=" << std::hex << word[0]
+					<< " jit=" << word[1];
+				EXPECT_EQ(TruncateLikeCvtWS(word[1]), TruncateLikeCvtWS(word[0]))
+					<< "mode 3 kept the host word on a row whose integer differs";
+			}
+			if (integer[2] != integer[0])
+			{
+				++fast_int_gaps;
+				if (word[1] == word[0])
+					++guard_answered;
+			}
+		}
+		else if (integer[2] != integer[0])
+		{
+			++fast_int_gaps;
+			++guard_answered;
+		}
+		EXPECT_EQ(fcr[1] & kStickyMask, fcr[0] & kStickyMask) << "mode 3 moved a sticky flag";
+		if (IsTopBinadeTierGap(word[0], word[1]))
+			ADD_FAILURE() << "mode 3 holds the EE range; a FLT_MAX word is the fast path's";
+		if (c.what[0] != 'a' && (c.fs & 0x7FFFFFFFu) != 0 && word_visible && word[1] == word[0] &&
+			integer[2] == integer[0])
+			++exact_rows;
+		if (::testing::Test::HasFailure())
+			return;
+	}
+	RecordProperty("fast_int_gaps", fast_int_gaps);
+	RecordProperty("full_word_gaps", full_word_gaps);
+	RecordProperty("guard_answered", guard_answered);
+	RecordProperty("exact_rows", exact_rows);
+	EXPECT_GT(fast_int_gaps, 0) << "anti-vacuity: no row where the fast path's integer differs";
+	EXPECT_GT(full_word_gaps, 0) << "anti-vacuity: mode 3 returned the unit's word on every row";
+	EXPECT_GT(guard_answered, 0) << "liveness: the guard never fired";
+	EXPECT_GT(exact_rows, 0) << "the pool's exact arm produced nothing";
+}
+
+// ---------------------------------------------------------------------------
+// A temp allocated inside a runtime arm. _allocTempNEONreg evicts when the pool
+// is full, and an eviction writes the evicted guest register back at the point
+// of allocation while the allocator forgets it unconditionally. Inside the
+// divide's normal arm that store is skipped whenever the divisor is zero, and
+// the guest register's newest value is lost. The block below fills the pool
+// with dirty FPRs, divides by zero, and reads every one of them back.
+// ---------------------------------------------------------------------------
+TEST(EeRecFpuDivUnitRounding, DivideByZeroWithAFullPoolKeepsEveryDirtyFpr)
+{
+	constexpr int kFirst = 4, kLast = 29; // f4..f29 dirtied, f0..f3 are the divide's
+	const auto run = [&](bool zero_divisor, bool exact_mode) {
+		std::vector<u32> prog;
+		for (int i = kFirst; i <= kLast; ++i)
+			prog.push_back(ee::ADD_S(i, i, 1)); // f_i = i + 1.0
+		prog.push_back(ee::DIV_S(3, 2, 0));
+		EeRecTestHarness h;
+		h.EnableCop1();
+		if (exact_mode)
+			h.EnableFpuExactMode();
+		else
+			h.EnableFpuFullMode();
+		h.SetFpr(0, zero_divisor ? 0.0f : 2.0f);
+		h.SetFpr(1, 1.0f);
+		h.SetFpr(2, 6.0f);
+		for (int i = kFirst; i <= kLast; ++i)
+			h.SetFpr(i, static_cast<float>(i));
+		h.LoadProgram(prog);
+		h.RunJitNoDiff();
+		int lost = 0;
+		for (int i = kFirst; i <= kLast; ++i)
+		{
+			const u32 expect = std::bit_cast<u32>(static_cast<float>(i + 1));
+			const u32 got = h.GetFprBitsJit(i);
+			if (got != expect)
+				++lost;
+			EXPECT_EQ(got, expect) << "f" << i << (zero_divisor ? " after a divide by zero" : "")
+								   << (exact_mode ? " at eeClampMode 4" : " at eeClampMode 3");
+		}
+		return lost;
+	};
+
+	EXPECT_EQ(run(false, false), 0) << "control: the normal arm ran, so every eviction's store ran";
+	EXPECT_EQ(run(true, true), 0) << "control: mode 4 allocates nothing inside the arm";
+	EXPECT_EQ(run(true, false), 0)
+		<< "a dirty FPR evicted for a temp inside the normal arm was never written back";
 }

--- a/tests/ctest/core/recompilers/ee_rec_fpu_divunit_rounding_tests.cpp
+++ b/tests/ctest/core/recompilers/ee_rec_fpu_divunit_rounding_tests.cpp
@@ -36,6 +36,7 @@
 #include "harness/EeRecTestHarness.h"
 
 #include "Config.h"
+#include "EeFpuModel.h"
 #include "common/FPControl.h"
 
 #include <algorithm>
@@ -779,6 +780,403 @@ TEST(EeRecFpuDivUnitRounding, FullModeTruncatesTheQuotientLikeTheUnit)
 	EXPECT_GT(full_word_gaps, 0) << "anti-vacuity: mode 3 returned the unit's word on every row";
 	EXPECT_GT(guard_answered, 0) << "liveness: the guard never fired";
 	EXPECT_GT(exact_rows, 0) << "the pool's exact arm produced nothing";
+}
+
+// ---------------------------------------------------------------------------
+// What the SQRT.S and RSQRT.S guards rely on, checked against the interpreter's
+// models. SQRT.S: the unit's root is the nearest single or one word below it,
+// and nearest whenever nearest rounds down or is exact. Every input of the
+// recurrence: 2^23 significands at both exponent parities.
+// ---------------------------------------------------------------------------
+namespace {
+
+// floor(sqrt(x)) for x below 2^48, from a double seed corrected both ways.
+u64 ISqrt48(u64 x)
+{
+	u64 r = static_cast<u64>(std::sqrt(static_cast<double>(x)));
+	while (r > 0 && r * r > x)
+		--r;
+	while ((r + 1) * (r + 1) <= x)
+		++r;
+	return r;
+}
+
+// The nearest single root of a normal word, and whether nearest rounded up.
+// Placed as the recurrence places it: the significand shifted one place on
+// an odd exponent field and two on an even one, rooted at 2^22 scale.
+u32 NearestSqrtWord(u32 ft, bool* rounded_up, bool* exact)
+{
+	const u32 E = (ft >> 23) & 0xFFu;
+	const u64 m = static_cast<u64>(0x800000u | (ft & 0x7FFFFFu)) << ((E & 1u) ? 1 : 2);
+	const u64 x = m << 22;
+	const u64 R = ISqrt48(x);
+	const u64 rem = x - R * R;
+	*exact = rem == 0;
+	*rounded_up = rem > R; // the exact root exceeds R + 1/2
+	const u32 sig = static_cast<u32>(R) + (*rounded_up ? 1u : 0u);
+	return (((E + 127u) >> 1) << 23) | (sig & 0x7FFFFFu);
+}
+
+} // namespace
+
+TEST(EeRecFpuDivUnitRounding, TheUnitsRootIsNearestOrTheWordBelow)
+{
+	u64 equal = 0, below = 0, above = 0, other = 0, down_rows = 0, down_and_below = 0;
+	for (u32 E : {127u, 128u})
+	{
+		for (u32 man = 0; man < (1u << 23); ++man)
+		{
+			const u32 ft = (E << 23) | man;
+			bool up = false, exact = false;
+			const u32 nearest = NearestSqrtWord(ft, &up, &exact);
+			const u32 unit = EeFpuModel::SqrtBits(ft);
+			if (unit == nearest)
+				++equal;
+			else if (unit + 1u == nearest)
+				++below;
+			else if (unit == nearest + 1u)
+				++above;
+			else
+				++other;
+			if (!up)
+			{
+				++down_rows;
+				if (unit != nearest)
+					++down_and_below;
+			}
+		}
+	}
+	EXPECT_EQ(above, 0u) << "a root above nearest: the recurrence has no such row";
+	EXPECT_EQ(other, 0u) << "a root more than one word from nearest";
+	EXPECT_EQ(down_and_below, 0u) << "nearest rounded down or was exact and the unit differs";
+	EXPECT_GT(below, 0u) << "liveness: no row where the unit sits below nearest";
+	EXPECT_GT(equal, 0u);
+	EXPECT_GT(down_rows, 0u);
+	RecordProperty("equal", static_cast<int>(equal));
+	RecordProperty("below", static_cast<int>(below));
+}
+
+// ---------------------------------------------------------------------------
+// RSQRT.S at mode 3 divides by the double root, so the unit's word is within a
+// window of the host's rather than adjacent to it. The bound: the single root
+// is at most 1.5 words below the true root and 0.5 above; one root word is at
+// most two quotient words; the recurrence adds T or T+1. That gives [-2, +4].
+// Flag paths and flushed or saturated quotients are skipped and counted.
+// ---------------------------------------------------------------------------
+TEST(EeRecFpuDivUnitRounding, RsqrtSAtFullModeStaysInsideTheWindow)
+{
+	RequireDistinctDivideRoundingMode();
+	Lcg r{0x5E1DC0DE5E1DC0DEull};
+	constexpr int kLo = -2, kHi = 4;
+	int hist[kHi - kLo + 1] = {};
+	int measured = 0, skipped = 0, outside = 0, min_d = 0, max_d = 0;
+	// Normal operands; every fourth row is the widest-window corner, a root
+	// just above a power of two (odd exponent field, small significand) under
+	// a quotient just below one.
+	const auto normal = [&](u32 lo_exp, u32 n_exp) {
+		return (lo_exp + r.next() % n_exp) << 23 | (r.next() & 0x7FFFFFu);
+	};
+	for (u32 iter = 0; iter < 20000; ++iter)
+	{
+		u32 fsBits, ftBits;
+		if (iter % 4u == 3u)
+		{
+			ftBits = ((1u + 2u * (r.next() % 127u)) << 23) | (r.next() & 0xFFu);
+			fsBits = normal(1u, 254u) | (0x7FFFFFu - (r.next() & 0xFFu));
+		}
+		else
+		{
+			fsBits = normal(1u, 254u);
+			ftBits = normal(1u, 254u);
+		}
+		fsBits |= (r.next() & 1u) << 31;
+		SCOPED_TRACE(::testing::Message()
+			<< "iter=" << iter << " Fs=" << std::hex << fsBits << " Ft=" << ftBits);
+
+		u32 res[2] = {};
+		for (int jit = 0; jit < 2; ++jit)
+		{
+			EeRecTestHarness h;
+			h.EnableCop1();
+			if (jit)
+				h.EnableFpuFullMode();
+			h.SetFprBits(1, fsBits);
+			h.SetFprBits(2, ftBits);
+			h.SetFcr31(0);
+			h.LoadProgram({ee::RSQRT_S(3, 1, 2)});
+			if (jit)
+			{
+				h.RunJitNoDiff();
+				res[1] = h.GetFprBitsJit(3);
+			}
+			else
+			{
+				h.RunInterpOnly();
+				res[0] = h.GetFprBitsInterp(3);
+			}
+		}
+		const u32 um = res[0] & 0x7FFFFFFFu, hm = res[1] & 0x7FFFFFFFu;
+		if (((fsBits >> 23) & 0xFFu) == 0 || ((ftBits >> 23) & 0xFFu) == 0 || um == 0 || hm == 0 ||
+			um >= 0x7F800000u || hm >= 0x7F800000u)
+		{
+			++skipped;
+			continue;
+		}
+		EXPECT_EQ(res[0] & 0x80000000u, res[1] & 0x80000000u) << "signs differ";
+		const s64 d = static_cast<s64>(um) - static_cast<s64>(hm);
+		++measured;
+		if (measured == 1)
+			min_d = max_d = static_cast<int>(d);
+		min_d = std::min<int>(min_d, static_cast<int>(d));
+		max_d = std::max<int>(max_d, static_cast<int>(d));
+		if (d < kLo || d > kHi)
+		{
+			++outside;
+			ADD_FAILURE() << "unit word " << std::hex << res[0] << " is " << std::dec << d
+						  << " words from the mode-3 word " << std::hex << res[1];
+		}
+		else
+			++hist[d - kLo];
+		if (::testing::Test::HasFailure())
+			return;
+	}
+	for (int i = 0; i < kHi - kLo + 1; ++i)
+		RecordProperty((std::string("d_") + std::to_string(i + kLo)).c_str(), hist[i]);
+	RecordProperty("measured", measured);
+	RecordProperty("skipped", skipped);
+	RecordProperty("min_d", min_d);
+	RecordProperty("max_d", max_d);
+	EXPECT_GT(measured, 10000);
+	EXPECT_GT(hist[0 - kLo], 0) << "no row where the engines agree";
+	EXPECT_LT(min_d, 0) << "liveness: the unit was never below the host word";
+	EXPECT_GT(max_d, 1) << "liveness: the unit was never more than one word above the host";
+}
+
+// ---------------------------------------------------------------------------
+// The same class for the root and the reciprocal root. SQRT.S: the radicand
+// is an exact square n^2 (n of at most twelve significant bits) or the word
+// either side of it. RSQRT.S: the divisor is such a square or its neighbour,
+// the dividend n times the root or its neighbour.
+// ---------------------------------------------------------------------------
+namespace {
+
+// The single nearest to m * 2^e for m below 2^24, or 0 when the exponent
+// field would leave [1, 254].
+u32 SingleFromScaled(u64 m, int e)
+{
+	if (m == 0)
+		return 0;
+	while (m < (1ull << 23)) { m <<= 1; --e; }
+	while (m >= (1ull << 24)) { m >>= 1; ++e; } // only reached by the product below
+	const int field = e + 23 + 127;
+	if (field < 1 || field > 254)
+		return 0;
+	return (static_cast<u32>(field) << 23) | (static_cast<u32>(m) & 0x7FFFFFu);
+}
+
+// A square n^2 as an exact single, with n = mn * 2^j, mn of `bits` bits.
+u32 ExactSquare(Lcg& r, u32 bits, int j, u32* n_word)
+{
+	const u32 mn = (1u << (bits - 1)) | (r.next() & ((1u << (bits - 1)) - 1u));
+	*n_word = SingleFromScaled(mn, j);
+	return SingleFromScaled(static_cast<u64>(mn) * mn, 2 * j);
+}
+
+u32 Nudge(Lcg& r, u32 w)
+{
+	switch (r.next() % 3u)
+	{
+		case 0: return w;
+		case 1: return w + 1u;
+		default: return w - 1u;
+	}
+}
+
+struct RootCase
+{
+	u32 fs, ft, fd, fi;
+	const char* what;
+};
+
+RootCase MakeSqrtCase(Lcg& r)
+{
+	u32 n = 0;
+	const u32 bits = 1u + r.next() % 12u;
+	const int j = -2 - static_cast<int>(bits - 1) + static_cast<int>(r.next() % 36u);
+	const u32 sq = ExactSquare(r, bits, j, &n);
+	if (sq == 0 || n == 0)
+		return MakeSqrtCase(r);
+	RootCase c{0, Nudge(r, sq), 3, 4, "fd, ft distinct"};
+	switch (r.next() % 3u)
+	{
+		case 0: break;
+		case 1: c.fd = 2; c.what = "fd == ft"; break;
+		default: c.fi = 3; c.what = "fi == fd"; break;
+	}
+	return c;
+}
+
+RootCase MakeRsqrtCase(Lcg& r)
+{
+	u32 t = 0;
+	const u32 tbits = 1u + r.next() % 12u;
+	const int k = -20 + static_cast<int>(r.next() % 41u);
+	const u32 sq = ExactSquare(r, tbits, k, &t);
+	if (sq == 0 || t == 0)
+		return MakeRsqrtCase(r);
+	// n * t exactly: n's bits and t's share the 24
+	const u32 nbits = 1u + r.next() % (24u - tbits);
+	const u32 mn = (1u << (nbits - 1)) | (r.next() & ((1u << (nbits - 1)) - 1u));
+	const int j = -2 - static_cast<int>(nbits - 1) + static_cast<int>(r.next() % 36u);
+	const u64 mt = 0x800000u | (t & 0x7FFFFFu);
+	const int et = static_cast<int>((t >> 23) & 0xFFu) - 127 - 23;
+	const u32 prod = SingleFromScaled(static_cast<u64>(mn) * mt, j + et);
+	if (prod == 0)
+		return MakeRsqrtCase(r);
+	RootCase c{Nudge(r, prod) | ((r.next() & 1u) << 31), Nudge(r, sq), 3, 4, "fd, fs, ft distinct"};
+	switch (r.next() % 4u)
+	{
+		case 0: break;
+		case 1: c.fd = 1; c.what = "fd == fs"; break;
+		case 2: c.fd = 2; c.what = "fd == ft"; break;
+		default: c.fi = 3; c.what = "fi == fd"; break;
+	}
+	return c;
+}
+
+// Runs one op on the three engines: interp, jit at mode 3, jit on the fast
+// path. word[] is the op's result, integer[] its cvt.w.s.
+void RunRootCase(const RootCase& c, bool rsqrt, u32 pre, u32 word[3], u32 integer[3], u32 fcr[3])
+{
+	for (int engine = 0; engine < 3; ++engine)
+	{
+		EeRecTestHarness h;
+		h.EnableCop1();
+		if (engine == 1)
+			h.EnableFpuFullMode();
+		h.SetFprBits(1, c.fs);
+		h.SetFprBits(2, c.ft);
+		h.SetFcr31(pre);
+		h.LoadProgram({rsqrt ? ee::RSQRT_S(c.fd, 1, 2) : ee::SQRT_S(c.fd, 2), ee::CVT_W_S(c.fi, c.fd)});
+		if (engine == 0)
+		{
+			h.RunInterpOnly();
+			word[0] = h.GetFprBitsInterp(c.fd);
+			integer[0] = h.GetFprBitsInterp(c.fi);
+			fcr[0] = h.InterpSnapshot().fprs.fprc[31];
+		}
+		else
+		{
+			h.RunJitNoDiff();
+			word[engine] = h.GetFprBitsJit(c.fd);
+			integer[engine] = h.GetFprBitsJit(c.fi);
+			fcr[engine] = h.JitSnapshot().fprs.fprc[31];
+		}
+	}
+}
+
+} // namespace
+
+TEST(EeRecFpuDivUnitRounding, FullModeTruncatesTheRootLikeTheUnit)
+{
+	RequireDistinctDivideRoundingMode();
+	Lcg r{0x5011EE7A5011EE7Aull};
+	int fast_int_gaps = 0, full_word_gaps = 0, guard_answered = 0;
+	for (u32 iter = 0; iter < 1200; ++iter)
+	{
+		const RootCase c = (iter % 4u == 3u) ? RootCase{0, fuzzOperand(r), 3, 4, "arbitrary"} : MakeSqrtCase(r);
+		const u32 pre = (r.next() % 4u == 0u) ? (kSI | kSD) : 0u;
+		SCOPED_TRACE(::testing::Message() << "iter=" << iter << " Ft=" << std::hex << c.ft
+										  << " fd=" << c.fd << " fi=" << c.fi << " (" << c.what << ")");
+		u32 word[3] = {}, integer[3] = {}, fcr[3] = {};
+		RunRootCase(c, false, pre, word, integer, fcr);
+		const bool word_visible = c.fi != c.fd;
+
+		EXPECT_EQ(integer[1], integer[0])
+			<< "mode 3's cvt.w.s integer is not the unit's: interp word=" << std::hex << word[0]
+			<< " jit word=" << word[1];
+		if (word_visible && word[1] != word[0])
+		{
+			++full_word_gaps;
+			EXPECT_TRUE(IsOneUlpTowardZero(word[0], word[1]))
+				<< "the unit's root is nearest or the word below; interp=" << std::hex << word[0]
+				<< " jit=" << word[1];
+			EXPECT_EQ(TruncateLikeCvtWS(word[1]), TruncateLikeCvtWS(word[0]))
+				<< "mode 3 kept the host word on a row whose integer differs";
+		}
+		if (integer[2] != integer[0])
+		{
+			++fast_int_gaps;
+			if (!word_visible || word[1] == word[0])
+				++guard_answered;
+		}
+		EXPECT_EQ(fcr[1] & kStickyMask, fcr[0] & kStickyMask) << "mode 3 moved a sticky flag";
+		if (::testing::Test::HasFailure())
+			return;
+	}
+	RecordProperty("fast_int_gaps", fast_int_gaps);
+	RecordProperty("full_word_gaps", full_word_gaps);
+	RecordProperty("guard_answered", guard_answered);
+	EXPECT_GT(fast_int_gaps, 0) << "anti-vacuity: no row where the fast path's integer differs";
+	EXPECT_GT(full_word_gaps, 0) << "anti-vacuity: mode 3 returned the unit's word on every row";
+	EXPECT_GT(guard_answered, 0) << "liveness: the guard never fired";
+}
+
+TEST(EeRecFpuDivUnitRounding, FullModeTruncatesTheReciprocalRootLikeTheUnit)
+{
+	RequireDistinctDivideRoundingMode();
+	Lcg r{0x25C1B00725C1B007ull};
+	int fast_int_gaps = 0, full_word_gaps = 0, guard_answered = 0, min_d = 0, max_d = 0;
+	for (u32 iter = 0; iter < 1200; ++iter)
+	{
+		const RootCase c = (iter % 4u == 3u)
+			? RootCase{fuzzOperand(r), fuzzOperand(r) & 0x7FFFFFFFu, 3, 4, "arbitrary"}
+			: MakeRsqrtCase(r);
+		const u32 pre = (r.next() % 4u == 0u) ? (kSI | kSD) : 0u;
+		SCOPED_TRACE(::testing::Message() << "iter=" << iter << " Fs=" << std::hex << c.fs << " Ft=" << c.ft
+										  << " fd=" << c.fd << " fi=" << c.fi << " (" << c.what << ")");
+		u32 word[3] = {}, integer[3] = {}, fcr[3] = {};
+		RunRootCase(c, true, pre, word, integer, fcr);
+		const bool word_visible = c.fi != c.fd;
+
+		EXPECT_EQ(integer[1], integer[0])
+			<< "mode 3's cvt.w.s integer is not the unit's: interp word=" << std::hex << word[0]
+			<< " jit word=" << word[1];
+		if (word_visible && word[1] != word[0] && !IsTopBinadeTierGap(word[0], word[1]))
+		{
+			++full_word_gaps;
+			const u32 um = word[0] & 0x7FFFFFFFu, hm = word[1] & 0x7FFFFFFFu;
+			const int d = static_cast<int>(static_cast<s64>(um) - static_cast<s64>(hm));
+			EXPECT_EQ(word[0] & 0x80000000u, word[1] & 0x80000000u);
+			if (um != 0 && hm != 0 && um < 0x7F800000u && hm < 0x7F800000u)
+			{
+				EXPECT_TRUE(d >= -2 && d <= 4)
+					<< "outside the window the guard spans: interp=" << std::hex << word[0]
+					<< " jit=" << word[1];
+				min_d = std::min(min_d, d);
+				max_d = std::max(max_d, d);
+			}
+			EXPECT_EQ(TruncateLikeCvtWS(word[1]), TruncateLikeCvtWS(word[0]))
+				<< "mode 3 kept the host word on a row whose integer differs";
+		}
+		if (integer[2] != integer[0])
+		{
+			++fast_int_gaps;
+			if (!word_visible || word[1] == word[0])
+				++guard_answered;
+		}
+		EXPECT_EQ(fcr[1] & kStickyMask, fcr[0] & kStickyMask) << "mode 3 moved a sticky flag";
+		if (::testing::Test::HasFailure())
+			return;
+	}
+	RecordProperty("fast_int_gaps", fast_int_gaps);
+	RecordProperty("full_word_gaps", full_word_gaps);
+	RecordProperty("guard_answered", guard_answered);
+	RecordProperty("min_d", min_d);
+	RecordProperty("max_d", max_d);
+	EXPECT_GT(fast_int_gaps, 0) << "anti-vacuity: no row where the fast path's integer differs";
+	EXPECT_GT(full_word_gaps, 0) << "anti-vacuity: mode 3 returned the unit's word on every row";
+	EXPECT_GT(guard_answered, 0) << "liveness: the guard never fired";
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Description of Changes
Mode 3 computed DIV.S, SQRT.S and RSQRT.S with the host's nearest rounding, so its word was one ULP from the unit's on a fair share of rows. Usually a game absorbs that, but it cannot when the quotient feeds cvt.w.s: a value one ULP under an integer truncates a whole integer lower than the console's, and games size textures and index tables that way. Mortal Kombat: Shaolin Monks builds its dialog panel from `(int)(logf(n) / logf(2))`, reads 5 where the console reads 6, and draws the message past the border. 

### Rationale behind Changes
Keep mode 3's host arithmetic and add a guard to each of the three ops that asks one question: could the unit's word truncate to a different integer than the word in hand. Only then does it call the mode-4 island, which runs the recurrence. So mode 3 now promises the unit's integer on every divide, root and reciprocal root, and the unit's word wherever that integer would otherwise have moved. Everywhere else the word is unchanged.

### Suggested Testing Steps
Play Mortal Kombat - SM

### AI Assistance (optional)
Yes