### PR TITLE
Libretro: open the disc through the frontend's file system too

### DIFF
--- a/common/FileSystem.cpp
+++ b/common/FileSystem.cpp
@@ -1148,6 +1148,17 @@ std::FILE* FileSystem::OpenSharedCFile(const char* filename, const char* mode, F
 	Error::SetErrno(error, errno);
 	return nullptr;
 #else
+	// The host's file system first, exactly as in OpenCFile(). The disc readers
+	// open the image through this variant, so without it a path that only the
+	// frontend can resolve fails at "Opening CDVD" while the same game on local
+	// storage boots. The share mode is not lost by going through the host: the
+	// POSIX path below has never honoured it either.
+	if (HostVFS::IsInstalled())
+	{
+		if (std::FILE* vfp = HostVFS::OpenAsCFile(filename, mode))
+			return vfp;
+	}
+
 	#if defined(__ANDROID__)
 	// content:// URIs (Storage Access Framework) must route through the JNI
 	// ContentResolver bridge — std::fopen can't open them. ChdFileReader opens

--- a/common/HostVFS.cpp
+++ b/common/HostVFS.cpp
@@ -118,23 +118,44 @@ namespace
 	// a std::FILE* have to ask the host about the handle behind it instead,
 	// and that is the only thing this maps. A handful of entries at most, and
 	// only touched on open and close.
-	std::mutex s_streams_lock;
-	std::vector<std::pair<std::FILE*, void*>> s_streams;
+	//
+	// Never destroyed, on purpose. One of these streams can be closed while the
+	// library is being torn down - a disc reader taken apart at unload does
+	// exactly that - and by then a plain static would already be gone. Locking
+	// a destroyed std::mutex is not a no-op, it is an abort:
+	//
+	//   FORTIFY: pthread_mutex_lock called on a destroyed mutex
+	//
+	// which is where the Android core died on close content. Leaking the
+	// registry costs a few dozen bytes for the life of the process.
+	struct StreamRegistry
+	{
+		std::mutex lock;
+		std::vector<std::pair<std::FILE*, void*>> streams;
+	};
+
+	StreamRegistry& Streams()
+	{
+		static StreamRegistry* registry = new StreamRegistry();
+		return *registry;
+	}
 
 	void RememberStream(std::FILE* fp, void* handle)
 	{
-		std::unique_lock lock(s_streams_lock);
-		s_streams.emplace_back(fp, handle);
+		StreamRegistry& registry = Streams();
+		std::unique_lock lock(registry.lock);
+		registry.streams.emplace_back(fp, handle);
 	}
 
 	void ForgetStream(void* handle)
 	{
-		std::unique_lock lock(s_streams_lock);
-		for (auto it = s_streams.begin(); it != s_streams.end(); ++it)
+		StreamRegistry& registry = Streams();
+		std::unique_lock lock(registry.lock);
+		for (auto it = registry.streams.begin(); it != registry.streams.end(); ++it)
 		{
 			if (it->second == handle)
 			{
-				s_streams.erase(it);
+				registry.streams.erase(it);
 				return;
 			}
 		}
@@ -283,8 +304,9 @@ bool HostVFS::SizeOfCFile(std::FILE* fp, s64* size)
 
 	void* handle = nullptr;
 	{
-		std::unique_lock lock(s_streams_lock);
-		for (const auto& [stream, stream_handle] : s_streams)
+		StreamRegistry& registry = Streams();
+		std::unique_lock lock(registry.lock);
+		for (const auto& [stream, stream_handle] : registry.streams)
 		{
 			if (stream == fp)
 			{

--- a/common/HostVFS.cpp
+++ b/common/HostVFS.cpp
@@ -4,8 +4,9 @@
 #include "common/HostVFS.h"
 #include "common/Console.h"
 
+#include <atomic>
 #include <cstring>
-#include <mutex>
+#include <thread>
 #include <vector>
 
 // The libretro VFS access flags, kept here rather than pulled from libretro.h:
@@ -119,43 +120,65 @@ namespace
 	// and that is the only thing this maps. A handful of entries at most, and
 	// only touched on open and close.
 	//
-	// Never destroyed, on purpose. One of these streams can be closed while the
-	// library is being torn down - a disc reader taken apart at unload does
-	// exactly that - and by then a plain static would already be gone. Locking
-	// a destroyed std::mutex is not a no-op, it is an abort:
+	// Plain storage with a spin lock, rather than a std::vector behind a
+	// std::mutex: one of these streams is closed while the library is being
+	// torn down - a disc reader taken apart at unload does exactly that - and a
+	// std::mutex that has already been destroyed by then does not ignore the
+	// lock, it aborts:
 	//
 	//   FORTIFY: pthread_mutex_lock called on a destroyed mutex
 	//
-	// which is where the Android core died on close content. Leaking the
-	// registry costs a few dozen bytes for the life of the process.
-	struct StreamRegistry
+	// which is where the Android core died on close content. Nothing here has a
+	// destructor to run or an allocation to free, so a late close finds it
+	// exactly as it was.
+	constexpr size_t kMaxStreams = 64;
+
+	struct StreamEntry
 	{
-		std::mutex lock;
-		std::vector<std::pair<std::FILE*, void*>> streams;
+		std::FILE* fp;
+		void* handle;
 	};
 
-	StreamRegistry& Streams()
-	{
-		static StreamRegistry* registry = new StreamRegistry();
-		return *registry;
-	}
+	std::atomic_flag s_streams_lock = ATOMIC_FLAG_INIT;
+	StreamEntry s_streams[kMaxStreams]{};
 
+	class StreamsLock
+	{
+	public:
+		StreamsLock()
+		{
+			while (s_streams_lock.test_and_set(std::memory_order_acquire))
+				std::this_thread::yield();
+		}
+		~StreamsLock() { s_streams_lock.clear(std::memory_order_release); }
+	};
+
+	// A stream that does not fit is simply not remembered: the only thing the
+	// table is for is SizeOfCFile(), which answers "no" and lets the caller
+	// fall back. Sixty-four is far more than the handful ever open at once.
 	void RememberStream(std::FILE* fp, void* handle)
 	{
-		StreamRegistry& registry = Streams();
-		std::unique_lock lock(registry.lock);
-		registry.streams.emplace_back(fp, handle);
+		StreamsLock lock;
+		for (StreamEntry& entry : s_streams)
+		{
+			if (!entry.fp)
+			{
+				entry.fp = fp;
+				entry.handle = handle;
+				return;
+			}
+		}
 	}
 
 	void ForgetStream(void* handle)
 	{
-		StreamRegistry& registry = Streams();
-		std::unique_lock lock(registry.lock);
-		for (auto it = registry.streams.begin(); it != registry.streams.end(); ++it)
+		StreamsLock lock;
+		for (StreamEntry& entry : s_streams)
 		{
-			if (it->second == handle)
+			if (entry.fp && entry.handle == handle)
 			{
-				registry.streams.erase(it);
+				entry.fp = nullptr;
+				entry.handle = nullptr;
 				return;
 			}
 		}
@@ -304,13 +327,12 @@ bool HostVFS::SizeOfCFile(std::FILE* fp, s64* size)
 
 	void* handle = nullptr;
 	{
-		StreamRegistry& registry = Streams();
-		std::unique_lock lock(registry.lock);
-		for (const auto& [stream, stream_handle] : registry.streams)
+		StreamsLock lock;
+		for (const StreamEntry& entry : s_streams)
 		{
-			if (stream == fp)
+			if (entry.fp == fp)
 			{
-				handle = stream_handle;
+				handle = entry.handle;
 				break;
 			}
 		}

--- a/pcsx2-libretro/Main.cpp
+++ b/pcsx2-libretro/Main.cpp
@@ -710,11 +710,15 @@ void LibretroCore::CPUThreadMain(VMBootParameters initial_params)
 					VMBootParameters bp = std::move(pending_boot.value());
 					pending_boot.reset();
 					std::fprintf(stderr, "[libretro] CPU thread: VMManager::Initialize...\n");
-					const VMBootResult br = VMManager::Initialize(bp);
+					// With the error in hand the log says which file could not be
+					// opened; without it a failed boot is a bare result code.
+					Error boot_error;
+					const VMBootResult br = VMManager::Initialize(bp, &boot_error);
 					std::fprintf(stderr, "[libretro] CPU thread: Initialize -> %d\n", (int)br);
 					if (br != VMBootResult::StartupSuccess)
 					{
-						Console.ErrorFmt("VMManager::Initialize failed (result {}).", static_cast<int>(br));
+						Console.ErrorFmt("VMManager::Initialize failed (result {}): {}",
+							static_cast<int>(br), boot_error.GetDescription());
 						s_shutdown_requested.store(true, std::memory_order_release);
 						break;
 					}
@@ -843,6 +847,26 @@ static void RegisterDiskControl(void)
 	environ_cb(RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE, (void*)&cb);
 }
 
+// Join a playlist entry to the directory the playlist came from.
+//
+// Not Path::Combine(): it collapses repeated separators, which turns the "//"
+// of a frontend URI - "saf://content:..." on Android - into a single slash and
+// leaves a path nothing can open. Nor is Path::IsAbsolute() any help there,
+// since such a path does not start with a separator. Anything with a scheme is
+// therefore joined by hand, and everything else keeps the old behaviour.
+static std::string JoinPlaylistEntry(const std::string& base, const std::string& entry)
+{
+	const std::string::size_type scheme = base.find("://");
+	if (scheme == std::string::npos || scheme == 0)
+		return Path::Combine(base, entry);
+
+	std::string ret = base;
+	if (!ret.empty() && ret.back() != '/')
+		ret.push_back('/');
+	ret.append(entry);
+	return ret;
+}
+
 // Parse an .m3u playlist into s_disk_images; returns the first disc path.
 static std::string LoadM3UPlaylist(const std::string& m3u_path)
 {
@@ -859,7 +883,7 @@ static std::string LoadM3UPlaylist(const std::string& m3u_path)
 		if (line.empty() || line[0] == '#')
 			continue;
 		if (!Path::IsAbsolute(line))
-			line = Path::Combine(base, line);
+			line = JoinPlaylistEntry(base, line);
 		s_disk_images.push_back(std::move(line));
 	}
 


### PR DESCRIPTION
A game the frontend can reach but the OS cannot — Android storage behind SAF, or a network share — did not boot, while the same game copied to local storage did. From the user's log:

```
[    1.0735] Opening CDVD...
[    1.0815] VMManager::Initialize failed (result 1).
```

Three things behind it:

* **`FileSystem::OpenSharedCFile()` never consulted `HostVFS`.** That is the variant `ChdFileReader` opens the image with, so it went straight to `std::fopen()` with a path only the frontend can resolve. `.iso` worked because `FlatFileReader` uses `OpenCFile()`, which does ask the host. The comment already in that function about the Android `content://` bridge describes the same failure — this is the general case of it.
* **`.m3u` broke one step earlier.** `Path::Combine()` collapses repeated separators, so joining a playlist entry to the playlist's directory turned `saf://content:...` into `saf:/content:...`, which nothing can open. `Path::IsAbsolute()` is no help either — such a path does not start with a separator. Playlist entries are now joined by hand when the base carries a scheme.
* **The log said nothing useful.** `VMManager::Initialize()` was called without an `Error`, so the reason it builds — `Failed to open CDVD '<file>': <errno>` — was dropped and only the result code reached the log. It is logged now.

Reported on Discord against the Android core; the reporter's device is a Moto g05 loading a `.chd` and an `.m3u` over rsaf/SMB.
