### PR TITLE
Libretro: keep the frame size steady between real frames

### DIFF
--- a/pcsx2-libretro/Main.cpp
+++ b/pcsx2-libretro/Main.cpp
@@ -1918,6 +1918,14 @@ RETRO_API void retro_run(void)
 
 	if (LibretroCore::s_hw_render_vulkan)
 	{
+		// A frontend reads the picture size from this callback on every frame,
+		// duplicates included, and RetroArch computes its integer scaling from
+		// that number rather than from the geometry the core announces. So a
+		// duplicate must not report a different size than the frame it repeats:
+		// the size the last real frame went out at is carried here for it.
+		static u32 last_frame_width = LibretroCore::kFrameWidth;
+		static u32 last_frame_height = LibretroCore::kFrameHeight;
+
 		// M2: consume the newest GS frame (if any) and hand it to the
 		// frontend. The retro_vulkan_image storage must outlive this call --
 		// the frontend keeps the pointer for cached-frame replays.
@@ -1954,11 +1962,13 @@ RETRO_API void retro_run(void)
 					VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY},
 				{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}};
 			vulkan->set_image(vulkan->handle, &vkimage, 0, nullptr, vulkan->queue_index);
+			last_frame_width = frame.width;
+			last_frame_height = frame.height;
 			video_cb(RETRO_HW_FRAME_BUFFER_VALID, frame.width, frame.height, 0);
 		}
 		else
 		{
-			video_cb(nullptr, LibretroCore::kFrameWidth, LibretroCore::kFrameHeight, 0);
+			video_cb(nullptr, last_frame_width, last_frame_height, 0);
 		}
 	}
 	else if (LibretroCore::s_hw_render_gl)


### PR DESCRIPTION
Fixes #676.

**What happens.** A frontend reads the picture size from the video callback on *every* frame, duplicates included, and RetroArch's integer scaling is computed from that number rather than from the geometry the core announces. On the Vulkan path a real frame goes out at the canvas size — `frame.width x frame.height` — while a duplicate was reported at the fixed `kFrameWidth x kFrameHeight` (640x448). So the frontend was told two different sizes in alternation and recomputed its viewport on each one. With Integer Scale off nothing shows, because the picture is fitted to the window either way; with it on, each recompute picks a different whole multiple, which is the picture growing and shrinking several times a second and the black borders pulsing in the reporter's recording.

**The fix.** Duplicates repeat the size the last real frame was handed over at.

**Why it shows at every internal resolution here.** The reporter notes that in PCEE2 the artifacts mostly appeared above 1x Native, while here they appear at any resolution. That follows from the same cause: the canvas is aspect-expanded before it is handed over, so it never equals 640x448 — the two sizes differ on every frame regardless of the upscale multiplier, where a fallback closer to the real size only diverges once upscaling moves it.

**Scope.** This is the half of the problem that produces the reported artifacts, and it is self-contained. There is a second half worth doing separately: `SET_GEOMETRY` currently follows the canvas (`geometry.base_width = frame.width`), which moves with the internal-resolution setting and with every field/frame merge, so it fires for changes that are not changes in the shape of the picture. Carrying the GS's native, un-upscaled resolution instead would be stable across both, but it needs plumbing on the GS side that does not exist here yet, so it is not in this change.

The same bug and the same first half were fixed in PCEE2 in WizzardSK/pcee2-libretro@e93e330, where it was verified on GT3 at 3x with Integer Scale on — artifacts before, clean after. I have no Android device with the affected GPU to confirm this build on, so a check from @matheuswillder would be worth having before it is trusted.
