### PR TITLE
iOS: the boot window was presenting a texture nothing ever wrote

### DIFF
--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -2139,6 +2139,9 @@ void GSDeviceMTL::PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture
 	else
 	{
 		// !dTex → Use current draw encoder
+		// This pass is already open, so a clear still pending on the source can no longer be
+		// committed here. Whoever produced sTex owes us the flush.
+		pxAssertMsg(sTex->GetState() != GSTexture::State::Cleared, "Presented texture still has a pending clear");
 		[m_current_render.encoder setRenderPipelineState:pipe];
 		[m_current_render.encoder setFragmentSamplerState:m_sampler_hw[filter == Biln ? SamplerSelector::Linear().key : SamplerSelector::Point().key] atIndex:0];
 		[m_current_render.encoder setFragmentTexture:static_cast<GSTextureMTL*>(sTex)->GetTexture() atIndex:0];

--- a/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
+++ b/pcsx2/GS/Renderers/Metal/GSDeviceMTL.mm
@@ -776,6 +776,11 @@ void GSDeviceMTL::DoMerge(GSTexture* sTex[3], GSVector4* sRect, GSTexture* dTex,
 
 	if (feedback_write_1) // FIXME I'm not sure dRect[0] is always correct
 		StretchRect(dTex, full_r, sTex[2], dRect[0], ShaderConvert::YUV, filter);
+
+	// With both circuits off nothing was drawn, so the clear above is the whole frame and it is
+	// still only deferred. Everyone downstream binds the native texture, and none of them can
+	// commit a clear, so do it here while a pass can still be opened.
+	FlushClears(dTex);
 }}
 
 void GSDeviceMTL::DoInterlace(GSTexture* sTex, const GSVector4& sRect, GSTexture* dTex, const GSVector4& dRect, ShaderInterlace shader, Filter filter, const InterlaceConstantBuffer& cb)


### PR DESCRIPTION
* Fixed the magenta flash that covered the screen on every game launch, from the moment a game was started until it put up its first frame.
* The stretch between VM start and a game's first output was presenting a texture that had been allocated and never written, so the screen showed whatever that allocation happened to be holding.
* Only real devices were affected. The simulator zero fills a fresh allocation, so it came up black there and the bug never showed.
* The PS2 background colour now reaches the screen on Metal when both display circuits are off, which is what the upstream change that exposed this set out to do in the first place.
* Added a Devel build assert so a texture that reaches the present pass with a clear still pending is caught where it happens, instead of turning into garbage on screen.
