### PR TITLE
libretro: link shaderc and stub the JNI calls on the Android core

### DIFF
--- a/pcsx2/Android/AndroidStubs.cpp
+++ b/pcsx2/Android/AndroidStubs.cpp
@@ -8,6 +8,9 @@
 #include "Input/InputManager.h"
 #include "CDVD/CDVDdiscReader.h"
 
+#include "common/FileSystem.h"
+#include "common/HostSys.h"
+
 // The two below stand in for pcsx2-qt, so they are wanted only by the APK.
 // pcsx2-libretro/Main.cpp defines both itself, and the libretro core is
 // linked from these same sources - hence the guard, or the Android core
@@ -21,6 +24,48 @@ END_HOTKEY_LIST()
 
 // Host::SetMouseLock - no mouse lock on Android
 void Host::SetMouseLock(bool state)
+{
+}
+
+#endif
+
+#ifdef ENABLE_LIBRETRO
+
+// The APK's JNI layer (platforms/android/.../native-lib.cpp) implements these,
+// and the libretro core is linked without it, so the Android core build ended
+// on five undefined symbols. Every one of them bridges to something the app
+// owns and the core does not have: the Storage Access Framework file it was
+// handed, the app's own directories, the Java vibrator, the notification
+// sound. The core reaches its files through the frontend's VFS instead, and
+// the frontend owns rumble and audio.
+
+int FileSystem::OpenFDFileContent(const char* filename)
+{
+	return -1;
+}
+
+bool FileSystem::CreateDirectoryViaJava(const char* path)
+{
+	return false;
+}
+
+bool FileSystem::CreateFileViaJava(const char* path)
+{
+	return false;
+}
+
+bool Common::PlaySoundAsync(const char* path)
+{
+	return false;
+}
+
+// Declared where it is called, in Input/InputManager.cpp.
+namespace Native
+{
+	void onPadRumble(int pad, int largeMotor, int smallMotor);
+}
+
+void Native::onPadRumble(int pad, int largeMotor, int smallMotor)
 {
 }
 

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -777,6 +777,14 @@ if(USE_VULKAN)
 		target_link_libraries(PCSX2_FLAGS INTERFACE adrenotools)
 		target_compile_definitions(PCSX2_FLAGS INTERFACE ARMSX2_USE_ADRENOTOOLS)
 	endif()
+	# VKShaderCache.cpp calls shaderc directly on Android, where every other
+	# platform dlopens it, so the library has to be on the link line. The APK
+	# links its own vendored `shaderc` target and sets the switch below; the
+	# buildbot's core build has only what find_package(Shaderc) found, and
+	# stopped on twenty undefined shaderc_* symbols without this.
+	if(ANDROID AND NOT ARMSX2_USE_BUNDLED_SHADERC AND TARGET Shaderc::shaderc_shared)
+		target_link_libraries(PCSX2_FLAGS INTERFACE Shaderc::shaderc_shared)
+	endif()
 endif()
 
 set(pcsx2GSMetalShaders

--- a/platforms/android/app/src/main/cpp/CMakeLists.txt
+++ b/platforms/android/app/src/main/cpp/CMakeLists.txt
@@ -38,6 +38,10 @@ set(ARMSX2_USE_ADRENOTOOLS ON CACHE BOOL "" FORCE)
 # Same for the Oboe audio backend: SearchForStuff below adds the vendored
 # 3rdparty/oboe, and this is the only build that has it.
 set(ARMSX2_USE_OBOE ON CACHE BOOL "" FORCE)
+# This build vendors shaderc (3rdparty/shaderc) and links the `shaderc` target
+# below; pcsx2/CMakeLists.txt leaves Shaderc::shaderc_shared alone when it sees
+# this, so the two do not both end up on the link line.
+set(ARMSX2_USE_BUNDLED_SHADERC ON CACHE BOOL "" FORCE)
 
 # The core's common/ and pcsx2/ CMakeLists guard on this sentinel (it is normally
 # set by the desktop top-level CMakeLists.txt, which the Android build bypasses).


### PR DESCRIPTION
`libretro-build-android-arm64-v8a` configures and compiles, then stops at the link on twenty-five undefined symbols ([pipeline 108328](https://git.libretro.com/libretro/armsx2/-/pipelines/108328)). Two causes, both the same shape as the adrenotools and Oboe ones: something the APK build provides and the core build does not.

**shaderc — twenty of them.** `VKShaderCache.cpp` calls shaderc directly under `__ANDROID__`, where every other platform dlopens it, and the APK puts its vendored `shaderc` target on the link line. The core build has only what `find_package(Shaderc)` found — the job does find it:

```
-- Found Shaderc: /builds/libretro/armsx2/.deps/lib/libshaderc_combined.a
```

but nothing links `Shaderc::shaderc_shared`, so every entry point comes up undefined:

```
ld.lld: error: undefined symbol: shaderc_compiler_initialize
ld.lld: error: undefined symbol: shaderc_compile_into_spv
...
```

It is linked now, for the Android builds that are not the APK. The APK says which one it is by setting `ARMSX2_USE_BUNDLED_SHADERC`, so its vendored copy and the found one never both land on the link line.

**The JNI five.** `FileSystem::OpenFDFileContent`, `CreateDirectoryViaJava`, `CreateFileViaJava`, `Common::PlaySoundAsync` and `Native::onPadRumble` live in `platforms/android/app/src/main/cpp/native-lib.cpp`, which the core is not linked with. Each bridges to something the app owns — the Storage Access Framework handle it was given, the app's own directories, the Java vibrator, the notification sound. The core reaches its files through the frontend's VFS, and the frontend owns rumble and audio, so they get stubs next to the ones `AndroidStubs.cpp` already carries, behind the same `ENABLE_LIBRETRO` guard.

Verified by building what the job builds — the same `build-dependencies.sh` and the same `CORE_ARGS`, arm64-v8a, API 28 ([run](https://github.com/WizzardSK/armsx2-libretro/actions/runs/33990528708)): `bin/armsx2_libretro.so`, `ELF 64-bit LSB shared object, ARM aarch64`, 284 MB unstripped.

Nothing here changes the APK build.
