### PR TITLE
libretro: build the core where the GL renderer and adrenotools are not

### DIFF
--- a/pcsx2-libretro/Main.cpp
+++ b/pcsx2-libretro/Main.cpp
@@ -70,7 +70,9 @@
 #include "pcsx2/GS.h"
 #include "pcsx2/GS/Renderers/Vulkan/GSDeviceVK.h"
 #include "pcsx2/GS/Renderers/Vulkan/VKLibretro.h"
+#ifdef ENABLE_OPENGL
 #include "pcsx2/GS/Renderers/OpenGL/GLContextLibretro.h"
+#endif
 #include "pcsx2/GameList.h"
 #include "pcsx2/Host.h"
 #include "pcsx2/INISettingsInterface.h"
@@ -1063,8 +1065,10 @@ static void ApplyCoreOptions(bool startup)
 			// only honour this at startup.
 			if (!std::strcmp(var.value, "Software"))
 				s_base_settings->SetIntValue("EmuCore/GS", "Renderer", static_cast<int>(GSRendererType::SW));
+#ifdef ENABLE_OPENGL
 			else if (!std::strcmp(var.value, "OpenGL"))
 				s_base_settings->SetIntValue("EmuCore/GS", "Renderer", static_cast<int>(GSRendererType::OGL));
+#endif
 		}
 
 		var = {"armsx2_upscale", nullptr};
@@ -1325,6 +1329,10 @@ static bool CreateVulkanDevice(retro_vulkan_context* context, VkInstance instanc
 // The GL half of the same story. The frontend owns the context; the core only
 // needs its two callbacks - one to resolve entry points, one to ask which FBO
 // this frame belongs in - which GLContextLibretro hands to GSDeviceOGL.
+//
+// None of it exists where the GL renderer is not built: USE_OPENGL is not even
+// offered on Apple, where the GS is Metal and Vulkan.
+#ifdef ENABLE_OPENGL
 static struct retro_hw_render_callback s_gl_hw_render = {};
 
 static void* GLGetProcAddress(const char* name)
@@ -1365,6 +1373,7 @@ static void OnGLContextDestroy(void)
 	LibretroCore::s_context_ready.store(false, std::memory_order_release);
 	GLContextLibretro::SetCallbacks(nullptr, nullptr);
 }
+#endif // ENABLE_OPENGL
 
 static void OnContextReset(void)
 {
@@ -1631,10 +1640,15 @@ RETRO_API bool retro_load_game(const struct retro_game_info* game)
 	// settings above; GL takes a different path from here, since it needs no
 	// device negotiation - the frontend simply makes a context current and
 	// hands the core an FBO to draw into.
+#ifdef ENABLE_OPENGL
 	const bool want_gl = (s_base_settings->GetIntValue("EmuCore/GS", "Renderer",
 							  static_cast<int>(GSRendererType::VK)) == static_cast<int>(GSRendererType::OGL));
+#else
+	const bool want_gl = false;
+#endif
 
 	LibretroCore::s_hw_render_gl = want_gl;
+#ifdef ENABLE_OPENGL
 	if (want_gl)
 	{
 		s_gl_hw_render = {};
@@ -1673,6 +1687,7 @@ RETRO_API bool retro_load_game(const struct retro_game_info* game)
 			VMManager::Internal::LoadStartupSettings();
 		}
 	}
+#endif // ENABLE_OPENGL
 	// Vulkan HW render. The negotiation interface must be registered inside
 	// retro_load_game; the frontend invokes it while creating its Vulkan
 	// context, after this returns.

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -769,9 +769,13 @@ if(USE_VULKAN)
 	)
 	target_link_libraries(PCSX2_FLAGS INTERFACE vulkan-headers)
 	target_include_directories(PCSX2_FLAGS INTERFACE ${SHADERC_INCLUDE_DIR})
