### PR TITLE
libretro: build the Android core without Oboe

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1245,8 +1245,6 @@ if(ARCH_ARM64 OR ANDROID OR ARMSX2_IOS)
 endif()
 
 if(ANDROID)
-	list(APPEND pcsx2HostSources
-		Host/OboeAudioStream.cpp)
 	list(APPEND pcsx2GSSources
 		GS/Renderers/OpenGL/GLContextEGL.cpp
 		GS/Renderers/OpenGL/GLContextEGLAndroid.cpp)
@@ -1257,12 +1255,20 @@ if(ANDROID)
 		Android/AndroidStubs.cpp
 		Android/AndroidPcapStubs.cpp)
 	# Oboe is the Android audio backend consumed by Host/OboeAudioStream.cpp.
-	# The `oboe` target (created in SearchForStuff.cmake) exports its `include/`
-	# dir as PUBLIC, so linking it into PCSX2_FLAGS propagates <oboe/Oboe.h> to
-	# the PCSX2 translation units. (android/log libs are already linked on the
-	# emucore target in the Android entry CMakeLists, so only oboe is needed here.)
-	target_link_libraries(PCSX2_FLAGS INTERFACE
-		oboe)
+	# Only the APK build has the library - its SearchForStuff adds the vendored
+	# 3rdparty/oboe - so this is behind a switch that build sets; the libretro
+	# core takes its audio from the frontend and stopped on <oboe/Oboe.h>. The
+	# `oboe` target exports its include/ dir as PUBLIC, so linking it into
+	# PCSX2_FLAGS propagates the header to the PCSX2 translation units.
+	# (android/log libs are already linked on the emucore target in the Android
+	# entry CMakeLists, so only oboe is needed here.)
+	if(ARMSX2_USE_OBOE)
+		list(APPEND pcsx2HostSources
+			Host/OboeAudioStream.cpp)
+		target_link_libraries(PCSX2_FLAGS INTERFACE
+			oboe)
+		target_compile_definitions(PCSX2_FLAGS INTERFACE ARMSX2_USE_OBOE)
+	endif()
 endif()
 
 if(ARMSX2_IOS)

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1179,7 +1179,7 @@ struct Pcsx2Config
 		};
 
 		static constexpr s32 MAX_VOLUME = 200;
-#ifdef __ANDROID__
+#ifdef ARMSX2_USE_OBOE
 		static constexpr AudioBackend DEFAULT_BACKEND = AudioBackend::Oboe;
 #else
 		static constexpr AudioBackend DEFAULT_BACKEND = AudioBackend::Cubeb;

--- a/pcsx2/Host/AudioStream.cpp
+++ b/pcsx2/Host/AudioStream.cpp
@@ -119,7 +119,7 @@ std::unique_ptr<AudioStream> AudioStream::CreateStream(AudioBackend backend, u32
 		case AudioBackend::SDL:
 			return CreateSDLAudioStream(sample_rate, parameters, stretch_enabled, error);
 
-#ifdef __ANDROID__
+#ifdef ARMSX2_USE_OBOE
 		case AudioBackend::Oboe:
 			return CreateOboeAudioStream(sample_rate, parameters, stretch_enabled, error);
 #endif

--- a/platforms/android/app/src/main/cpp/CMakeLists.txt
+++ b/platforms/android/app/src/main/cpp/CMakeLists.txt
@@ -35,6 +35,10 @@ set(ENABLE_QT_UI OFF CACHE BOOL "" FORCE)
 # core the buildbot makes - do not.
 set(ARMSX2_USE_ADRENOTOOLS ON CACHE BOOL "" FORCE)
 
+# Same for the Oboe audio backend: SearchForStuff below adds the vendored
+# 3rdparty/oboe, and this is the only build that has it.
+set(ARMSX2_USE_OBOE ON CACHE BOOL "" FORCE)
+
 # The core's common/ and pcsx2/ CMakeLists guard on this sentinel (it is normally
 # set by the desktop top-level CMakeLists.txt, which the Android build bypasses).
 set(TOP_CMAKE_WAS_SOURCED TRUE)


### PR DESCRIPTION
Next one along from #655, same shape ([pipeline 108309](https://git.libretro.com/libretro/armsx2/-/pipelines/108309) — macOS and Linux green now, Android still red):

```
pcsx2/Host/OboeAudioStream.cpp:11:10: fatal error: 'oboe/Oboe.h' file not found
```

Oboe comes from the APK build — its own `SearchForStuff.cmake` adds the vendored `3rdparty/oboe` — and nothing adds it for the core the buildbot makes, so `pcsx2/CMakeLists.txt` was compiling and linking a backend whose library is not there.

`ARMSX2_USE_OBOE` gates the source, the link and the `AudioBackend::Oboe` case, and `platforms/android`'s CMakeLists sets it next to `ARMSX2_USE_ADRENOTOOLS`. The libretro core takes its audio from the frontend, so it needs none of this, and `DEFAULT_BACKEND` falls back to Cubeb where Oboe is not built.