-	if(ANDROID AND CMAKE_ANDROID_ARCH_ABI STREQUAL "arm64-v8a")
-		# VKLoader.cpp's adrenotools_open_libvulkan splice needs adrenotools/driver.h.
+	# The custom-driver splice in VKLoader.cpp, which only the APK build has the
+	# library for - the buildbot's Android core build adds no adrenotools, and
+	# an unknown target name here becomes a bare -ladrenotools with no include
+	# path, which is how that job came to stop on a missing driver.h.
+	if(ANDROID AND CMAKE_ANDROID_ARCH_ABI STREQUAL "arm64-v8a" AND ARMSX2_USE_ADRENOTOOLS)
 		target_link_libraries(PCSX2_FLAGS INTERFACE adrenotools)
+		target_compile_definitions(PCSX2_FLAGS INTERFACE ARMSX2_USE_ADRENOTOOLS)
 	endif()
 endif()
 

--- a/pcsx2/GS/Renderers/Vulkan/VKLoader.cpp
+++ b/pcsx2/GS/Renderers/Vulkan/VKLoader.cpp
@@ -14,7 +14,7 @@
 #include <cstring>
 #include <string>
 
-#if defined(__ANDROID__)
+#if defined(ARMSX2_USE_ADRENOTOOLS)
 #include <dlfcn.h>
 #include <mutex>
 #include "adrenotools/driver.h"
@@ -44,7 +44,7 @@ void Vulkan::ResetVulkanLibraryFunctionPointers()
 
 static DynamicLibrary s_vulkan_library;
 
-#if defined(__ANDROID__)
+#if defined(ARMSX2_USE_ADRENOTOOLS)
 namespace
 {
 	std::mutex s_custom_driver_mutex;
@@ -136,7 +136,7 @@ bool Vulkan::LoadVulkanLibrary(Error* error)
 		return false;
 	}
 #else
-#if defined(__ANDROID__)
+#if defined(ARMSX2_USE_ADRENOTOOLS)
 	// User-picked custom driver (e.g. Mesa Turnip from K11MCH1/AdrenoToolsDrivers)
 	// takes priority. Falls back to the system loader on any failure so the boot
 	// still proceeds — the Console.Warning above already logged the cause.

--- a/platforms/android/app/src/main/cpp/CMakeLists.txt
+++ b/platforms/android/app/src/main/cpp/CMakeLists.txt
@@ -30,6 +30,11 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 # Android is a non-desktop frontend: no Qt UI.
 set(ENABLE_QT_UI OFF CACHE BOOL "" FORCE)
 
+# This build has libadrenotools (added below), so the custom Vulkan driver
+# splice in VKLoader.cpp is compiled in. Other Android builds - the libretro
+# core the buildbot makes - do not.
+set(ARMSX2_USE_ADRENOTOOLS ON CACHE BOOL "" FORCE)
+
 # The core's common/ and pcsx2/ CMakeLists guard on this sentinel (it is normally
 # set by the desktop top-level CMakeLists.txt, which the Android build bypasses).
 set(TOP_CMAKE_WAS_SOURCED TRUE)


### PR DESCRIPTION
Two buildbot jobs went red once the core started building on more than Linux ([pipeline 108294](https://git.libretro.com/libretro/armsx2/-/pipelines/108294)).

**macOS** links nothing GL — `USE_OPENGL` is not even offered on Apple, where the GS is Metal and Vulkan — so `GLContextLibretro.cpp` is not in the build while `Main.cpp` calls into it:

```
Undefined symbols for architecture arm64:
  "GLContextLibretro::SetCallbacks(void* (*)(char const*), unsigned int (*)(), GLContext::Profile, int, int)",
      referenced from: OnGLContextReset() in Main.cpp.o
```

The frontend-owned GL context is behind `ENABLE_OPENGL` now — the define `USE_OPENGL` sets — and the renderer option only offers OpenGL where it exists.

**The Android core build** has no libadrenotools; only the APK adds it. An unknown target name in `target_link_libraries` becomes a bare `-ladrenotools` with no include path, so `VKLoader.cpp` stopped on a header:

```
pcsx2/GS/Renderers/Vulkan/VKLoader.cpp:20:10: fatal error: 'adrenotools/driver.h' file not found
```

The custom-driver splice now has its own switch, `ARMSX2_USE_ADRENOTOOLS`, which `platforms/android`'s CMakeLists sets and nothing else does. The declaration in `VKLoader.h` stays where it was, so the JNI caller is unaffected.
